### PR TITLE
Add missing sort by fields

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/admin_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/admin_controller.ex
@@ -6,8 +6,24 @@ defmodule AdminAPI.V1.AdminController do
   alias AdminAPI.V1.UserView
   alias EWalletDB.{User, UserQuery}
 
+  # The field names to be mapped into DB column names.
+  # The keys and values must be strings as this is mapped early before
+  # any operations are done on the field names. For example:
+  # `"request_field_name" => "db_column_name"`
+  @mapped_fields %{
+    "created_at" => "inserted_at"
+  }
+
+  # The fields that are allowed to be searched.
+  # Note that these values here *must be the DB column names*
+  # Because requests cannot customize which fields to search (yet!),
+  # `@mapped_fields` don't affect them.
   @search_fields [{:id, :uuid}, :email]
-  @sort_fields [:id, :email]
+
+  # The fields that are allowed to be sorted.
+  # Note that the values here *must be the DB column names*.
+  # If the request provides different names, map it via `@mapped_fields` first.
+  @sort_fields [:id, :email, :inserted_at, :updated_at]
 
   @doc """
   Retrieves a list of admins.
@@ -16,7 +32,7 @@ defmodule AdminAPI.V1.AdminController do
     User
     |> UserQuery.where_has_membership()
     |> SearchParser.to_query(attrs, @search_fields)
-    |> SortParser.to_query(attrs, @sort_fields)
+    |> SortParser.to_query(attrs, @sort_fields, @mapped_fields)
     |> Paginator.paginate_attrs(attrs)
     |> respond_multiple(conn)
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/api_key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/api_key_controller.ex
@@ -21,7 +21,7 @@ defmodule AdminAPI.V1.APIKeyController do
   # The fields that are allowed to be sorted.
   # Note that the values here *must be the DB column names*.
   # If the request provides different names, map it via `@mapped_fields` first.
-  @sort_fields [:id, :key, :inserted_at, :updated_at]
+  @sort_fields [:id, :key, :owner_app, :inserted_at, :updated_at]
 
   @doc """
   Retrieves a list of API keys including soft-deleted.

--- a/apps/admin_api/lib/admin_api/v1/controllers/user_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/user_controller.ex
@@ -5,8 +5,24 @@ defmodule AdminAPI.V1.UserController do
   alias EWallet.Web.{SearchParser, SortParser, Paginator}
   alias EWalletDB.User
 
+  # The field names to be mapped into DB column names.
+  # The keys and values must be strings as this is mapped early before
+  # any operations are done on the field names. For example:
+  # `"request_field_name" => "db_column_name"`
+  @mapped_fields %{
+    "created_at" => "inserted_at"
+  }
+
+  # The fields that are allowed to be searched.
+  # Note that these values here *must be the DB column names*
+  # Because requests cannot customize which fields to search (yet!),
+  # `@mapped_fields` don't affect them.
   @search_fields [{:id, :uuid}, :username, :provider_user_id]
-  @sort_fields [:id, :username, :provider_user_id]
+
+  # The fields that are allowed to be sorted.
+  # Note that the values here *must be the DB column names*.
+  # If the request provides different names, map it via `@mapped_fields` first.
+  @sort_fields [:id, :username, :provider_user_id, :inserted_at, :updated_at]
 
   @doc """
   Retrieves a list of users.
@@ -14,7 +30,7 @@ defmodule AdminAPI.V1.UserController do
   def all(conn, attrs) do
     User
     |> SearchParser.to_query(attrs, @search_fields)
-    |> SortParser.to_query(attrs, @sort_fields)
+    |> SortParser.to_query(attrs, @sort_fields, @mapped_fields)
     |> Paginator.paginate_attrs(attrs)
     |> respond_multiple(conn)
   end


### PR DESCRIPTION
This PR adds some missing `sort_by` fields. Mostly `created_at` and `inserted_at`, and also `owner_app` for API keys.