### PR TITLE
Rename development to develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ podTemplate(
             )
         }
 
-        if (env.BRANCH_NAME == 'development') {
+        if (env.BRANCH_NAME == 'develop') {
             stage('Push') {
                 sh("gcloud docker -- push ${imageName}:${gitCommit}")
                 sh("gcloud container images add-tag ${imageName}:${gitCommit} ${imageName}:latest")


### PR DESCRIPTION
Based on Robin's recommendations, I've decided to rename `development` to `develop` (to stay consistent with other projects.