### PR TITLE
Ensure PostgreSQL is already running prior running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,10 @@ podTemplate(
         }
 
         stage('Test') {
+            container('postgresql') {
+                sh("pg_isready -t 60 -h localhost -p 5432")
+            }
+
             sh(
                 """
                 docker run --rm \


### PR DESCRIPTION
Otherwise test might fail if postgresql container couldn't be started quick enough. This shouldn't be the case due to compilation which should take longer than spinning up a PostgreSQL container, but it's better to guard this case anyway since it _could_ happen.

https://phabricator.omisego.io/T669