### PR TITLE
Fix avatar removal for JS formData

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
@@ -169,6 +169,52 @@ defmodule AdminAPI.V1.AccountControllerTest do
       assert account.avatar == nil
     end
 
+    test "removes the avatar from an account with empty string" do
+      account = insert(:account)
+
+      response = user_request("/account.upload_avatar", %{
+        "id" => account.id,
+        "avatar" => %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      })
+
+      assert response["success"]
+
+      response = user_request("/account.upload_avatar", %{
+        "id" => account.id,
+        "avatar" => ""
+      })
+      assert response["success"]
+
+      account = Account.get(account.id)
+      assert account.avatar == nil
+    end
+
+    test "removes the avatar from an account with 'null' string" do
+      account = insert(:account)
+
+      response = user_request("/account.upload_avatar", %{
+        "id" => account.id,
+        "avatar" => %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      })
+
+      assert response["success"]
+
+      response = user_request("/account.upload_avatar", %{
+        "id" => account.id,
+        "avatar" => "null"
+      })
+      assert response["success"]
+
+      account = Account.get(account.id)
+      assert account.avatar == nil
+    end
+
     test "returns 'account:id_not_found' if the given ID was not found" do
       response = user_request("/account.upload_avatar", %{
         "id" => "fake",

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_controller_test.exs
@@ -147,6 +147,58 @@ defmodule AdminAPI.V1.AdminControllerTest do
       assert admin.avatar == nil
     end
 
+    test "removes the avatar from a user with empty string" do
+      account     = insert(:account)
+      role        = insert(:role, %{name: "some_role"})
+      admin       = insert(:admin, %{email: "admin@omise.co"})
+      uuid        = admin.id
+      _membership = insert(:membership, %{user: admin, account: account, role: role})
+
+      response = user_request("/admin.upload_avatar", %{
+        "id" => uuid,
+        "avatar" => %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      })
+      assert response["success"]
+
+      response = user_request("/admin.upload_avatar", %{
+        "id" => uuid,
+        "avatar" => ""
+      })
+      assert response["success"]
+
+      admin = User.get(admin.id)
+      assert admin.avatar == nil
+    end
+
+    test "removes the avatar from a user with 'null' string" do
+      account     = insert(:account)
+      role        = insert(:role, %{name: "some_role"})
+      admin       = insert(:admin, %{email: "admin@omise.co"})
+      uuid        = admin.id
+      _membership = insert(:membership, %{user: admin, account: account, role: role})
+
+      response = user_request("/admin.upload_avatar", %{
+        "id" => uuid,
+        "avatar" => %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      })
+      assert response["success"]
+
+      response = user_request("/admin.upload_avatar", %{
+        "id" => uuid,
+        "avatar" => "null"
+      })
+      assert response["success"]
+
+      admin = User.get(admin.id)
+      assert admin.avatar == nil
+    end
+
     test "returns 'user:id_not_found' if the given ID is not an admin" do
       user     = insert(:user)
       response = user_request("/admin.upload_avatar", %{

--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -104,6 +104,13 @@ defmodule EWalletDB.Account do
   Stores an avatar for the given account.
   """
   def store_avatar(%Account{} = account, attrs) do
+    attrs =
+      case attrs["avatar"] do
+        ""     -> %{avatar: nil}
+        "null" -> %{avatar: nil}
+        avatar -> %{avatar: avatar}
+      end
+
     changeset = avatar_changeset(account, attrs)
 
     case Repo.update(changeset) do

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -167,8 +167,14 @@ defmodule EWalletDB.User do
   Stores an avatar for the given user.
   """
   def store_avatar(%User{} = user, attrs) do
-    changeset = avatar_changeset(user, attrs)
+    attrs =
+      case attrs["avatar"] do
+        ""     -> %{avatar: nil}
+        "null" -> %{avatar: nil}
+        avatar -> %{avatar: avatar}
+      end
 
+    changeset = avatar_changeset(user, attrs)
     case Repo.update(changeset) do
       {:ok, user} -> get(user.id)
       result      -> result


### PR DESCRIPTION
`formData` in javascript doesn't support sending `null` values. To fix that, the API will now remove avatar if `""` or `"null"` is sent as value for the `avatar` field.