### PR TITLE
Add /admin.all and /admin.get endpoints

### DIFF
--- a/apps/kubera_admin/lib/kubera_admin/v1/controllers/admin_controller.ex
+++ b/apps/kubera_admin/lib/kubera_admin/v1/controllers/admin_controller.ex
@@ -1,0 +1,56 @@
+defmodule KuberaAdmin.V1.AdminController do
+  use KuberaAdmin, :controller
+  import KuberaAdmin.V1.ErrorHandler
+  alias Ecto.UUID
+  alias Kubera.Web.{SearchParser, SortParser, Paginator}
+  alias KuberaAdmin.V1.UserView
+  alias KuberaDB.{User, UserQuery}
+
+  @search_fields [{:id, :uuid}, :email]
+  @sort_fields [:id, :email]
+
+  @doc """
+  Retrieves a list of admins.
+  """
+  def all(conn, attrs) do
+    User
+    |> UserQuery.where_has_membership()
+    |> SearchParser.to_query(attrs, @search_fields)
+    |> SortParser.to_query(attrs, @sort_fields)
+    |> Paginator.paginate_attrs(attrs)
+    |> respond_multiple(conn)
+  end
+
+  @doc """
+  Retrieves a specific admin by its id.
+  """
+  def get(conn, %{"id" => id}) do
+    case UUID.cast(id) do
+      {:ok, uuid} ->
+        query = UserQuery.where_has_membership()
+
+        uuid
+        |> User.get(query)
+        |> respond_single(conn)
+      _ ->
+        handle_error(conn, :invalid_parameter, "Admin ID must be a UUID")
+    end
+  end
+
+  # Respond with a list of admins
+  defp respond_multiple(%Paginator{} = paged_users, conn) do
+    render(conn, UserView, :users, %{users: paged_users})
+  end
+  defp respond_multiple({:error, code, description}, conn) do
+    handle_error(conn, code, description)
+  end
+
+  # Respond with a single admin
+  defp respond_single(%User{} = user, conn) do
+    render(conn, UserView, :user, %{user: user})
+  end
+  # Responds when the admin is not found
+  defp respond_single(nil, conn) do
+    handle_error(conn, :user_id_not_found)
+  end
+end

--- a/apps/kubera_admin/lib/kubera_admin/v1/router.ex
+++ b/apps/kubera_admin/lib/kubera_admin/v1/router.ex
@@ -33,6 +33,10 @@ defmodule KuberaAdmin.V1.Router do
     post "/user.all", UserController, :all
     post "/user.get", UserController, :get
 
+    # Admin endpoints
+    post "/admin.all", AdminController, :all
+    post "/admin.get", AdminController, :get
+
     # Self endpoints (operations on the currently authenticated user)
     post "/me.get", SelfController, :get
     post "/logout", AuthController, :logout

--- a/apps/kubera_admin/swagger-doc.yaml
+++ b/apps/kubera_admin/swagger-doc.yaml
@@ -31,6 +31,8 @@ tags:
     description: These are the endpoints related to the account.
   - name: User
     description: These are the endpoints related to users.
+  - name: Admin
+    description: These are the endpoints related to admins.
 paths:
   ############################
   #         SESSION          #
@@ -230,6 +232,43 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/UserResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+  ############################
+  #          ADMINS          #
+  ############################
+  /admin.all:
+    post:
+      tags:
+        - Admin
+      summary: Get the list of admins
+      operationId: admin_all
+      security:
+        - AdminAuth: []
+      parameters:
+        - $ref: "#/components/parameters/UserAuthorizationHeader"
+      requestBody:
+        $ref: '#/components/requestBodies/AdminAllBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/AdminsResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+  /admin.get:
+    post:
+      tags:
+        - Admin
+      summary: Get a specific admin
+      operationId: admin_get
+      security:
+        - AdminAuth: []
+      parameters:
+        - $ref: "#/components/parameters/UserAuthorizationHeader"
+      requestBody:
+        $ref: '#/components/requestBodies/AdminGetBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/AdminResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
 
@@ -509,6 +548,64 @@ components:
               current_page: 1
               is_first_page: true
               is_last_page: true
