### PR TITLE
Add timestamps to account serializer

### DIFF
--- a/apps/kubera/lib/kubera/errors/invalid_date_format_error.ex
+++ b/apps/kubera/lib/kubera/errors/invalid_date_format_error.ex
@@ -1,0 +1,3 @@
+defmodule Kubera.Errors.InvalidDateFormatError do
+  defexception message: "Invalid date format error, supports only NaiveDateTime and DateTime"
+end

--- a/apps/kubera/lib/kubera/web/date.ex
+++ b/apps/kubera/lib/kubera/web/date.ex
@@ -1,0 +1,29 @@
+defmodule Kubera.Web.Date do
+  @moduledoc """
+  This module allows formatting of a date (naive or date time) into an iso8601 string.
+  """
+
+  alias Kubera.Errors.InvalidDateFormatError
+
+  @doc """
+  Parses the given naive date time to an iso8601 string.
+  """
+  def to_iso8601(%NaiveDateTime{} = date) do
+    date
+    |> DateTime.from_naive!("Etc/UTC")
+    |> to_iso8601()
+  end
+
+  @doc """
+  Parses the given date time to an iso8601 string.
+  """
+  def to_iso8601(%DateTime{} = date) do
+    DateTime.to_iso8601(date)
+  end
+  @doc """
+  Raise a InvalidDateFormatError if the type is invalid.
+  """
+  def to_iso8601(_) do
+    raise InvalidDateFormatError
+  end
+end

--- a/apps/kubera/test/kubera/web/date_test.exs
+++ b/apps/kubera/test/kubera/web/date_test.exs
@@ -1,0 +1,27 @@
+defmodule Kubera.Web.DateTest do
+  use ExUnit.Case
+  alias Kubera.Web.Date
+  alias Kubera.Errors.InvalidDateFormatError
+
+  describe "Kubera.Web.Date.to_iso8601/1" do
+    test "formats a valid naive date time" do
+      naive_date = ~N[2000-01-01 10:01:02]
+      formatted_date = Date.to_iso8601(naive_date)
+
+      assert formatted_date == "2000-01-01T10:01:02Z"
+    end
+
+    test "formats a normal date time" do
+      {:ok, date, 0} = DateTime.from_iso8601("2000-01-01T10:01:02Z")
+      formatted_date = Date.to_iso8601(date)
+
+      assert formatted_date == "2000-01-01T10:01:02Z"
+    end
+
+    test "Raise an exception if the type is not supported" do
+      assert_raise InvalidDateFormatError, fn ->
+        Date.to_iso8601("an invalid type")
+      end
+    end
+  end
+end

