### PR TITLE
Ensure files are always stored in the same folder

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
@@ -136,13 +136,13 @@ defmodule AdminAPI.V1.AccountControllerTest do
       assert response["success"]
       assert response["data"]["object"] == "account"
       assert response["data"]["avatar"]["large"] =~
-             "http://example.com/public/uploads/test/account/avatars/#{account.id}/large.jpg?v="
+             "http://example.com/public/uploads/test/account/avatars/#{account.id}/large.png?v="
       assert response["data"]["avatar"]["original"] =~
              "http://example.com/public/uploads/test/account/avatars/#{account.id}/original.jpg?v="
       assert response["data"]["avatar"]["small"] =~
-             "http://example.com/public/uploads/test/account/avatars/#{account.id}/small.jpg?v="
+             "http://example.com/public/uploads/test/account/avatars/#{account.id}/small.png?v="
       assert response["data"]["avatar"]["thumb"] =~
-             "http://example.com/public/uploads/test/account/avatars/#{account.id}/thumb.jpg?v="
+             "http://example.com/public/uploads/test/account/avatars/#{account.id}/thumb.png?v="
     end
 
     test "returns 'account:id_not_found' if the given ID was not found" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_controller_test.exs
@@ -111,13 +111,13 @@ defmodule AdminAPI.V1.AdminControllerTest do
       assert response["data"]["object"] == "user"
       assert response["data"]["email"] == admin.email
       assert response["data"]["avatar"]["large"] =~
-             "http://example.com/public/uploads/test/user/avatars/#{uuid}/large.jpg?v="
+             "http://example.com/public/uploads/test/user/avatars/#{uuid}/large.png?v="
       assert response["data"]["avatar"]["original"] =~
              "http://example.com/public/uploads/test/user/avatars/#{uuid}/original.jpg?v="
       assert response["data"]["avatar"]["small"] =~
-             "http://example.com/public/uploads/test/user/avatars/#{uuid}/small.jpg?v="
+             "http://example.com/public/uploads/test/user/avatars/#{uuid}/small.png?v="
       assert response["data"]["avatar"]["thumb"] =~
-             "http://example.com/public/uploads/test/user/avatars/#{uuid}/thumb.jpg?v="
+             "http://example.com/public/uploads/test/user/avatars/#{uuid}/thumb.png?v="
     end
 
     test "returns 'user:id_not_found' if the given ID is not an admin" do

--- a/apps/ewallet_db/lib/ewallet_db/storage/local.ex
+++ b/apps/ewallet_db/lib/ewallet_db/storage/local.ex
@@ -9,7 +9,13 @@ defmodule EWallet.Storage.Local do
 
   def put(definition, version, {file, scope}) do
     destination_dir = definition.storage_dir(version, {file, scope})
-    path = Path.join(destination_dir, file.file_name)
+
+    path = Path.join([
+      Application.get_env(:ewallet, :root),
+      destination_dir,
+      file.file_name
+    ])
+
     path |> Path.dirname() |> File.mkdir_p!()
 
     if binary = file.binary do

--- a/apps/ewallet_db/lib/ewallet_db/uploaders/avatar.ex
+++ b/apps/ewallet_db/lib/ewallet_db/uploaders/avatar.ex
@@ -13,15 +13,15 @@ defmodule EWalletDB.Uploaders.Avatar do
   end
 
   def transform(:large, _) do
-    {:convert, "-strip -thumbnail 400x400^ -gravity center -extent 400x400"}
+    {:convert, "-strip -thumbnail 400x400^ -gravity center -extent 400x400 -format png", :png}
   end
 
   def transform(:small, _) do
-    {:convert, "-strip -thumbnail 150x150^ -gravity center -extent 150x150"}
+    {:convert, "-strip -thumbnail 150x150^ -gravity center -extent 150x150 -format png", :png}
   end
 
   def transform(:thumb, _) do
-    {:convert, "-strip -thumbnail 50x50^ -gravity center -extent 50x50"}
+    {:convert, "-strip -thumbnail 50x50^ -gravity center -extent 50x50 -format png", :png}
   end
 
   def filename(version, _) do

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,6 +9,8 @@ use Mix.Config
 # back to each application for organization purposes.
 import_config "../apps/*/config/config.exs"
 
+config :ewallet, root: File.cwd!
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",


### PR DESCRIPTION
There was a funny randomness when storing files, depending which sub-app was the current one. To fix that, this PR comes with a `root` config defined in the root config file. Also, all files are now converted to `png`.