### PR TITLE
Add `AccountScopePlug` module

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/plugs/account_scope_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/account_scope_plug.ex
@@ -1,0 +1,32 @@
+defmodule AdminAPI.V1.AccountScopePlug do
+  @moduledoc """
+  This plug extracts the account's scope from the request header,
+  and assigns it to the connection as `scoped_account_id` for downstream usage.
+  """
+  import Plug.Conn
+  import AdminAPI.V1.ErrorHandler
+  alias Ecto.UUID
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    parse_header(conn)
+  end
+
+  defp parse_header(conn) do
+    header =
+      conn
+      |> get_req_header("omgadmin-account-id")
+      |> List.first()
+
+    with header when not is_nil(header) <- header,
+         {:ok, uuid} when is_binary(uuid) <- UUID.cast(header) do
+      assign(conn, :scoped_account_id, uuid)
+    else
+      # If the header is provided, it must be a UUID
+      :error -> handle_error(conn, :invalid_account_id)
+      # If the header is not provided, this plug does nothing
+      nil -> conn
+    end
+  end
+end

--- a/apps/admin_api/test/admin_api/v1/plugs/account_scope_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/account_scope_plug_test.exs
@@ -1,0 +1,40 @@
+defmodule AdminAPI.V1.AccountScopePlugTest do
+  use AdminAPI.ConnCase, async: true
+  alias AdminAPI.V1.AccountScopePlug
+  alias Ecto.UUID
+
+  # Lower-case header keys is enforced by `Plug.Conn` and only in test environments,
+  # otherwise it will raise an `InvalidHeaderError`.
+  # See https://github.com/elixir-plug/plug/blob/master/lib/plug/conn.ex
+  @header_name "omgadmin-account-id"
+
+  describe "AccountScopePlug.call/2" do
+    test "assigns scoped_account_id to the connection if the header value is a UUID" do
+      account_id = UUID.generate()
+      conn       = test_with(account_id)
+
+      refute conn.halted
+      assert conn.assigns.scoped_account_id == account_id
+    end
+
+    test "halts with error if the header is provided but not a UUID" do
+      conn = test_with("not-a-uuid")
+
+      assert conn.halted
+      refute Map.has_key?(conn.assigns, :scoped_account_id)
+    end
+
+    test "skips and does not assign scoped_account_id if the header is not provided" do
+      conn = AccountScopePlug.call(build_conn(), [])
+
+      refute conn.halted
+      refute Map.has_key?(conn.assigns, :scoped_account_id)
+    end
+  end
+
+  defp test_with(account_id) do
+    build_conn()
+    |> put_req_header(@header_name, account_id)
+    |> AccountScopePlug.call([])
+  end
+end


### PR DESCRIPTION
# Overview

This PR adds a new Plug that parses `OMGAdmin-Account-ID: 00000000-0000-0000-0000-000000000000` header into the connection's assignments. The assignment can be used for query scoping downstream using `conn.assigns.scoped_account_id`.