+    # Schema for admin response body
+    AdminResponseSchema:
+      allOf:
+      - $ref: '#/components/schemas/BaseResponseSchema'
+      - type: object
+        properties:
+          data:
+            type: object
+            $ref: '#/components/schemas/UserSchema'
+        required:
+          - data
+        example:
+          data:
+            object: "user"
+            id: "cec34607-0761-4a59-8357-18963e42a1aa"
+            provider_user_id: "wijf-fbancomw-dqwjudb"
+            username: "johndoe"
+            email: "johndoe@omise.co"
+            metadata: {"first_name": "John", "last_name": "Doe"}
+            created_at: "2018-01-01T00:00:00Z"
+            updated_at: "2018-01-01T10:00:00Z"
+    # Schema for admins body response
+    AdminsResponseSchema:
+      allOf:
+      - $ref: '#/components/schemas/BaseResponseSchema'
+      - type: object
+        properties:
+          data:
+            type: object
+            allOf:
+              - $ref: '#/components/schemas/PaginatedListSchema'
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UserSchema'
+        required:
+          - data
+        example:
+          version: "1"
+          success: true
+          data:
+            object: "list"
+            data:
+              - object: "user"
+                id: "cec34607-0761-4a59-8357-18963e42a1aa"
+                provider_user_id: "wijf-fbancomw-dqwjudb"
+                username: "johndoe"
+                email: "johndoe@omise.co"
+                metadata: {"first_name": "John", "last_name": "Doe"}
+                created_at: "2018-01-01T00:00:00Z"
+                updated_at: "2018-01-01T10:00:00Z"
+            pagination:
+              per_page: 10
+              current_page: 1
+              is_first_page: true
+              is_last_page: true
     # Schema for an error object
     ErrorSchema:
       type: object
@@ -743,6 +840,48 @@ components:
               - id
             example:
               id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+    # Request body for listing admins
+    AdminAllBody:
+      description: The parameters to use for listing the admins
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              page:
+                type: integer
+                minimum: 1
+              per_page:
+                type: integer
+                minimum: 1
+              search_term:
+                type: string
+              sort_by:
+                type: string
+              sort_dir:
+                type: string
+                enum: ["asc", "desc"]
+            example:
+              page: 1
+              per_page: 10
+              search_term: "text to search for"
+              sort_by: "email"
+              sort_dir: "asc"
+    # Request body for getting a specific admin
+    AdminGetBody:
+      description: The parameters to use for retrieving a specific admin by its id
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              id:
+                type: string
+                format: uuid
+            required:
+              - id
+            example:
+              id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
   parameters:
     # Headers
     ClientAuthorizationHeader:
@@ -802,6 +941,20 @@ components:
         application/vnd.omisego.v1+json:
           schema:
             $ref: '#/components/schemas/UsersResponseSchema'
+    # Admin response
+    AdminResponse:
+      description: Admin response
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            $ref: '#/components/schemas/AdminResponseSchema'
+    # Admins response
+    AdminsResponse:
+      description: Admins response
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            $ref: '#/components/schemas/AdminsResponseSchema'
     # Empty
     EmptyResponse:
       description: Empty response

