### PR TITLE
Revert "Allow /user.all search by email (#24)"

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/user_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/user_controller.ex
@@ -5,7 +5,7 @@ defmodule AdminAPI.V1.UserController do
   alias EWallet.Web.{SearchParser, SortParser, Paginator}
   alias EWalletDB.User
 
-  @search_fields [{:id, :uuid}, :username, :provider_user_id, :email]
+  @search_fields [{:id, :uuid}, :username, :provider_user_id]
   @sort_fields [:id, :username, :provider_user_id]
 
   @doc """

--- a/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
@@ -39,24 +39,6 @@ defmodule AdminAPI.V1.UserControllerTest do
       assert Enum.at(users, 1)["username"] == "match_user2"
       assert Enum.at(users, 2)["username"] == "match_user1"
     end
-
-    test "returns a list of users by the given email serch term" do
-      insert(:user, %{email: "match-email@example.com"})
-      insert(:user, %{email: "email@match-domain.com"})
-      insert(:user, %{email: "missed@example.com"})
-
-      attrs = %{
-        "search_term" => "MaTcH" # Search is case-insensitive
-      }
-
-      response = user_request("/user.all", attrs)
-      users = response["data"]["data"]
-
-      assert response["success"]
-      assert Enum.count(users) == 2
-      assert Enum.at(users, 0)["email"] == "match-email@example.com"
-      assert Enum.at(users, 1)["email"] == "email@match-domain.com"
-    end
   end
 
   describe "/user.get" do


### PR DESCRIPTION
Search for admin user should be done via `/admin.all`, which already implemented email search.