### PR TITLE
Use Salty with GitHub URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,17 +30,9 @@ RUN set -xe && \
 COPY . /app
 WORKDIR /app
 
-ARG habitus_host
-ARG habitus_port
-
 RUN set -xe && \
-    mkdir -p ~/.ssh/ && \
-    curl -sL -o ~/.ssh/key http://$habitus_host:$habitus_port/v1/secrets/file/ssh_key && \
-    curl -sL -o ~/.ssh/config http://$habitus_host:$habitus_port/v1/secrets/file/ssh_config && \
-    chmod 600 ~/.ssh/key && \
     mix deps.get && \
-    MIX_ENV=prod mix compile && \
-    rm -rf ~/.ssh
+    MIX_ENV=prod mix compile
 
 ENV PORT 4000
 EXPOSE 4000

--- a/apps/ewallet_db/mix.exs
+++ b/apps/ewallet_db/mix.exs
@@ -41,7 +41,7 @@ defmodule EWalletDB.Mixfile do
       {:ex_machina, "~> 2.0", only: :test},
       {:poison, "~> 3.1"},
       {:bcrypt_elixir, "~> 1.0"},
-      {:salty, git: "ssh://git@github.com/omisego/salty.git"},
+      {:salty, github: "omisego/salty"},
       {:cloak, "~> 0.3.3"},
       {:plug, "~> 1.0"},
       {:arc, "~> 0.8.0"},

--- a/apps/local_ledger_db/mix.exs
+++ b/apps/local_ledger_db/mix.exs
@@ -29,7 +29,7 @@ defmodule LocalLedgerDB.Mixfile do
     [
       {:postgrex, ">= 0.0.0"},
       {:ecto, "~> 2.1.6"},
-      {:salty, git: "ssh://git@github.com/omisego/salty.git"},
+        {:salty, github: "omisego/salty"},
       {:cloak, "~> 0.3.3"},
       {:ex_machina, "~> 2.0", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -53,7 +53,7 @@
   "rabbitmq_rpc": {:git, "ssh://git@github.com/omisego/rabbitmq-rpc.git", "d5d918bfd453eae6747509acd46b857512410137", [tag: "0.3.0"]},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "recon": {:hex, :recon, "2.3.4", "b406c2fccdeaa0d94e23b5e30ae3d635a2d461e363a5c9c6316897037cf050d2", [:rebar3], [], "hexpm"},
-  "salty": {:git, "ssh://git@github.com/omisego/salty.git", "6f53855a44e1b31b1fc208df52e971454c85f33b", []},
+  "salty": {:git, "https://github.com/omisego/salty.git", "5d377a1391865aecccfa62725996c54aa6d9a5c2", []},
   "sentry": {:hex, :sentry, "6.0.3", "e83f21901008a6c76ff81cc696a053fbd1d6a12600050d3e61928c7945b3621e", [:mix], [{:hackney, "~> 1.8 or 1.6.5", [hex: :hackney, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: true]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}, {:uuid, "~> 1.0", [hex: :uuid, repo: "hexpm", optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "sweet_xml": {:hex, :sweet_xml, "0.6.5", "dd9cde443212b505d1b5f9758feb2000e66a14d3c449f04c572f3048c66e6697", [:mix], [], "hexpm"},


### PR DESCRIPTION
# Overview

We needed some authentication to get Salty before. Now that it's been open-sourced, we can just pull it from GitHub (until the library is actually pushed to Hex).

# Changes

- Use `github:` to pull Salty
- Remove Habitus in Dockerfile

# Impact

None.