### PR TITLE
Add maximum `per_page` value

### DIFF
--- a/apps/ewallet/config/config.exs
+++ b/apps/ewallet/config/config.exs
@@ -2,7 +2,9 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :ewallet, ecto_repos: []
+config :ewallet,
+  ecto_repos: [],
+  max_per_page: System.get_env("REQUEST_MAX_PER_PAGE") || 100
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/apps/ewallet/test/ewallet/web/paginator_test.exs
+++ b/apps/ewallet/test/ewallet/web/paginator_test.exs
@@ -26,6 +26,20 @@ defmodule EWallet.Web.PaginatorTest do
       assert paginator.pagination.per_page == 4
     end
 
+    test "returns per_page but never greater than the system's _default_ maximum (100)" do
+      paginator = Paginator.paginate_attrs(Account, %{"per_page" => 999})
+      assert paginator.pagination.per_page == 100
+    end
+
+    test "returns per_page but never greater than the system's _defined_ maximum" do
+      Application.put_env(:ewallet, :max_per_page, 20)
+
+      paginator = Paginator.paginate_attrs(Account, %{"per_page" => 100})
+      assert paginator.pagination.per_page == 20
+
+      Application.delete_env(:ewallet, :max_per_page)
+    end
+
     test "returns :error if given attrs.page is a negative integer" do
       result = Paginator.paginate_attrs(Account, %{"page" => -1})
       assert {:error, :invalid_parameter, _} = result

--- a/docs/setup/env.md
+++ b/docs/setup/env.md
@@ -24,6 +24,13 @@ The eWallet needs access to two different databases: one for the eWallet itself 
 - `DATABASE_URL`
 - `LOCAL_LEDGER_DATABASE_URL`
 
+## Incoming Requests
+
+The eWallet allows you to configure different aspects of the incoming requests.
+We try to provide sane default values, but if needed, the following environment variables are configurable:
+
+- `REQUEST_MAX_PER_PAGE`: The maximum value of `per_page` a request can make. This helps prevent requests from overloading the system by sending a very high `per_page` value.
+
 ## Error Reporting
 
 The eWallet only supports [Sentry](https://sentry.io/welcome/) for now. You can specify the DSN for it with the following environment variable:


### PR DESCRIPTION
Issue/Task Number: N/A

# Overview

Thanks to a great suggestion by kartsims in #93, this PR adds a maximum limit to `per_page` input to prevent a request overloading the system by sending a very high `per_page` value.

# Changes

- Updated `EWallet.Web.Paginator` to support `max_per_page`
- Added a configurable value in `ewallet/config/config.exs` called `max_per_page`
- Set the default `max_per_page` to 100
- Updated `docs/setup/env.md` to include `REQUEST_MAX_PER_PAGE`

# Implementation Details

- If the given `per_page` is higher than the `max_per_page`, the `per_page` will automatically be set to the `max_per_page` value instead of returning an error.

# Usage

Try send a request with a very high `per_page` value, you should see the response returning only up to the defined `max_per_page`.

You should also see that the response's `pagination.per_page` return the value that is actually used for the query, not the requested value.

This is only applicable to endpoints that are already supporting `per_page` attribute, e.g. `/admin/api/transaction.all`.

# Impact

You can optionally set the limit via an environment variable `REQUEST_MAX_PER_PAGE`. But apart from that, no extra steps required.