### PR TITLE
Default search_term in swagger docs to empty strings

### DIFF
--- a/apps/admin_api/priv/swagger.yaml
+++ b/apps/admin_api/priv/swagger.yaml
@@ -1542,7 +1542,7 @@ components:
             example:
               page: 1
               per_page: 10
-              search_term: "text to search for"
+              search_term: ""
               sort_by: "field_name"
               sort_dir: "asc"
     MintedTokenGetBody:
@@ -1626,7 +1626,7 @@ components:
             example:
               page: 1
               per_page: 10
-              search_term: "text to search for"
+              search_term: ""
               sort_by: "field_name"
               sort_dir: "asc"
     AccountGetBody:
@@ -1818,7 +1818,7 @@ components:
             example:
               page: 1
               per_page: 10
-              search_term: "text to search for"
+              search_term: ""
               sort_by: "field_name"
               sort_dir: "asc"
     UserGetBody:
@@ -1887,7 +1887,7 @@ components:
             example:
               page: 1
               per_page: 10
-              search_term: "text to search for"
+              search_term: ""
               sort_by: "created_at"
               sort_dir: "desc"
     TransactionGetBody:
@@ -1931,7 +1931,7 @@ components:
             example:
               page: 1
               per_page: 10
-              search_term: "text to search for"
+              search_term: ""
               sort_by: "email"
               sort_dir: "asc"
     AdminGetBody:
@@ -1994,7 +1994,7 @@ components:
             example:
               page: 1
               per_page: 10
-              search_term: "text to search for"
+              search_term: ""
               sort_by: "created_at"
               sort_dir: "desc"
     AccessKeyDeleteBody:
@@ -2048,7 +2048,7 @@ components:
             example:
               page: 1
               per_page: 10
-              search_term: "text to search for"
+              search_term: ""
               sort_by: "created_at"
               sort_dir: "asc"
     APIKeyCreateBody:

--- a/apps/ewallet_api/priv/swagger.yaml
+++ b/apps/ewallet_api/priv/swagger.yaml
@@ -1166,8 +1166,8 @@ components:
             example:
               page: 1
               per_page: 10
-              search_term: "text to search for"
-              seatch_terms: {"name": "some_name"}
+              search_term: ""
+              seatch_terms: {}
               sort_by: "field_name"
               sort_dir: "asc"
     UserTransactionsBody:
@@ -1203,8 +1203,8 @@ components:
               address: "address_owned_by_user (optional)"
               page: 1
               per_page: 10
-              search_term: "text to search for"
-              seatch_terms: {"name": "some_name"}
+              search_term: ""
+              seatch_terms: {}
               sort_by: "field_name"
               sort_dir: "asc"
     CurrentUserTransactionsBody:
@@ -1237,8 +1237,8 @@ components:
               address: "address_owned_by_current_user (optional)"
               page: 1
               per_page: 10
-              search_term: "text to search for"
-              seatch_terms: {"name": "some_name"}
+              search_term: ""
+              seatch_terms: {}
               sort_by: "field_name"
               sort_dir: "asc"
     ######################################


### PR DESCRIPTION
Issue/Task Number: N/A

# Overview

Thanks to a great suggestion by kartsims in #93, this PR replaces `search_term` and `search_terms` value in swagger doc to empty strings and objects so that requests from Swagger UI show unfiltered results by default.

# Changes

- Updated swagger docs for both eWallet API and Admin API

# Implementation Details

Textual update

# Usage

Try making `*.all` requests from Swagger UI. Instead of showing empty results with the default request bodies, they should now return unfiltered results.

# Impact

Usual deployment. No extra steps required.