--- a/apps/kubera_admin/test/kubera_admin/v1/controllers/admin_controller_test.exs
+++ b/apps/kubera_admin/test/kubera_admin/v1/controllers/admin_controller_test.exs
@@ -1,0 +1,93 @@
+defmodule KuberaAdmin.V1.AdminControllerTest do
+  use KuberaAdmin.ConnCase, async: true
+  alias Ecto.UUID
+
+  describe "/admin.all" do
+    test "returns a list of admins and pagination data" do
+      response = user_request("/admin.all")
+
+      # Asserts return data
+      assert response["success"]
+      assert response["data"]["object"] == "list"
+      assert is_list(response["data"]["data"])
+
+      # Asserts pagination data
+      pagination = response["data"]["pagination"]
+      assert is_integer pagination["per_page"]
+      assert is_integer pagination["current_page"]
+      assert is_boolean pagination["is_last_page"]
+      assert is_boolean pagination["is_first_page"]
+    end
+
+    test "returns a list of admins according to search_term, sort_by and sort_direction" do
+      account = insert(:account)
+      role    = insert(:role, %{name: "some_role"})
+      admin1  = insert(:admin, %{email: "admin1@omise.co"})
+      admin2  = insert(:admin, %{email: "admin2@omise.co"})
+      admin3  = insert(:admin, %{email: "admin3@omise.co"})
+      _user   = insert(:user, %{email: "user1@omise.co"})
+
+      insert(:membership, %{user: admin1, account: account, role: role})
+      insert(:membership, %{user: admin2, account: account, role: role})
+      insert(:membership, %{user: admin3, account: account, role: role})
+
+      attrs = %{
+        "search_term" => "AdMiN", # Search is case-insensitive
+        "sort_by"     => "email",
+        "sort_dir"    => "desc"
+      }
+
+      response = user_request("/admin.all", attrs)
+      admins = response["data"]["data"]
+
+      assert response["success"]
+      assert Enum.count(admins) == 3
+      assert Enum.at(admins, 0)["email"] == "admin3@omise.co"
+      assert Enum.at(admins, 1)["email"] == "admin2@omise.co"
+      assert Enum.at(admins, 2)["email"] == "admin1@omise.co"
+    end
+  end
+
+  describe "/admin.get" do
+    test "returns an admin by the given admin's ID" do
+      account     = insert(:account)
+      role        = insert(:role, %{name: "some_role"})
+      admin       = insert(:admin, %{email: "admin@omise.co"})
+      _membership = insert(:membership, %{user: admin, account: account, role: role})
+
+      response = user_request("/admin.get", %{"id" => admin.id})
+
+      assert response["success"]
+      assert response["data"]["object"] == "user"
+      assert response["data"]["email"] == admin.email
+    end
+
+    test "returns 'user:id_not_found' if the given ID is not an admin" do
+      user     = insert(:user)
+      response = user_request("/admin.get", %{"id" => user.id})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "user:id_not_found"
+      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+    end
+
+    test "returns 'user:id_not_found' if the given ID was not found" do
+      response  = user_request("/admin.get", %{"id" => UUID.generate()})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "user:id_not_found"
+      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+    end
+
+    test "returns 'client:invalid_parameter' if the given ID is not UUID" do
+      response  = user_request("/admin.get", %{"id" => "not_uuid"})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Admin ID must be a UUID"
+    end
+  end
+end

--- a/apps/kubera_db/lib/kubera_db/user.ex
+++ b/apps/kubera_db/lib/kubera_db/user.ex
@@ -63,8 +63,8 @@ defmodule KuberaDB.User do
   @doc """
   Retrieves a specific user.
   """
-  def get(id) do
-    User
+  def get(id, queryable \\ User) do
+    queryable
     |> Repo.get(id)
     |> Repo.preload(:balances)
   end

--- a/apps/kubera_db/lib/kubera_db/user_query.ex
+++ b/apps/kubera_db/lib/kubera_db/user_query.ex
@@ -1,0 +1,17 @@
+defmodule KuberaDB.UserQuery do
+  @moduledoc """
+  Helper functions to manipulate a `KuberaDB.User`'s query.
+  """
+  import Ecto.Query
+  alias KuberaDB.{Membership, User}
+
+  @doc """
+  Scopes the given user query to users with one or more membership only.
+  If a `queryable` is not given, it automatically creates a new User query.
+  """
+  def where_has_membership(queryable \\ User) do
+    queryable
+    |> join(:inner, [u], m in Membership, u.id == m.user_id)
+    |> select([c], c) # Returns only the User struct, not the Memberships
+  end
+end

--- a/apps/kubera_db/test/kubera_db/auth_token_test.exs
+++ b/apps/kubera_db/test/kubera_db/auth_token_test.exs
@@ -64,7 +64,7 @@ defmodule KuberaDB.AuthTokenTest do
 
   describe "AuthToken.authenticate/3" do
     test "returns an existing token if user_id and token match" do
-      user = insert(:admin_user)
+      user = insert(:admin)
       auth_token_string = AuthToken.generate(user, @owner_app)
 
       auth_user = AuthToken.authenticate(user.id, auth_token_string, @owner_app)
@@ -72,7 +72,7 @@ defmodule KuberaDB.AuthTokenTest do
     end
 
     test "returns an existing token if user_id and token match and user has multiple tokens" do
-      user = insert(:admin_user)
+      user = insert(:admin)
       token1 = AuthToken.generate(user, @owner_app)
       token2 = AuthToken.generate(user, @owner_app)
 
