### PR TITLE
Add metadata to transactions list

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/serializers/transaction_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/transaction_serializer.ex
@@ -32,6 +32,7 @@ defmodule AdminAPI.V1.TransactionSerializer do
         object: "exchange",
         rate: 1,
       },
+      metadata: transaction.metadata,
       status: transaction.status,
       created_at: Date.to_iso8601(transaction.inserted_at),
       updated_at: Date.to_iso8601(transaction.updated_at)

--- a/apps/admin_api/priv/swagger.yaml
+++ b/apps/admin_api/priv/swagger.yaml
@@ -1111,6 +1111,8 @@ components:
               type: string
             rate:
               type: number
+        metadata:
+          type: object
         status:
           type: string
           enum:
@@ -1130,6 +1132,7 @@ components:
         - from
         - to
         - exchange
+        - metadata
         - status
         - created_at
         - updated_at
@@ -1175,6 +1178,7 @@ components:
                 subunit_to_unit: 100
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"
+            metadata: {}
             exchange:
               object: "exchange"
               rate: 1
@@ -1234,6 +1238,7 @@ components:
                 exchange:
                   object: "exchange"
                   rate: 1
+                metadata: {}
                 status: "confirmed"
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"

--- a/apps/admin_api/test/admin_api/v1/serializers/transaction_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/transaction_serializer_test.exs
@@ -44,6 +44,7 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
           object: "exchange",
           rate: 1,
         },
+        metadata: %{some: "metadata"},
         status: transaction.status,
         created_at: Date.to_iso8601(transaction.inserted_at),
         updated_at: Date.to_iso8601(transaction.updated_at)
@@ -107,6 +108,7 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
               object: "exchange",
               rate: 1,
             },
+            metadata: %{some: "metadata"},
             status: transaction1.status,
             created_at: Date.to_iso8601(transaction1.inserted_at),
             updated_at: Date.to_iso8601(transaction1.updated_at)
@@ -147,6 +149,7 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
               object: "exchange",
               rate: 1,
             },
+            metadata: %{some: "metadata"},
             status: transaction2.status,
             created_at: Date.to_iso8601(transaction2.inserted_at),
             updated_at: Date.to_iso8601(transaction2.updated_at)

--- a/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
@@ -47,6 +47,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
             object: "exchange",
             rate: 1,
           },
+          metadata: %{some: "metadata"},
           status: transaction.status,
           created_at: Date.to_iso8601(transaction.inserted_at),
           updated_at: Date.to_iso8601(transaction.updated_at)
@@ -114,6 +115,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                 object: "exchange",
                 rate: 1,
               },
+              metadata: %{some: "metadata"},
               status: transaction1.status,
               created_at: Date.to_iso8601(transaction1.inserted_at),
               updated_at: Date.to_iso8601(transaction1.updated_at)
@@ -154,6 +156,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                 object: "exchange",
                 rate: 1,
               },
+              metadata: %{some: "metadata"},
               status: transaction2.status,
               created_at: Date.to_iso8601(transaction2.inserted_at),
               updated_at: Date.to_iso8601(transaction2.updated_at)

--- a/apps/ewallet_api/lib/ewallet_api/v1/serializers/json/transaction_serializer.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/serializers/json/transaction_serializer.ex
@@ -32,6 +32,7 @@ defmodule EWalletAPI.V1.JSON.TransactionSerializer do
         object: "exchange",
         rate: 1,
       },
+      metadata: transaction.metadata,
       status: transaction.status,
       created_at: Date.to_iso8601(transaction.inserted_at),
       updated_at: Date.to_iso8601(transaction.updated_at)

--- a/apps/ewallet_api/priv/swagger.yaml
+++ b/apps/ewallet_api/priv/swagger.yaml
@@ -833,6 +833,8 @@ components:
               type: string
             rate:
               type: number
+        metadata:
+          type: object
         status:
           type: string
           enum:
@@ -852,6 +854,7 @@ components:
         - from
         - to
         - exchange
+        - metadata
         - status
         - created_at
         - updated_at
@@ -896,6 +899,7 @@ components:
             exchange:
               object: "exchange"
               rate: 1
+            metadata: {}
             status: "confirmed"
             created_at: "2018-01-01T00:00:00Z"
             updated_at: "2018-01-01T10:00:00Z"
@@ -952,6 +956,7 @@ components:
                 exchange:
                   object: "exchange"
                   rate: 1
+                metadata: {}
                 status: "confirmed"
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"

--- a/apps/ewallet_api/test/ewallet_api/v1/serializers/json/transaction_serializer_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/serializers/json/transaction_serializer_test.exs
@@ -40,6 +40,7 @@ defmodule EWalletAPI.V1.JSON.TransactionSerializerTest do
           object: "exchange",
           rate: 1,
         },
+        metadata: %{some: "metadata"},
         status: transaction.status,
         created_at: Date.to_iso8601(transaction.inserted_at),
         updated_at: Date.to_iso8601(transaction.updated_at)

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
@@ -43,6 +43,7 @@ defmodule EWalletAPI.V1.TransactionViewTest do
             object: "exchange",
             rate: 1,
           },
+          metadata: %{some: "metadata"},
           status: transaction.status,
           created_at: Date.to_iso8601(transaction.inserted_at),
           updated_at: Date.to_iso8601(transaction.updated_at)


### PR DESCRIPTION
Issue/Task Number: T50 - [Issue](https://github.com/omisego/ruby-sdk/issues/11)

# Overview

The transactions sent back in the listing endpoints don't currently contain the `metadata` field. This PR fixes that.

# Changes

- Add `metadata` to EWallet `TransactionSerializer`
- Add `metadata` to AdminAPI `TransactionSerializer`
- Fixes tests

# Implementation Details

Nothing much, except a new field in the serializers.

# Usage

.

# Impact

No special requirements.