--- a/apps/kubera_admin/lib/kubera_admin/v1/serializers/account_serializer.ex
+++ b/apps/kubera_admin/lib/kubera_admin/v1/serializers/account_serializer.ex
@@ -3,7 +3,7 @@ defmodule KuberaAdmin.V1.AccountSerializer do
   Serializes account(s) into V1 response format.
   """
   alias KuberaAdmin.V1.PaginatorSerializer
-  alias Kubera.Web.Paginator
+  alias Kubera.Web.{Paginator, Date}
 
   def to_json(%Paginator{} = paginator) do
     PaginatorSerializer.to_json(paginator, &to_json/1)
@@ -14,7 +14,9 @@ defmodule KuberaAdmin.V1.AccountSerializer do
       id: account.id,
       name: account.name,
       description: account.description,
-      master: account.master
+      master: account.master,
+      created_at: Date.to_iso8601(account.inserted_at),
+      updated_at: Date.to_iso8601(account.updated_at)
     }
   end
 end

--- a/apps/kubera_admin/test/kubera_admin/v1/serializers/account_serializer_test.exs
+++ b/apps/kubera_admin/test/kubera_admin/v1/serializers/account_serializer_test.exs
@@ -1,26 +1,28 @@
 defmodule KuberaAdmin.V1.AccountSerializerTest do
   use KuberaAdmin.SerializerCase, :v1
   alias KuberaAdmin.V1.AccountSerializer
-  alias Kubera.Web.Paginator
+  alias Kubera.Web.{Paginator, Date}
 
   describe "AccountSerializer.to_json/1" do
     test "serializes an account into V1 response format" do
-      account = build(:account)
+      account = insert(:account)
 
       expected = %{
         object: "account",
         id: account.id,
         name: account.name,
         description: account.description,
-        master: account.master
+        master: account.master,
+        created_at: Date.to_iso8601(account.inserted_at),
+        updated_at: Date.to_iso8601(account.updated_at)
       }
 
       assert AccountSerializer.to_json(account) == expected
     end
 
     test "serializes an account paginator into a list object" do
-      account1 = build(:account)
-      account2 = build(:account)
+      account1 = insert(:account)
+      account2 = insert(:account)
       paginator = %Paginator{
         data: [account1, account2],
         pagination: %{
@@ -39,14 +41,18 @@ defmodule KuberaAdmin.V1.AccountSerializerTest do
             id: account1.id,
             name: account1.name,
             description: account1.description,
-            master: account1.master
+            master: account1.master,
+            created_at: Date.to_iso8601(account1.inserted_at),
+            updated_at: Date.to_iso8601(account1.updated_at)
           },
           %{
             object: "account",
             id: account2.id,
             name: account2.name,
             description: account2.description,
-            master: account2.master
+            master: account2.master,
+            created_at: Date.to_iso8601(account2.inserted_at),
+            updated_at: Date.to_iso8601(account2.updated_at)
           }
         ],
         pagination: %{

--- a/apps/kubera_admin/test/kubera_admin/v1/views/account_view_test.exs
+++ b/apps/kubera_admin/test/kubera_admin/v1/views/account_view_test.exs
@@ -1,12 +1,11 @@
 defmodule KuberaAdmin.V1.AccountViewTest do
   use KuberaAdmin.ViewCase, :v1
-  alias Kubera.Web.Paginator
+  alias Kubera.Web.{Paginator, Date}
   alias KuberaAdmin.V1.AccountView
 
   describe "KuberaAdmin.V1.AccountView.render/2" do
     test "renders account.json with correct response structure" do
-      account = build(:account)
-
+      account = insert(:account)
       expected = %{
         version: @expected_version,
         success: true,
@@ -15,7 +14,9 @@ defmodule KuberaAdmin.V1.AccountViewTest do
           id: account.id,
           name: account.name,
           description: account.description,
-          master: account.master
+          master: account.master,
+          created_at: Date.to_iso8601(account.inserted_at),
+          updated_at: Date.to_iso8601(account.updated_at)
         }
       }
 
@@ -23,8 +24,8 @@ defmodule KuberaAdmin.V1.AccountViewTest do
     end
 
     test "renders accounts.json with correct response structure" do
-      account1 = build(:account)
-      account2 = build(:account)
+      account1 = insert(:account)
+      account2 = insert(:account)
 
       paginator = %Paginator{
         data: [account1, account2],
@@ -47,14 +48,18 @@ defmodule KuberaAdmin.V1.AccountViewTest do
               id: account1.id,
               name: account1.name,
               description: account1.description,
-              master: account1.master
+              master: account1.master,
+              created_at: Date.to_iso8601(account1.inserted_at),
+              updated_at: Date.to_iso8601(account1.updated_at)
             },
             %{
               object: "account",
               id: account2.id,
               name: account2.name,
               description: account2.description,
-              master: account2.master
+              master: account2.master,
+              created_at: Date.to_iso8601(account2.inserted_at),
+              updated_at: Date.to_iso8601(account2.updated_at)
             }
           ],
           pagination: %{

--- a/apps/kubera_admin/test/support/serializer_case.ex
+++ b/apps/kubera_admin/test/support/serializer_case.ex
@@ -7,6 +7,12 @@ defmodule KuberaAdmin.SerializerCase do
     quote do
       use ExUnit.Case
       import KuberaDB.Factory
+      alias KuberaDB.Repo
+      alias Ecto.Adapters.SQL.Sandbox
+
+      setup do
+        :ok = Sandbox.checkout(Repo)
+      end
     end
   end
 

--- a/apps/kubera_admin/test/support/view_case.ex
+++ b/apps/kubera_admin/test/support/view_case.ex
@@ -9,6 +9,12 @@ defmodule KuberaAdmin.ViewCase do
       use ExUnit.Case
       import KuberaDB.Factory
       import Phoenix.View
+      alias KuberaDB.Repo
+      alias Ecto.Adapters.SQL.Sandbox
+
+      setup do
+        :ok = Sandbox.checkout(Repo)
+      end
 
       @expected_version "1" # The expected response version
     end


### PR DESCRIPTION
This is a nice to have in the admin panel, being able to see the created_at and updated_at of entities
This pr add these 2 fields to accounts and offer a `Date` module to easily parse Naive or normal DateTime into iso8601.