@@ -88,29 +88,29 @@ defmodule KuberaDB.AuthTokenTest do
     end
 
     test "returns false if auth token belongs to a different user" do
-      user = insert(:admin_user)
+      user = insert(:admin)
       auth_token_string = AuthToken.generate(user, @owner_app)
 
-      another_user = insert(:admin_user)
+      another_user = insert(:admin)
       assert AuthToken.authenticate(another_user.id, auth_token_string, @owner_app) == false
     end
 
     test "returns false if token exists but for a different owner app" do
-      user = insert(:admin_user)
+      user = insert(:admin)
       auth_token_string = AuthToken.generate(user, :different_app)
 
       assert AuthToken.authenticate(user.id, auth_token_string, @owner_app) == :false
     end
 
     test "returns false if token does not exists" do
-      user = insert(:admin_user)
+      user = insert(:admin)
       AuthToken.generate(user, @owner_app)
 
       assert AuthToken.authenticate(user.id, "unmatched", @owner_app) == false
     end
 
     test "returns false if auth token is nil" do
-      user = insert(:admin_user)
+      user = insert(:admin)
       AuthToken.generate(user, @owner_app)
 
       assert AuthToken.authenticate(user.id, nil, @owner_app) == false

--- a/apps/kubera_db/test/kubera_db/user_query_test.exs
+++ b/apps/kubera_db/test/kubera_db/user_query_test.exs
@@ -1,0 +1,39 @@
+defmodule KuberaDB.UserQueryTest do
+  use KuberaDB.SchemaCase
+  alias KuberaDB.{User, UserQuery}
+
+  describe "UserQuery.where_has_membership/1" do
+    test "returns only admins" do
+      account = insert(:account)
+      role    = insert(:role, %{name: "some_role"})
+      admin1  = insert(:admin, %{email: "admin1@omise.co"})
+      admin2  = insert(:admin, %{email: "admin2@omise.co"})
+      user    = insert(:user, %{email: "user1@omise.co"})
+
+      insert(:membership, %{user: admin1, account: account, role: role})
+      insert(:membership, %{user: admin2, account: account, role: role})
+
+      result =
+        User
+        |> UserQuery.where_has_membership()
+        |> Repo.all()
+
+      assert Enum.count(result) == 2
+      assert Enum.at(result, 0).email == admin1.email
+      assert Enum.at(result, 1).email == admin2.email
+      refute Enum.any?(result, fn(admin) -> admin.email == user.email end)
+    end
+
+    test "uses `KuberaDB.User` if `queryable` is not given" do
+      account = insert(:account)
+      role    = insert(:role, %{name: "some_role"})
+      admin   = insert(:admin, %{email: "admin@omise.co"})
+      insert(:membership, %{user: admin, account: account, role: role})
+
+      query = UserQuery.where_has_membership()
+      result = Repo.all(query)
+
+      assert Enum.count(result) == 1
+    end
+  end
+end

--- a/apps/kubera_db/test/support/factory.ex
+++ b/apps/kubera_db/test/support/factory.ex
@@ -64,7 +64,7 @@ defmodule KuberaDB.Factory do
     }
   end
 
-  def admin_user_factory do
+  def admin_factory do
     %User{
       username: nil,
       provider_user_id: nil,


### PR DESCRIPTION
# Description
Adds 2 new endpoints to Kubera Admin API:
1. `/admin.all` - Retrieve a list of admins
2. `/admin.get` - Retrieve a specific admin

Note that these two endpoints return "user" objects because admins are actually users with specific roles/memberships.

# Testing

Apart from running unit tests, you can try out the endpoints via curl commands.

## /admin.all

```sh
curl -X POST \
10.5.10.20:5000/admin.all \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGAdmin $(echo -n "api_key_id:api_key:user_id:auth_token" | base64 | tr -d '\n')" \
-v -w "\n" | jq
```

## /admin.get
```sh
curl -X POST \
10.5.10.20:5000/user.get \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGAdmin $(echo -n "api_key_id:api_key:user_id:auth_token" | base64 | tr -d '\n')" \
-H "Content-Type: application/json" \
-d '{"id": "de0de389-5706-4257-ac55-84c1346b7ca1"}' \
-v -w "\n" | jq
```