### PR TITLE
T58 - Metadata and encrypted metadata

### DIFF
--- a/apps/admin_api/lib/admin_api/invites/inviter.ex
+++ b/apps/admin_api/lib/admin_api/invites/inviter.ex
@@ -36,8 +36,7 @@ defmodule AdminAPI.Inviter do
       nil ->
         {:ok, user} = User.insert(%{
           email: email,
-          password: Crypto.generate_key(32),
-          metadata: %{}
+          password: Crypto.generate_key(32)
         })
         user
     end

--- a/apps/admin_api/lib/admin_api/v1/controllers/minted_token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/minted_token_controller.ex
@@ -75,8 +75,7 @@ defmodule AdminAPI.V1.MintedTokenController do
       "idempotency_token" => minted_token.id,
       "token_id" => minted_token.friendly_id,
       "amount" => amount,
-      "description" => "",
-      "metadata" => %{}
+      "description" => ""
     })
 
     case res do

--- a/apps/admin_api/lib/admin_api/v1/serializers/account_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/account_serializer.ex
@@ -25,6 +25,8 @@ defmodule AdminAPI.V1.AccountSerializer do
       description: account.description,
       master: Account.master?(account),
       avatar: Avatar.urls({account.avatar, account}),
+      metadata: account.metadata,
+      encrypted_metadata: account.encrypted_metadata,
       created_at: Date.to_iso8601(account.inserted_at),
       updated_at: Date.to_iso8601(account.updated_at)
     }

--- a/apps/admin_api/lib/admin_api/v1/serializers/minted_token_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/minted_token_serializer.ex
@@ -15,6 +15,8 @@ defmodule AdminAPI.V1.MintedTokenSerializer do
       symbol: minted_token.symbol,
       name: minted_token.name,
       subunit_to_unit: minted_token.subunit_to_unit,
+      metadata: minted_token.metadata,
+      encrypted_metadata: minted_token.encrypted_metadata,
       created_at: Date.to_iso8601(minted_token.inserted_at),
       updated_at: Date.to_iso8601(minted_token.updated_at)
     }

--- a/apps/admin_api/lib/admin_api/v1/serializers/transaction_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/transaction_serializer.ex
@@ -33,6 +33,7 @@ defmodule AdminAPI.V1.TransactionSerializer do
         rate: 1,
       },
       metadata: transaction.metadata,
+      encrypted_metadata: transaction.encrypted_metadata,
       status: transaction.status,
       created_at: Date.to_iso8601(transaction.inserted_at),
       updated_at: Date.to_iso8601(transaction.updated_at)

--- a/apps/admin_api/lib/admin_api/v1/serializers/user_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/user_serializer.ex
@@ -17,6 +17,7 @@ defmodule AdminAPI.V1.UserSerializer do
       provider_user_id: user.provider_user_id,
       email: user.email,
       metadata: user.metadata,
+      encrypted_metadata: user.encrypted_metadata,
       avatar: Avatar.urls({user.avatar, user}),
       created_at: Date.to_iso8601(user.inserted_at),
       updated_at: Date.to_iso8601(user.updated_at)

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -730,6 +730,10 @@ components:
         updated_at:
           type: string
           format: date-time
+        metadata:
+          type: object
+        encrypted_metadata:
+          type: object
       required:
         - object
         - id
@@ -820,6 +824,10 @@ components:
           type: boolean
         avatar:
           type: object
+        metadata:
+          type: object
+        encrypted_metadata:
+          type: object
         created_at:
           type: string
           format: date-time
@@ -856,6 +864,8 @@ components:
             name: "Account Name"
             description: "The account description"
             master: true
+            metadata: {}
+            encrypted_metadata: {}
             avatar: {"original": "file_url"}
             created_at: "2018-01-01T00:00:00Z"
             updated_at: "2018-01-01T10:00:00Z"
@@ -918,6 +928,8 @@ components:
           format: email
         metadata:
           type: object
+        encrypted_metadata:
+          type: object
         avatar:
           type: object
         created_at:
@@ -929,7 +941,6 @@ components:
       required:
         - object
         - id
-        - metadata
         - created_at
         - updated_at
       example:
@@ -939,6 +950,7 @@ components:
         username: "johndoe"
         email: "johndoe@omise.co"
         metadata: {"first_name": "John", "last_name": "Doe"}
+        encrypted_metadata: {"something": "secret"}
         avatar: {"original": "file_url"}
         created_at: "2018-01-01T00:00:00Z"
         updated_at: "2018-01-01T10:00:00Z"
@@ -961,6 +973,7 @@ components:
             username: "johndoe"
             email: "johndoe@omise.co"
             metadata: {"first_name": "John", "last_name": "Doe"}
+            encrypted_metadata: {"something": "secret"}
             created_at: "2018-01-01T00:00:00Z"
             updated_at: "2018-01-01T10:00:00Z"
     UsersResponseSchema:
@@ -993,6 +1006,7 @@ components:
                 username: "johndoe"
                 email: "johndoe@omise.co"
                 metadata: {"first_name": "John", "last_name": "Doe"}
+                encrypted_metadata: {"something": "secret"}
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"
             pagination:
@@ -1023,6 +1037,7 @@ components:
             username: "johndoe"
             email: "johndoe@omise.co"
             metadata: {"first_name": "John", "last_name": "Doe"}
+            encrypted_metadata: {"something": "secret"}
             avatar: {"original": "file_url"}
             created_at: "2018-01-01T00:00:00Z"
             updated_at: "2018-01-01T10:00:00Z"
@@ -1056,6 +1071,7 @@ components:
                 username: "johndoe"
                 email: "johndoe@omise.co"
                 metadata: {"first_name": "John", "last_name": "Doe"}
+                encrypted_metadata: {"something": "secret"}
                 avatar: {"original": "file_url"}
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"
@@ -1110,6 +1126,8 @@ components:
               type: number
         metadata:
           type: object
+        encrypted_metadata:
+          type: object
         status:
           type: string
           enum:
@@ -1129,7 +1147,6 @@ components:
         - from
         - to
         - exchange
-        - metadata
         - status
         - created_at
         - updated_at
@@ -1176,6 +1193,7 @@ components:
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"
             metadata: {}
+            encrypted_metadata: {}
             exchange:
               object: "exchange"
               rate: 1
@@ -1236,6 +1254,7 @@ components:
                   object: "exchange"
                   rate: 1
                 metadata: {}
+                encrypted_metadata: {}
                 status: "confirmed"
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"
@@ -1589,6 +1608,8 @@ components:
                   type: integer
                 metadata:
                   type: object
+                encrypted_metadata:
+                  type: object
               required:
                 - name
                 - symbol
@@ -1653,12 +1674,18 @@ components:
                 type: string
               master:
                 type: string
+              metadata:
+                type: object
+              encrypted_metadata:
+                type: object
             required:
               - name
             example:
               name: "Account Name"
               description: "The account description"
               master: true
+              metadata: {}
+              encrypted_metadata: {}
     AccountUpdateBody:
       description: The parameters to use for updating an account
       required: true
@@ -1675,6 +1702,10 @@ components:
                 type: string
               master:
                 type: string
+              metadata:
+                type: object
+              encrypted_metadata:
+                type: object
             required:
               - id
               - name
@@ -1685,6 +1716,8 @@ components:
               name: "Account Name"
               description: "The account description"
               master: true
+              metadata: {}
+              encrypted_metadata: {}
     AccountListUsersBody:
       description: The parameters to use for assigning listing users in an account
       required: true

--- a/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
@@ -76,12 +76,18 @@ defmodule AdminAPI.V1.AccountControllerTest do
   describe "/account.create" do
     test "creates a new account and returns it" do
       parent       = User.get_account(get_test_user())
-      request_data = params_for(:account, %{parent_id: parent.id})
+      request_data = params_for(:account, %{
+        parent_id: parent.id,
+        metadata: %{something: "interesting"},
+        encrypted_metadata: %{something: "secret"}
+      })
       response     = user_request("/account.create", request_data)
 
       assert response["success"] == true
       assert response["data"]["object"] == "account"
       assert response["data"]["name"] == request_data.name
+      assert response["data"]["metadata"] == %{"something" => "interesting"}
+      assert response["data"]["encrypted_metadata"] == %{"something" => "secret"}
     end
 
     test "returns an error if account name is not provided" do

--- a/apps/admin_api/test/admin_api/v1/controllers/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_membership_controller_test.exs
@@ -24,6 +24,7 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
               "provider_user_id" => user.provider_user_id,
               "email" => user.email,
               "metadata" => user.metadata,
+              "encrypted_metadata" => %{},
               "created_at" => Date.to_iso8601(user.inserted_at),
               "updated_at" => Date.to_iso8601(user.updated_at),
               "account_role" => role.name,

--- a/apps/admin_api/test/admin_api/v1/controllers/invite_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/invite_controller_test.exs
@@ -28,6 +28,7 @@ defmodule AdminAPI.V1.InviteControllerTest do
           "first_name" => user.metadata["first_name"],
           "last_name" => user.metadata["last_name"]
         },
+        "encrypted_metadata" => %{},
         "created_at" => Date.to_iso8601(user.inserted_at),
         "updated_at" => Date.to_iso8601(user.updated_at)
       }

--- a/apps/admin_api/test/admin_api/v1/controllers/minted_token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/minted_token_controller_test.exs
@@ -79,12 +79,16 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
         symbol: "BTC",
         name: "Bitcoin",
         description: "desc",
-        subunit_to_unit: 100
+        subunit_to_unit: 100,
+        metadata: %{something: "interesting"},
+        encrypted_metadata: %{something: "secret"}
       })
       mint = Mint |> Repo.all() |> Enum.at(0)
 
       assert response["success"]
       assert response["data"]["object"] == "minted_token"
+      assert response["data"]["metadata"] == %{"something" => "interesting"}
+      assert response["data"]["encrypted_metadata"] == %{"something" => "secret"}
       assert MintedToken.get(response["data"]["id"]) != nil
       assert mint == nil
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/self_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/self_controller_test.exs
@@ -28,6 +28,8 @@ defmodule AdminAPI.V1.SelfControllerTest do
             "name" => account.name,
             "description" => account.description,
             "master" => Account.master?(account),
+            "metadata" => %{},
+            "encrypted_metadata" => %{},
             "avatar" => %{
               "original" => nil,
               "large" => nil,
@@ -70,6 +72,8 @@ defmodule AdminAPI.V1.SelfControllerTest do
             "name" => account.name,
             "description" => account.description,
             "master" => Account.master?(account),
+            "metadata" => %{},
+            "encrypted_metadata" => %{},
             "avatar" => %{
               "original" => nil,
               "large" => nil,

--- a/apps/admin_api/test/admin_api/v1/serializers/account_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/account_serializer_test.exs
@@ -15,6 +15,8 @@ defmodule AdminAPI.V1.AccountSerializerTest do
         name: account.name,
         description: account.description,
         master: Account.master?(account),
+        metadata: %{},
+        encrypted_metadata: %{},
         avatar: %{
           original: nil,
           large: nil,
@@ -51,6 +53,8 @@ defmodule AdminAPI.V1.AccountSerializerTest do
             name: account1.name,
             description: account1.description,
             master: Account.master?(account1),
+            metadata: %{},
+            encrypted_metadata: %{},
             avatar: %{
               original: nil,
               large: nil,
@@ -67,6 +71,8 @@ defmodule AdminAPI.V1.AccountSerializerTest do
             name: account2.name,
             description: account2.description,
             master: Account.master?(account2),
+            metadata: %{},
+            encrypted_metadata: %{},
             avatar: %{
               original: nil,
               large: nil,

--- a/apps/admin_api/test/admin_api/v1/serializers/membership_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/membership_serializer_test.exs
@@ -21,6 +21,7 @@ defmodule AdminAPI.V1.MembershipSerializerTest do
           "first_name" => user.metadata["first_name"],
           "last_name" => user.metadata["last_name"]
         },
+        encrypted_metadata: %{},
         avatar: %{
           original: nil,
           large: nil,
@@ -52,6 +53,7 @@ defmodule AdminAPI.V1.MembershipSerializerTest do
           "first_name" => user.metadata["first_name"],
           "last_name" => user.metadata["last_name"]
         },
+        encrypted_metadata: %{},
         avatar: %{
           original: nil,
           large: nil,

--- a/apps/admin_api/test/admin_api/v1/serializers/minted_token_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/minted_token_serializer_test.exs
@@ -13,6 +13,8 @@ defmodule AdminAPI.V1.MintedTokenSerializerTest do
         symbol: minted_token.symbol,
         name: minted_token.name,
         subunit_to_unit: minted_token.subunit_to_unit,
+        metadata: %{},
+        encrypted_metadata: %{},
         created_at: Date.to_iso8601(minted_token.inserted_at),
         updated_at: Date.to_iso8601(minted_token.updated_at)
       }
@@ -41,6 +43,8 @@ defmodule AdminAPI.V1.MintedTokenSerializerTest do
             id: minted_token1.friendly_id,
             symbol: minted_token1.symbol,
             name: minted_token1.name,
+            metadata: %{},
+            encrypted_metadata: %{},
             subunit_to_unit: minted_token1.subunit_to_unit,
             created_at: Date.to_iso8601(minted_token1.inserted_at),
             updated_at: Date.to_iso8601(minted_token1.updated_at)
@@ -50,6 +54,8 @@ defmodule AdminAPI.V1.MintedTokenSerializerTest do
             id: minted_token2.friendly_id,
             symbol: minted_token2.symbol,
             name: minted_token2.name,
+            metadata: %{},
+            encrypted_metadata: %{},
             subunit_to_unit: minted_token2.subunit_to_unit,
             created_at: Date.to_iso8601(minted_token2.inserted_at),
             updated_at: Date.to_iso8601(minted_token2.updated_at)

--- a/apps/admin_api/test/admin_api/v1/serializers/transaction_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/transaction_serializer_test.exs
@@ -22,6 +22,8 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
             symbol: minted_token.symbol,
             name: minted_token.name,
             subunit_to_unit: minted_token.subunit_to_unit,
+            metadata: %{},
+            encrypted_metadata: %{},
             created_at: Date.to_iso8601(minted_token.inserted_at),
             updated_at: Date.to_iso8601(minted_token.updated_at)
           },
@@ -35,6 +37,8 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
             id: minted_token.friendly_id,
             symbol: minted_token.symbol,
             name: minted_token.name,
+            metadata: %{},
+            encrypted_metadata: %{},
             subunit_to_unit: minted_token.subunit_to_unit,
             created_at: Date.to_iso8601(minted_token.inserted_at),
             updated_at: Date.to_iso8601(minted_token.updated_at)
@@ -45,6 +49,7 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
           rate: 1,
         },
         metadata: %{some: "metadata"},
+        encrypted_metadata: %{},
         status: transaction.status,
         created_at: Date.to_iso8601(transaction.inserted_at),
         updated_at: Date.to_iso8601(transaction.updated_at)
@@ -85,6 +90,8 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
                 id: minted_token1.friendly_id,
                 symbol: minted_token1.symbol,
                 name: minted_token1.name,
+                metadata: %{},
+                encrypted_metadata: %{},
                 subunit_to_unit: minted_token1.subunit_to_unit,
                 created_at: Date.to_iso8601(minted_token1.inserted_at),
                 updated_at: Date.to_iso8601(minted_token1.updated_at)
@@ -99,6 +106,8 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
                 id: minted_token1.friendly_id,
                 symbol: minted_token1.symbol,
                 name: minted_token1.name,
+                metadata: %{},
+                encrypted_metadata: %{},
                 subunit_to_unit: minted_token1.subunit_to_unit,
                 created_at: Date.to_iso8601(minted_token1.inserted_at),
                 updated_at: Date.to_iso8601(minted_token1.updated_at)
@@ -109,6 +118,7 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
               rate: 1,
             },
             metadata: %{some: "metadata"},
+            encrypted_metadata: %{},
             status: transaction1.status,
             created_at: Date.to_iso8601(transaction1.inserted_at),
             updated_at: Date.to_iso8601(transaction1.updated_at)
@@ -126,6 +136,8 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
                 id: minted_token2.friendly_id,
                 symbol: minted_token2.symbol,
                 name: minted_token2.name,
+                metadata: %{},
+                encrypted_metadata: %{},
                 subunit_to_unit: minted_token2.subunit_to_unit,
                 created_at: Date.to_iso8601(minted_token2.inserted_at),
                 updated_at: Date.to_iso8601(minted_token2.updated_at)
@@ -140,6 +152,8 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
                 id: minted_token2.friendly_id,
                 symbol: minted_token2.symbol,
                 name: minted_token2.name,
+                metadata: %{},
+                encrypted_metadata: %{},
                 subunit_to_unit: minted_token2.subunit_to_unit,
                 created_at: Date.to_iso8601(minted_token2.inserted_at),
                 updated_at: Date.to_iso8601(minted_token2.updated_at)
@@ -150,6 +164,7 @@ defmodule AdminAPI.V1.TransactionSerializerTest do
               rate: 1,
             },
             metadata: %{some: "metadata"},
+            encrypted_metadata: %{},
             status: transaction2.status,
             created_at: Date.to_iso8601(transaction2.inserted_at),
             updated_at: Date.to_iso8601(transaction2.updated_at)

--- a/apps/admin_api/test/admin_api/v1/serializers/user_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/user_serializer_test.exs
@@ -23,6 +23,7 @@ defmodule AdminAPI.V1.UserSerializerTest do
           "first_name" => user.metadata["first_name"],
           "last_name" => user.metadata["last_name"]
         },
+        encrypted_metadata: %{},
         created_at: Date.to_iso8601(user.inserted_at),
         updated_at: Date.to_iso8601(user.updated_at)
       }
@@ -63,6 +64,7 @@ defmodule AdminAPI.V1.UserSerializerTest do
               "first_name" => user1.metadata["first_name"],
               "last_name" => user1.metadata["last_name"]
             },
+            encrypted_metadata: %{},
             created_at: Date.to_iso8601(user1.inserted_at),
             updated_at: Date.to_iso8601(user1.updated_at)
           },
@@ -82,6 +84,7 @@ defmodule AdminAPI.V1.UserSerializerTest do
               "first_name" => user2.metadata["first_name"],
               "last_name" => user2.metadata["last_name"]
             },
+            encrypted_metadata: %{},
             created_at: Date.to_iso8601(user2.inserted_at),
             updated_at: Date.to_iso8601(user2.updated_at)
           }

--- a/apps/admin_api/test/admin_api/v1/views/account_membership_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/account_membership_view_test.exs
@@ -28,6 +28,7 @@ defmodule AdminAPI.V1.AccountMembershipViewTest do
                 "first_name" => membership1.user.metadata["first_name"],
                 "last_name" => membership1.user.metadata["last_name"]
               },
+              encrypted_metadata: %{},
               created_at: Date.to_iso8601(membership1.user.inserted_at),
               updated_at: Date.to_iso8601(membership1.user.updated_at)
             },
@@ -44,6 +45,7 @@ defmodule AdminAPI.V1.AccountMembershipViewTest do
                 "first_name" => membership2.user.metadata["first_name"],
                 "last_name" => membership2.user.metadata["last_name"]
               },
+              encrypted_metadata: %{},
               created_at: Date.to_iso8601(membership2.user.inserted_at),
               updated_at: Date.to_iso8601(membership2.user.updated_at)
             }

--- a/apps/admin_api/test/admin_api/v1/views/account_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/account_view_test.exs
@@ -23,6 +23,8 @@ defmodule AdminAPI.V1.AccountViewTest do
             small: nil,
             thumb: nil
           },
+          metadata: %{},
+          encrypted_metadata: %{},
           created_at: Date.to_iso8601(account.inserted_at),
           updated_at: Date.to_iso8601(account.updated_at)
         }
@@ -64,6 +66,8 @@ defmodule AdminAPI.V1.AccountViewTest do
                 small: nil,
                 thumb: nil
               },
+              metadata: %{},
+              encrypted_metadata: %{},
               created_at: Date.to_iso8601(account1.inserted_at),
               updated_at: Date.to_iso8601(account1.updated_at)
             },
@@ -80,6 +84,8 @@ defmodule AdminAPI.V1.AccountViewTest do
                 small: nil,
                 thumb: nil
               },
+              metadata: %{},
+              encrypted_metadata: %{},
               created_at: Date.to_iso8601(account2.inserted_at),
               updated_at: Date.to_iso8601(account2.updated_at)
             }

--- a/apps/admin_api/test/admin_api/v1/views/minted_token_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/minted_token_view_test.exs
@@ -15,6 +15,8 @@ defmodule AdminAPI.V1.MintedTokenViewTest do
           id: minted_token.friendly_id,
           symbol: minted_token.symbol,
           name: minted_token.name,
+          metadata: %{},
+          encrypted_metadata: %{},
           subunit_to_unit: minted_token.subunit_to_unit,
           created_at: Date.to_iso8601(minted_token.inserted_at),
           updated_at: Date.to_iso8601(minted_token.updated_at)
@@ -49,6 +51,8 @@ defmodule AdminAPI.V1.MintedTokenViewTest do
               id: minted_token1.friendly_id,
               symbol: minted_token1.symbol,
               name: minted_token1.name,
+              metadata: %{},
+              encrypted_metadata: %{},
               subunit_to_unit: minted_token1.subunit_to_unit,
               created_at: Date.to_iso8601(minted_token1.inserted_at),
               updated_at: Date.to_iso8601(minted_token1.updated_at)
@@ -58,6 +62,8 @@ defmodule AdminAPI.V1.MintedTokenViewTest do
               id: minted_token2.friendly_id,
               symbol: minted_token2.symbol,
               name: minted_token2.name,
+              metadata: %{},
+              encrypted_metadata: %{},
               subunit_to_unit: minted_token2.subunit_to_unit,
               created_at: Date.to_iso8601(minted_token2.inserted_at),
               updated_at: Date.to_iso8601(minted_token2.updated_at)

--- a/apps/admin_api/test/admin_api/v1/views/self_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/self_view_test.exs
@@ -29,6 +29,7 @@ defmodule AdminAPI.V1.SelfViewTest do
             "first_name" => user.metadata["first_name"],
             "last_name" => user.metadata["last_name"]
           },
+          encrypted_metadata: %{},
           created_at: Date.to_iso8601(user.inserted_at),
           updated_at: Date.to_iso8601(user.updated_at)
         }

--- a/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
@@ -24,6 +24,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
               id: minted_token.friendly_id,
               symbol: minted_token.symbol,
               name: minted_token.name,
+              metadata: %{},
+              encrypted_metadata: %{},
               subunit_to_unit: minted_token.subunit_to_unit,
               created_at: Date.to_iso8601(minted_token.inserted_at),
               updated_at: Date.to_iso8601(minted_token.updated_at)
@@ -38,6 +40,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
               id: minted_token.friendly_id,
               symbol: minted_token.symbol,
               name: minted_token.name,
+              metadata: %{},
+              encrypted_metadata: %{},
               subunit_to_unit: minted_token.subunit_to_unit,
               created_at: Date.to_iso8601(minted_token.inserted_at),
               updated_at: Date.to_iso8601(minted_token.updated_at)
@@ -48,6 +52,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
             rate: 1,
           },
           metadata: %{some: "metadata"},
+          encrypted_metadata: %{},
           status: transaction.status,
           created_at: Date.to_iso8601(transaction.inserted_at),
           updated_at: Date.to_iso8601(transaction.updated_at)
@@ -92,6 +97,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
                   id: minted_token1.friendly_id,
                   symbol: minted_token1.symbol,
                   name: minted_token1.name,
+                  metadata: %{},
+                  encrypted_metadata: %{},
                   subunit_to_unit: minted_token1.subunit_to_unit,
                   created_at: Date.to_iso8601(minted_token1.inserted_at),
                   updated_at: Date.to_iso8601(minted_token1.updated_at)
@@ -106,6 +113,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
                   id: minted_token1.friendly_id,
                   symbol: minted_token1.symbol,
                   name: minted_token1.name,
+                  metadata: %{},
+                  encrypted_metadata: %{},
                   subunit_to_unit: minted_token1.subunit_to_unit,
                   created_at: Date.to_iso8601(minted_token1.inserted_at),
                   updated_at: Date.to_iso8601(minted_token1.updated_at)
@@ -116,6 +125,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                 rate: 1,
               },
               metadata: %{some: "metadata"},
+              encrypted_metadata: %{},
               status: transaction1.status,
               created_at: Date.to_iso8601(transaction1.inserted_at),
               updated_at: Date.to_iso8601(transaction1.updated_at)
@@ -133,6 +143,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
                   id: minted_token2.friendly_id,
                   symbol: minted_token2.symbol,
                   name: minted_token2.name,
+                  metadata: %{},
+                  encrypted_metadata: %{},
                   subunit_to_unit: minted_token2.subunit_to_unit,
                   created_at: Date.to_iso8601(minted_token2.inserted_at),
                   updated_at: Date.to_iso8601(minted_token2.updated_at)
@@ -147,6 +159,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
                   id: minted_token2.friendly_id,
                   symbol: minted_token2.symbol,
                   name: minted_token2.name,
+                  metadata: %{},
+                  encrypted_metadata: %{},
                   subunit_to_unit: minted_token2.subunit_to_unit,
                   created_at: Date.to_iso8601(minted_token2.inserted_at),
                   updated_at: Date.to_iso8601(minted_token2.updated_at)
@@ -157,6 +171,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                 rate: 1,
               },
               metadata: %{some: "metadata"},
+              encrypted_metadata: %{},
               status: transaction2.status,
               created_at: Date.to_iso8601(transaction2.inserted_at),
               updated_at: Date.to_iso8601(transaction2.updated_at)

--- a/apps/admin_api/test/admin_api/v1/views/user_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/user_view_test.exs
@@ -29,6 +29,7 @@ defmodule AdminAPI.V1.UserViewTest do
             "first_name" => user.metadata["first_name"],
             "last_name" => user.metadata["last_name"]
           },
+          encrypted_metadata: %{},
           created_at: Date.to_iso8601(user.inserted_at),
           updated_at: Date.to_iso8601(user.updated_at)
         }
@@ -73,6 +74,7 @@ defmodule AdminAPI.V1.UserViewTest do
                 "first_name" => user1.metadata["first_name"],
                 "last_name" => user1.metadata["last_name"]
               },
+              encrypted_metadata: %{},
               created_at: Date.to_iso8601(user1.inserted_at),
               updated_at: Date.to_iso8601(user1.updated_at)
             },
@@ -92,6 +94,7 @@ defmodule AdminAPI.V1.UserViewTest do
                 "first_name" => user2.metadata["first_name"],
                 "last_name" => user2.metadata["last_name"]
               },
+              encrypted_metadata: %{},
               created_at: Date.to_iso8601(user2.inserted_at),
               updated_at: Date.to_iso8601(user2.updated_at)
             }

--- a/apps/ewallet/lib/ewallet/gates/mint_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/mint_gate.ex
@@ -19,7 +19,8 @@ defmodule EWallet.MintGate do
       "token_id" => minted_token_id,
       "amount" => 100_000,
       "description" => "Another mint bites the dust.",
-      "metadata" => %{probably: "something useful. Or not."}
+      "metadata" => %{probably: "something useful. Or not."},
+      "encrypted_metadata" => %{something: "secret."},
     })
 
     case res do
@@ -39,8 +40,7 @@ defmodule EWallet.MintGate do
     "idempotency_token" => idempotency_token,
     "token_id" => token_id,
     "amount" => amount,
-    "description" => description,
-    "metadata" => metadata
+    "description" => description
   } = attrs) do
     minted_token = MintedToken.get(token_id)
     account = Account.get_master_account()
@@ -54,7 +54,8 @@ defmodule EWallet.MintGate do
           to: Account.get_primary_balance(account).address,
           minted_token_id: minted_token.id,
           amount: amount,
-          metadata: metadata,
+          metadata: attrs["metadata"] || %{},
+          encrypted_metadata: attrs["encrypted_metadata"],
           payload: attrs
         })
       end)

--- a/apps/ewallet/lib/ewallet/gates/mint_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/mint_gate.ex
@@ -55,7 +55,7 @@ defmodule EWallet.MintGate do
           minted_token_id: minted_token.id,
           amount: amount,
           metadata: attrs["metadata"] || %{},
-          encrypted_metadata: attrs["encrypted_metadata"],
+          encrypted_metadata: attrs["encrypted_metadata"] || %{},
           payload: attrs
         })
       end)

--- a/apps/ewallet/lib/ewallet/gates/transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_gate.ex
@@ -20,6 +20,7 @@ defmodule EWallet.TransactionGate do
       "token_id" => "OMG:a5f64c8c-9f3b-4247-b01c-098a7e204142",
       "amount" => 100_000,
       "metadata" => %{some: "data"},
+      "encrypted_metadata" => %{some: "secret"},
       "idempotency_token" => idempotency_token
     })
 
@@ -36,7 +37,6 @@ defmodule EWallet.TransactionGate do
     "to_address" => _,
     "token_id" => _,
     "amount" => _,
-    "metadata" => _,
     "idempotency_token" => _
   } = attrs) do
     with {:ok, from, to, minted_token} <- AddressRecordFetcher.fetch(attrs),
@@ -63,6 +63,7 @@ defmodule EWallet.TransactionGate do
       "amount" => 100_000,
       "type" => Transaction.debit_type,
       "metadata" => %{some: "data"},
+      "encrypted_metadata" => %{some: "secret"},
       "idempotency_token" => idempotency_token
     })
 
@@ -78,7 +79,6 @@ defmodule EWallet.TransactionGate do
     "provider_user_id" => _,
     "token_id" => _,
     "amount" => _,
-    "metadata" => _,
     "idempotency_token" => _,
     "type" => type
   } = attrs) do
@@ -100,7 +100,6 @@ defmodule EWallet.TransactionGate do
 
   defp get_or_insert_transfer(from, to, minted_token, %{
     "amount" => amount,
-    "metadata" => metadata,
     "idempotency_token" => idempotency_token
   } = attrs) do
     TransferGate.get_or_insert(%{
@@ -109,7 +108,8 @@ defmodule EWallet.TransactionGate do
       to: to.address,
       minted_token_id: minted_token.id,
       amount: amount,
-      metadata: metadata,
+      metadata: attrs["metadata"] || %{},
+      encrypted_metadata: attrs["encrypted_metadata"] || %{},
       payload: attrs
     })
   end

--- a/apps/ewallet/lib/ewallet/gates/transfer_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transfer_gate.ex
@@ -18,6 +18,7 @@ defmodule EWallet.TransferGate do
       minted_token_id: "f7ef021b-95bf-45c8-990f-743ca99d742a",
       amount: 10,
       metadata: %{},
+      encrypted_metadata: %{},
       payload: %{}
     })
 
@@ -35,7 +36,6 @@ defmodule EWallet.TransferGate do
     to: _,
     minted_token_id: _,
     amount: _,
-    metadata: _,
     payload: _
   } = attrs) do
     attrs

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
@@ -10,13 +10,11 @@ defmodule EWalletAPI.V1.TransferController do
     "to_address" => to_address,
     "token_id" => token_id,
     "amount" => amount,
-    "metadata" => metadata
   } = attrs)
   when from_address != nil
   when to_address != nil
   and token_id != nil
   and is_integer(amount)
-  and metadata != nil
   do
     attrs
     |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
@@ -31,13 +29,11 @@ defmodule EWalletAPI.V1.TransferController do
   defp credit_or_debit(conn, type, %{
     "provider_user_id" => provider_user_id,
     "token_id" => token_id,
-    "amount" => amount,
-    "metadata" => metadata} = attrs
+    "amount" => amount} = attrs
   )
   when provider_user_id != nil
   and token_id != nil
   and is_integer(amount)
-  and metadata != nil
   do
     attrs
     |> Map.put("type", type)

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/user_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/user_controller.ex
@@ -27,8 +27,7 @@ defmodule EWalletAPI.V1.UserController do
   # missing param as not need to update.
   def update(conn, %{
     "provider_user_id" => id,
-    "username" => _,
-    "metadata" => %{}
+    "username" => _
   } = attrs) when is_binary(id) and byte_size(id) > 0  do
     id
     |> User.get_by_provider_user_id()

--- a/apps/ewallet_api/lib/ewallet_api/v1/serializers/json/minted_token_serializer.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/serializers/json/minted_token_serializer.ex
@@ -13,7 +13,9 @@ defmodule EWalletAPI.V1.JSON.MintedTokenSerializer do
       id: minted_token.friendly_id,
       symbol: minted_token.symbol,
       name: minted_token.name,
-      subunit_to_unit: minted_token.subunit_to_unit
+      subunit_to_unit: minted_token.subunit_to_unit,
+      metadata: minted_token.metadata,
+      encrypted_metadata: minted_token.encrypted_metadata
     }
   end
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/serializers/json/transaction_serializer.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/serializers/json/transaction_serializer.ex
@@ -33,6 +33,7 @@ defmodule EWalletAPI.V1.JSON.TransactionSerializer do
         rate: 1,
       },
       metadata: transaction.metadata,
+      encrypted_metadata: transaction.encrypted_metadata,
       status: transaction.status,
       created_at: Date.to_iso8601(transaction.inserted_at),
       updated_at: Date.to_iso8601(transaction.updated_at)

--- a/apps/ewallet_api/lib/ewallet_api/v1/serializers/json/user_serializer.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/serializers/json/user_serializer.ex
@@ -10,7 +10,8 @@ defmodule EWalletAPI.V1.JSON.UserSerializer do
       id: user.id,
       username: user.username,
       provider_user_id: user.provider_user_id,
-      metadata: user.metadata
+      metadata: user.metadata,
+      encrypted_metadata: user.encrypted_metadata
     }
   end
 end

--- a/apps/ewallet_api/priv/spec.yaml
+++ b/apps/ewallet_api/priv/spec.yaml
@@ -536,18 +536,20 @@ components:
           type: string
         metadata:
           type: object
+        encrypted_metadata:
+          type: object
       required:
         - object
         - id
         - username
         - provider_user_id
-        - metadata
       example:
         object: "user"
         id: "cec34607-0761-4a59-8357-18963e42a1aa"
         provider_user_id: "wijf-fbancomw-dqwjudb"
         username: "thibault@omise.co"
         metadata: {"first_name": "Thibault", "last_name": "Denizet"}
+        encrypted_metadata: {}
     UserResponseSchema:
       description: "The response schema for a user"
       allOf:
@@ -566,6 +568,7 @@ components:
             provider_user_id: "wijf-fbancomw-dqwjudb"
             username: "thibault@omise.co"
             metadata: {"first_name": "Thibault", "last_name": "Denizet"}
+            encrypted_metadata: {}
 
     ######################################
     #            BALANCE SCHEMAS         #
@@ -775,6 +778,10 @@ components:
           type: string
         subunit_to_unit:
           type: number
+        metadata:
+          type: object
+        encrypted_metadata:
+          type: object
       required:
         - object
         - symbol
@@ -786,6 +793,8 @@ components:
         symbol: "OMG"
         name: "Mint"
         subunit_to_unit: 100000000000000000
+        metadata: {}
+        encrypted_metadata: {}
 
     ######################################
     #         TRANSACTION SCHEMAS        #
@@ -832,6 +841,8 @@ components:
               type: number
         metadata:
           type: object
+        encrypted_metadata:
+          type: object
         status:
           type: string
           enum:
@@ -851,7 +862,6 @@ components:
         - from
         - to
         - exchange
-        - metadata
         - status
         - created_at
         - updated_at
@@ -897,6 +907,7 @@ components:
               object: "exchange"
               rate: 1
             metadata: {}
+            encrypted_metadata: {}
             status: "confirmed"
             created_at: "2018-01-01T00:00:00Z"
             updated_at: "2018-01-01T10:00:00Z"
@@ -954,6 +965,7 @@ components:
                   object: "exchange"
                   rate: 1
                 metadata: {}
+                encrypted_metadata: {}
                 status: "confirmed"
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"
@@ -1113,14 +1125,16 @@ components:
                 type: string
               metadata:
                 type: object
+              encrypted_metadata:
+                type: object
             required:
               - provider_user_id
               - username
-              - metadata
             example:
               provider_user_id: "wijf-fbancomw-dqwjudb"
               username: "thibault@omise.co"
               metadata: {"first_name": "Thibault", "last_name": "Denizet"}
+              encrypted_metadata: {}
     ProviderIdBody:
       description: The parameters to use for providing a provider user id
       required: true
@@ -1258,18 +1272,20 @@ components:
                 type: integer
               metadata:
                 type: object
+              encrypted_metadata:
+                type: object
             required:
               - from_address
               - to_address
               - token_id
               - amount
-              - metadata
             example:
               from_address: "81e75f46-ee14-4e4c-a1e5-cddcb26dce9c"
               to_address: "4aa07691-2f99-4cb1-b36c-50763e2d2ba8"
               token_id: "BTC:61822683-68d8-4af6-94d7-5ed4c34ecf1a"
               amount: 100
               metadata: {}
+              encrypted_metadata: {}
     BalanceAdjustmentBody:
       description: |
         The parameters for crediting or debiting the balance of the specified user
@@ -1295,11 +1311,12 @@ components:
                 type: string
               metadata:
                 type: object
+              encrypted_metadata:
+                type: object
             required:
               - provider_user_id
               - token_id
               - amount
-              - metadata
             example:
               provider_user_id: "wijf-fbancomw-dqwjudb"
               token_id: "BTC:61822683-68d8-4af6-94d7-5ed4c34ecf1a"
@@ -1307,6 +1324,7 @@ components:
               account_id: "865ff420-899a-4eb3-8364-19edc5d51676"
               burn_balance_identifier: "burn"
               metadata: {}
+              encrypted_metadata: {}
     CreateTransactionRequestBody:
       description: Create a transaction request using the specified values. That request can then be consumed using a different endpoint by a different client to create a transaction from that request.
       required: true
@@ -1366,6 +1384,8 @@ components:
                 type: string
               metadata:
                 type: object
+              encrypted_metadata:
+                type: object
             required:
               - transaction_request_id
             example:
@@ -1375,6 +1395,7 @@ components:
               amount: 100
               address: "2ae52683-68d8-4af6-94d7-5ed4c34ecf1a"
               metadata: {}
+              encrypted_metadata: {}
 
   ######################################
   #           REQUEST HEADERS          #

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/computed_balance_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/computed_balance_controller_test.exs
@@ -40,6 +40,8 @@ defmodule EWalletAPI.V1.ComputedBalanceControllerTest do
                     "subunit_to_unit" => btc.subunit_to_unit,
                     "symbol" => btc.symbol,
                     "id" => btc.friendly_id,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 },
                 %{
@@ -51,6 +53,8 @@ defmodule EWalletAPI.V1.ComputedBalanceControllerTest do
                     "subunit_to_unit" => omg.subunit_to_unit,
                     "symbol" => omg.symbol,
                     "id" => omg.friendly_id,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 }
               ]
@@ -96,7 +100,9 @@ defmodule EWalletAPI.V1.ComputedBalanceControllerTest do
                     "object" => "minted_token",
                     "subunit_to_unit" => btc.subunit_to_unit,
                     "symbol" => btc.symbol,
-                    "id" => btc.friendly_id
+                    "id" => btc.friendly_id,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 },
                 %{
@@ -107,7 +113,9 @@ defmodule EWalletAPI.V1.ComputedBalanceControllerTest do
                     "object" => "minted_token",
                     "subunit_to_unit" => omg.subunit_to_unit,
                     "symbol" => omg.symbol,
-                    "id" => omg.friendly_id
+                    "id" => omg.friendly_id,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 }
               ]

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
@@ -56,7 +56,9 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                     "object" => "minted_token",
                     "subunit_to_unit" => btc.subunit_to_unit,
                     "symbol" => btc.symbol,
-                    "id" => btc.friendly_id
+                    "id" => btc.friendly_id,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 },
                 %{
@@ -67,7 +69,9 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                     "object" => "minted_token",
                     "subunit_to_unit" => omg.subunit_to_unit,
                     "symbol" => omg.symbol,
-                    "id" => omg.friendly_id
+                    "id" => omg.friendly_id,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 }
               ]

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
@@ -118,6 +118,8 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
   describe "/user.list_transactions" do
     test "returns all the transactions for a specific provider_user_id", meta do
       response = provider_request("/user.list_transactions", %{
+        "sort_by" => "created_at",
+        "sort_dir" => "asc",
         "provider_user_id" => meta.user.provider_user_id
       })
       assert response["data"]["data"] |> length() == 4

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule EWalletAPI.V1.TransactionControllerTest do
-  use EWalletAPI.ConnCase, async: true
+  use EWalletAPI.ConnCase, async: false
   alias EWalletDB.User
 
   setup do

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_consumption_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_consumption_controller_test.exs
@@ -56,7 +56,9 @@ defmodule EWalletAPI.V1.TransactionRequestConsumptionControllerTest do
             "name" => minted_token.name,
             "object" => "minted_token",
             "subunit_to_unit" => minted_token.subunit_to_unit,
-            "symbol" => minted_token.symbol
+            "symbol" => minted_token.symbol,
+            "metadata" => %{},
+            "encrypted_metadata" => %{}
           },
           "transaction_request_id" => transaction_request.id,
           "transaction_id" => inserted_transfer.id,
@@ -203,7 +205,9 @@ defmodule EWalletAPI.V1.TransactionRequestConsumptionControllerTest do
             "name" => minted_token.name,
             "object" => "minted_token",
             "subunit_to_unit" => minted_token.subunit_to_unit,
-            "symbol" => minted_token.symbol
+            "symbol" => minted_token.symbol,
+            "metadata" => %{},
+            "encrypted_metadata" => %{}
           },
           "transaction_request_id" => transaction_request.id,
           "transaction_id" => inserted_transfer.id,

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -33,7 +33,9 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
             "name" => minted_token.name,
             "object" => "minted_token",
             "subunit_to_unit" => minted_token.subunit_to_unit,
-            "symbol" => minted_token.symbol
+            "symbol" => minted_token.symbol,
+            "metadata" => %{},
+            "encrypted_metadata" => %{}
           },
           "type" => "send",
           "status" => "valid",
@@ -74,7 +76,9 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
             "name" => minted_token.name,
             "object" => "minted_token",
             "subunit_to_unit" => minted_token.subunit_to_unit,
-            "symbol" => minted_token.symbol
+            "symbol" => minted_token.symbol,
+            "metadata" => %{},
+            "encrypted_metadata" => %{}
           },
           "type" => "send",
           "status" => "valid",
@@ -214,7 +218,9 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
             "name" => minted_token.name,
             "object" => "minted_token",
             "subunit_to_unit" => minted_token.subunit_to_unit,
-            "symbol" => minted_token.symbol
+            "symbol" => minted_token.symbol,
+            "metadata" => %{},
+            "encrypted_metadata" => %{}
           },
           "type" => "send",
           "status" => "valid",
@@ -255,7 +261,9 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
             "name" => minted_token.name,
             "object" => "minted_token",
             "subunit_to_unit" => minted_token.subunit_to_unit,
-            "symbol" => minted_token.symbol
+            "symbol" => minted_token.symbol,
+            "metadata" => %{},
+            "encrypted_metadata" => %{}
           },
           "type" => "send",
           "status" => "valid",

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule EWalletAPI.V1.TransferControllerTest do
   use EWalletAPI.ConnCase, async: true
-  alias EWalletDB.{User, MintedToken, Account}
+  alias EWalletDB.{User, MintedToken, Account, Transfer}
   alias Ecto.UUID
 
   describe "/transfer" do
@@ -48,8 +48,13 @@ defmodule EWalletAPI.V1.TransferControllerTest do
         to_address: balance2.address,
         token_id: minted_token.friendly_id,
         amount: 100_000 * minted_token.subunit_to_unit,
-        metadata: %{}
+        metadata: %{something: "interesting"},
+        encrypted_metadata: %{something: "secret"}
       })
+
+      transfer = get_last_inserted(Transfer)
+      assert transfer.metadata == %{"something" => "interesting"}
+      assert transfer.encrypted_metadata == %{"something" => "secret"}
 
       assert response == %{
         "success" => true,
@@ -236,8 +241,13 @@ defmodule EWalletAPI.V1.TransferControllerTest do
         provider_user_id: user.provider_user_id,
         token_id: minted_token.friendly_id,
         amount: 1_000 * minted_token.subunit_to_unit,
-        metadata: %{}
+        metadata: %{something: "interesting"},
+        encrypted_metadata: %{something: "secret"}
       })
+
+      transfer = get_last_inserted(Transfer)
+      assert transfer.metadata == %{"something" => "interesting"}
+      assert transfer.encrypted_metadata == %{"something" => "secret"}
 
       assert response == %{
         "success" => true,
@@ -429,8 +439,14 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       response = provider_request_with_idempotency("/user.debit_balance", UUID.generate(), %{
         provider_user_id: user.provider_user_id,
         token_id: minted_token.friendly_id,
-        amount: 150_000 * minted_token.subunit_to_unit
+        amount: 150_000 * minted_token.subunit_to_unit,
+        metadata: %{something: "interesting"},
+        encrypted_metadata: %{something: "secret"}
       })
+
+      transfer = get_last_inserted(Transfer)
+      assert transfer.metadata == %{"something" => "interesting"}
+      assert transfer.encrypted_metadata == %{"something" => "secret"}
 
       assert response == %{
         "version" => "1",

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -69,7 +69,9 @@ defmodule EWalletAPI.V1.TransferControllerTest do
                     "object" => "minted_token",
                     "subunit_to_unit" => 100,
                     "id" => minted_token.friendly_id,
-                    "symbol" => minted_token.symbol
+                    "symbol" => minted_token.symbol,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 }
               ]
@@ -86,7 +88,9 @@ defmodule EWalletAPI.V1.TransferControllerTest do
                     "name" => minted_token.name,
                     "object" => "minted_token",
                     "subunit_to_unit" => 100,
-                    "symbol" => minted_token.symbol
+                    "symbol" => minted_token.symbol,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   },
                 }
               ]
@@ -253,7 +257,9 @@ defmodule EWalletAPI.V1.TransferControllerTest do
                     "object" => "minted_token",
                     "subunit_to_unit" => 100,
                     "id" => minted_token.friendly_id,
-                    "symbol" => minted_token.symbol
+                    "symbol" => minted_token.symbol,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 }
               ]
@@ -423,8 +429,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       response = provider_request_with_idempotency("/user.debit_balance", UUID.generate(), %{
         provider_user_id: user.provider_user_id,
         token_id: minted_token.friendly_id,
-        amount: 150_000 * minted_token.subunit_to_unit,
-        metadata: %{}
+        amount: 150_000 * minted_token.subunit_to_unit
       })
 
       assert response == %{
@@ -446,6 +451,8 @@ defmodule EWalletAPI.V1.TransferControllerTest do
                     "subunit_to_unit" => 100,
                     "symbol" => minted_token.symbol,
                     "id" => minted_token.friendly_id,
+                    "metadata" => %{},
+                    "encrypted_metadata" => %{}
                   }
                 }
               ]

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/user_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/user_controller_test.exs
@@ -115,24 +115,6 @@ defmodule EWalletAPI.V1.UserControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
       assert response["data"]["description"] == "Invalid parameter provided"
     end
-
-    test "returns an error if metadata is not provided" do
-      user = insert(:user)
-
-      # ExMachine will remove the param if set to nil.
-      request_data = params_for(:user, %{
-        provider_user_id: user.provider_user_id,
-        metadata: nil
-      })
-
-      response = provider_request("/user.update", request_data)
-
-      assert response["version"] == @expected_version
-      assert response["success"] == false
-      assert response["data"]["object"] == "error"
-      assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
-    end
   end
 
   describe "/user.get" do
@@ -152,7 +134,8 @@ defmodule EWalletAPI.V1.UserControllerTest do
           "metadata" => %{
             "first_name" => inserted_user.metadata["first_name"],
             "last_name" => inserted_user.metadata["last_name"]
-          }
+          },
+          "encrypted_metadata" => %{}
         }
       }
 

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/user_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/user_controller_test.exs
@@ -132,25 +132,7 @@ defmodule EWalletAPI.V1.UserControllerTest do
       assert response["data"]["encrypted_metadata"] == %{}
     end
 
-    test "" do
-      user = insert(:user, %{
-        metadata: %{first_name: "updated_first_name"},
-        encrypted_metadata: %{my_secret_stuff: "123"}
-      })
-
-      response = provider_request("/user.update", %{
-        provider_user_id: user.provider_user_id,
-        username: "new_username",
-        metadata: %{},
-        encrypted_metadata: %{}
-      })
-
-      assert response["success"] == true
-      assert response["data"]["metadata"] == %{}
-      assert response["data"]["encrypted_metadata"] == %{}
-    end
-
-    test "does not change the metadata/encrypted_metadata if nil is sent" do
+    test "returns an 'invalid parameter' error when sending nil for metadata/encrypted_metadata" do
       user = insert(:user, %{
         metadata: %{first_name: "updated_first_name"},
         encrypted_metadata: %{my_secret_stuff: "123"}

--- a/apps/ewallet_api/test/ewallet_api/v1/serializers/json/minted_token_serializer_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/serializers/json/minted_token_serializer_test.exs
@@ -11,7 +11,9 @@ defmodule EWalletAPI.V1.MintedTokenSerializerTest do
         id: minted_token.friendly_id,
         symbol: minted_token.symbol,
         name: minted_token.name,
-        subunit_to_unit: minted_token.subunit_to_unit
+        subunit_to_unit: minted_token.subunit_to_unit,
+        metadata: minted_token.metadata,
+        encrypted_metadata: minted_token.encrypted_metadata
       }
 
       assert MintedTokenSerializer.serialize(minted_token) == expected
@@ -30,14 +32,18 @@ defmodule EWalletAPI.V1.MintedTokenSerializerTest do
           id: token1.friendly_id,
           symbol: token1.symbol,
           name: token1.name,
-          subunit_to_unit: token1.subunit_to_unit
+          subunit_to_unit: token1.subunit_to_unit,
+          metadata: token1.metadata,
+          encrypted_metadata: token1.encrypted_metadata
         },
         %{
           object: "minted_token",
           id: token2.friendly_id,
           symbol: token2.symbol,
           name: token2.name,
-          subunit_to_unit: token2.subunit_to_unit
+          subunit_to_unit: token2.subunit_to_unit,
+          metadata: token2.metadata,
+          encrypted_metadata: token2.encrypted_metadata
         }
       ]
 

--- a/apps/ewallet_api/test/ewallet_api/v1/serializers/json/transaction_request_consumption_serializer_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/serializers/json/transaction_request_consumption_serializer_test.exs
@@ -19,7 +19,9 @@ defmodule EWalletAPI.V1.TransactionRequestConsumptionSerializerTest do
           id: consumption.minted_token.friendly_id,
           name: consumption.minted_token.name,
           subunit_to_unit: consumption.minted_token.subunit_to_unit,
-          symbol: consumption.minted_token.symbol
+          symbol: consumption.minted_token.symbol,
+          metadata: consumption.minted_token.metadata,
+          encrypted_metadata: consumption.minted_token.encrypted_metadata
         },
         correlation_id: consumption.correlation_id,
         idempotency_token: consumption.idempotency_token,

--- a/apps/ewallet_api/test/ewallet_api/v1/serializers/json/transaction_request_serializer_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/serializers/json/transaction_request_serializer_test.exs
@@ -18,7 +18,9 @@ defmodule EWalletAPI.V1.TransactionRequestSerializerTest do
           id: transaction_request.minted_token.friendly_id,
           name: transaction_request.minted_token.name,
           subunit_to_unit: transaction_request.minted_token.subunit_to_unit,
-          symbol: transaction_request.minted_token.symbol
+          symbol: transaction_request.minted_token.symbol,
+          metadata: transaction_request.minted_token.metadata,
+          encrypted_metadata: transaction_request.minted_token.encrypted_metadata
         },
         amount: transaction_request.amount,
         user_id: transaction_request.user_id,

--- a/apps/ewallet_api/test/ewallet_api/v1/serializers/json/transaction_serializer_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/serializers/json/transaction_serializer_test.exs
@@ -21,7 +21,9 @@ defmodule EWalletAPI.V1.JSON.TransactionSerializerTest do
             id: transaction.minted_token.friendly_id,
             symbol: transaction.minted_token.symbol,
             name: transaction.minted_token.name,
-            subunit_to_unit: transaction.minted_token.subunit_to_unit
+            subunit_to_unit: transaction.minted_token.subunit_to_unit,
+            metadata: transaction.minted_token.metadata,
+            encrypted_metadata: transaction.minted_token.encrypted_metadata
           },
         },
         to: %{
@@ -33,7 +35,9 @@ defmodule EWalletAPI.V1.JSON.TransactionSerializerTest do
             id: transaction.minted_token.friendly_id,
             symbol: transaction.minted_token.symbol,
             name: transaction.minted_token.name,
-            subunit_to_unit: transaction.minted_token.subunit_to_unit
+            subunit_to_unit: transaction.minted_token.subunit_to_unit,
+            metadata: transaction.minted_token.metadata,
+            encrypted_metadata: transaction.minted_token.encrypted_metadata
           },
         },
         exchange: %{
@@ -41,6 +45,7 @@ defmodule EWalletAPI.V1.JSON.TransactionSerializerTest do
           rate: 1,
         },
         metadata: %{some: "metadata"},
+        encrypted_metadata: %{},
         status: transaction.status,
         created_at: Date.to_iso8601(transaction.inserted_at),
         updated_at: Date.to_iso8601(transaction.updated_at)

--- a/apps/ewallet_api/test/ewallet_api/v1/serializers/json/user_serializer_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/serializers/json/user_serializer_test.exs
@@ -12,7 +12,8 @@ defmodule EWalletAPI.V1.UserSerializerTest do
         metadata: %{
           first_name: "John",
           last_name: "Doe"
-        }
+        },
+        encrypted_metadata: %{}
       }
 
       expected = %{
@@ -23,7 +24,8 @@ defmodule EWalletAPI.V1.UserSerializerTest do
         metadata: %{
           first_name: "John",
           last_name: "Doe"
-        }
+        },
+        encrypted_metadata: %{}
       }
 
       assert UserSerializer.serialize(user) == expected

--- a/apps/ewallet_api/test/ewallet_api/v1/views/self_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/self_view_test.exs
@@ -17,7 +17,8 @@ defmodule EWalletAPI.V1.SelfViewTest do
           metadata: %{
             "first_name" => user.metadata["first_name"],
             "last_name" => user.metadata["last_name"]
-          }
+          },
+          encrypted_metadata: %{}
         }
       }
 
@@ -39,14 +40,18 @@ defmodule EWalletAPI.V1.SelfViewTest do
               id: token1.friendly_id,
               symbol: token1.symbol,
               name: token1.name,
-              subunit_to_unit: token1.subunit_to_unit
+              subunit_to_unit: token1.subunit_to_unit,
+              metadata: %{},
+              encrypted_metadata: %{}
             },
             %{
               object: "minted_token",
               id: token2.friendly_id,
               symbol: token2.symbol,
               name: token2.name,
-              subunit_to_unit: token2.subunit_to_unit
+              subunit_to_unit: token2.subunit_to_unit,
+              metadata: %{},
+              encrypted_metadata: %{}
             }]
         }
       }

--- a/apps/ewallet_api/test/ewallet_api/v1/views/settings_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/settings_view_test.exs
@@ -19,14 +19,18 @@ defmodule EWalletAPI.V1.SettingsViewTest do
               id: token1.friendly_id,
               symbol: token1.symbol,
               name: token1.name,
-              subunit_to_unit: token1.subunit_to_unit
+              subunit_to_unit: token1.subunit_to_unit,
+              metadata: %{},
+              encrypted_metadata: %{}
             },
             %{
               object: "minted_token",
               id: token2.friendly_id,
               symbol: token2.symbol,
               name: token2.name,
-              subunit_to_unit: token2.subunit_to_unit
+              subunit_to_unit: token2.subunit_to_unit,
+              metadata: %{},
+              encrypted_metadata: %{}
             }]
         }
       }

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_consumption_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_consumption_view_test.exs
@@ -22,7 +22,9 @@ defmodule EWalletAPI.V1.TransactionRequestConsumptionViewTest do
             id: consumption.minted_token.friendly_id,
             name: consumption.minted_token.name,
             subunit_to_unit: consumption.minted_token.subunit_to_unit,
-            symbol: consumption.minted_token.symbol
+            symbol: consumption.minted_token.symbol,
+            metadata: %{},
+            encrypted_metadata: %{}
           },
           correlation_id: consumption.correlation_id,
           idempotency_token: consumption.idempotency_token,

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_view_test.exs
@@ -21,7 +21,9 @@ defmodule EWalletAPI.V1.TransactionRequestViewTest do
             id: transaction_request.minted_token.friendly_id,
             name: transaction_request.minted_token.name,
             subunit_to_unit: transaction_request.minted_token.subunit_to_unit,
-            symbol: transaction_request.minted_token.symbol
+            symbol: transaction_request.minted_token.symbol,
+            metadata: %{},
+            encrypted_metadata: %{}
           },
           amount: transaction_request.amount,
           address: transaction_request.balance_address,

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
@@ -24,7 +24,9 @@ defmodule EWalletAPI.V1.TransactionViewTest do
               id: transaction.minted_token.friendly_id,
               symbol: transaction.minted_token.symbol,
               name: transaction.minted_token.name,
-              subunit_to_unit: transaction.minted_token.subunit_to_unit
+              subunit_to_unit: transaction.minted_token.subunit_to_unit,
+              metadata: %{},
+              encrypted_metadata: %{}
             }
           },
           to: %{
@@ -36,7 +38,9 @@ defmodule EWalletAPI.V1.TransactionViewTest do
               id: transaction.minted_token.friendly_id,
               symbol: transaction.minted_token.symbol,
               name: transaction.minted_token.name,
-              subunit_to_unit: transaction.minted_token.subunit_to_unit
+              subunit_to_unit: transaction.minted_token.subunit_to_unit,
+              metadata: %{},
+              encrypted_metadata: %{}
             }
           },
           exchange: %{
@@ -44,6 +48,7 @@ defmodule EWalletAPI.V1.TransactionViewTest do
             rate: 1,
           },
           metadata: %{some: "metadata"},
+          encrypted_metadata: %{},
           status: transaction.status,
           created_at: Date.to_iso8601(transaction.inserted_at),
           updated_at: Date.to_iso8601(transaction.updated_at)

--- a/apps/ewallet_api/test/ewallet_api/v1/views/user_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/user_view_test.exs
@@ -27,7 +27,8 @@ defmodule EWalletAPI.V1.UserViewTest do
           metadata: %{
             first_name: user.metadata.first_name,
             last_name: user.metadata.last_name
-          }
+          },
+          encrypted_metadata: %{}
         }
       }
 

--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -16,7 +16,8 @@ defmodule EWalletDB.Account do
     field :description, :string
     field :relative_depth, :integer, virtual: true
     field :avatar, EWalletDB.Uploaders.Avatar.Type
-
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
     belongs_to :parent, Account, foreign_key: :parent_id, # this column
                                  references: :id, # the parent's column
                                  type: UUID
@@ -31,7 +32,7 @@ defmodule EWalletDB.Account do
 
   defp changeset(%Account{} = account, attrs) do
     account
-    |> cast(attrs, [:name, :description, :parent_id])
+    |> cast(attrs, [:name, :description, :parent_id, :metadata, :encrypted_metadata])
     |> validate_required(:name)
     |> validate_parent_id()
     |> unique_constraint(:name)

--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -33,7 +33,7 @@ defmodule EWalletDB.Account do
   defp changeset(%Account{} = account, attrs) do
     account
     |> cast(attrs, [:name, :description, :parent_id, :metadata, :encrypted_metadata])
-    |> validate_required(:name)
+    |> validate_required([:name, :metadata, :encrypted_metadata])
     |> validate_parent_id()
     |> unique_constraint(:name)
     |> assoc_constraint(:parent)

--- a/apps/ewallet_db/lib/ewallet_db/balance.ex
+++ b/apps/ewallet_db/lib/ewallet_db/balance.ex
@@ -33,7 +33,8 @@ defmodule EWalletDB.Balance do
     belongs_to :account, Account, foreign_key: :account_id,
                                   references: :id,
                                   type: UUID
-    field :metadata, Cloak.EncryptedMapField
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
     field :encryption_version, :binary
     timestamps()
   end
@@ -41,7 +42,8 @@ defmodule EWalletDB.Balance do
   defp changeset(%Balance{} = balance, attrs) do
     balance
     |> cast(attrs, [
-      :address, :account_id, :minted_token_id, :user_id, :metadata, :name, :identifier
+      :address, :account_id, :minted_token_id, :user_id, :metadata,
+      :encrypted_metadata, :name, :identifier
     ])
     |> validate_required([:address, :name, :identifier])
     |> validate_format(:identifier, ~r/#{@genesis}|#{@burn}|#{@primary}|#{@secondary}:.*/)

--- a/apps/ewallet_db/lib/ewallet_db/balance.ex
+++ b/apps/ewallet_db/lib/ewallet_db/balance.ex
@@ -46,7 +46,7 @@ defmodule EWalletDB.Balance do
       :address, :account_id, :minted_token_id, :user_id, :metadata,
       :encrypted_metadata, :name, :identifier
     ])
-    |> validate_required([:address, :name, :identifier])
+    |> validate_required([:address, :name, :identifier, :metadata, :encrypted_metadata])
     |> validate_format(:identifier, ~r/#{@genesis}|#{@burn}|#{@primary}|#{@secondary}:.*/)
     |> validate_required_exclusive(%{account_id: nil, user_id: nil, identifier: @genesis})
     |> unique_constraint(:address)

--- a/apps/ewallet_db/lib/ewallet_db/balance.ex
+++ b/apps/ewallet_db/lib/ewallet_db/balance.ex
@@ -24,6 +24,10 @@ defmodule EWalletDB.Balance do
     field :address, :string
     field :name, :string
     field :identifier, :string
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
+    field :encryption_version, :binary
+
     belongs_to :user, User, foreign_key: :user_id,
                             references: :id,
                             type: UUID
@@ -33,9 +37,6 @@ defmodule EWalletDB.Balance do
     belongs_to :account, Account, foreign_key: :account_id,
                                   references: :id,
                                   type: UUID
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
-    field :encryption_version, :binary
     timestamps()
   end
 

--- a/apps/ewallet_db/lib/ewallet_db/minted_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/minted_token.ex
@@ -23,7 +23,8 @@ defmodule EWalletDB.MintedToken do
     field :iso_numeric, :string # "978"
     field :smallest_denomination, :integer # 1
     field :locked, :boolean # false
-    field :metadata, Cloak.EncryptedMapField
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
     field :encryption_version, :binary
     belongs_to :account, Account, foreign_key: :account_id,
                                            references: :id,
@@ -37,7 +38,7 @@ defmodule EWalletDB.MintedToken do
       :symbol, :iso_code, :name, :description, :short_symbol,
       :subunit, :subunit_to_unit, :symbol_first, :html_entity,
       :iso_numeric, :smallest_denomination, :locked, :account_id,
-      :metadata, :friendly_id
+      :metadata, :encrypted_metadata, :friendly_id
     ])
     |> validate_required([
       :symbol, :name, :subunit_to_unit, :account_id

--- a/apps/ewallet_db/lib/ewallet_db/minted_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/minted_token.ex
@@ -41,7 +41,8 @@ defmodule EWalletDB.MintedToken do
       :metadata, :encrypted_metadata, :friendly_id
     ])
     |> validate_required([
-      :symbol, :name, :subunit_to_unit, :account_id
+      :symbol, :name, :subunit_to_unit, :account_id,
+      :metadata, :encrypted_metadata
     ])
     |> set_friendly_id()
     |> validate_required([:friendly_id])

--- a/apps/ewallet_db/lib/ewallet_db/transfer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transfer.ex
@@ -54,7 +54,7 @@ defmodule EWalletDB.Transfer do
     ])
     |> validate_required([
       :idempotency_token, :status, :type, :payload, :amount,
-      :minted_token_id, :to, :from
+      :minted_token_id, :to, :from, :metadata, :encrypted_metadata
     ])
     |> validate_inclusion(:status, @statuses)
     |> validate_inclusion(:type, @types)

--- a/apps/ewallet_db/lib/ewallet_db/transfer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transfer.ex
@@ -31,7 +31,8 @@ defmodule EWalletDB.Transfer do
     field :type, :string, default: @internal # internal / external
     field :payload, Cloak.EncryptedMapField # Payload received from client
     field :ledger_response, Cloak.EncryptedMapField # Response returned by ledger
-    field :metadata, Cloak.EncryptedMapField
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
     field :encryption_version, :binary
     belongs_to :minted_token, MintedToken, foreign_key: :minted_token_id,
                                            references: :id,
@@ -49,7 +50,7 @@ defmodule EWalletDB.Transfer do
     transfer
     |> cast(attrs, [
       :idempotency_token, :status, :type, :payload, :ledger_response, :metadata,
-      :amount, :minted_token_id, :to, :from
+      :encrypted_metadata, :amount, :minted_token_id, :to, :from
     ])
     |> validate_required([
       :idempotency_token, :status, :type, :payload, :amount,

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -19,7 +19,8 @@ defmodule EWalletDB.User do
     field :password_confirmation, :string, virtual: true
     field :password_hash, :string
     field :provider_user_id, :string
-    field :metadata, Cloak.EncryptedMapField
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
     field :encryption_version, :binary
     field :avatar, EWalletDB.Uploaders.Avatar.Type
 
@@ -36,8 +37,8 @@ defmodule EWalletDB.User do
   defp changeset(changeset, attrs) do
     changeset
     |> cast(attrs, [:username, :provider_user_id, :email, :password,
-                    :password_confirmation, :metadata, :invite_id])
-    |> validate_required([:metadata])
+                    :password_confirmation, :metadata, :encrypted_metadata,
+                    :invite_id])
     |> validate_confirmation(:password, message: "does not match password!")
     |> validate_immutable(:provider_user_id)
     |> unique_constraint(:username)
@@ -156,8 +157,7 @@ defmodule EWalletDB.User do
     %{
       user_id: user.id,
       name: identifier,
-      identifier: identifier,
-      metadata: %{}
+      identifier: identifier
     }
     |> Balance.insert()
   end

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -39,6 +39,7 @@ defmodule EWalletDB.User do
     |> cast(attrs, [:username, :provider_user_id, :email, :password,
                     :password_confirmation, :metadata, :encrypted_metadata,
                     :invite_id])
+    |> validate_required([:metadata, :encrypted_metadata])
     |> validate_confirmation(:password, message: "does not match password!")
     |> validate_immutable(:provider_user_id)
     |> unique_constraint(:username)

--- a/apps/ewallet_db/priv/repo/migrations/20180307044742_add_encrypted_metadata.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180307044742_add_encrypted_metadata.exs
@@ -18,11 +18,16 @@ defmodule EWalletDB.Repo.Migrations.AddEncryptedMetadata do
         remove :metadata
         add :metadata, :map, null: false, default: "{}"
       end
+
+      create index(table_name, [:metadata], using: "gin")
     end)
   end
 
   def down do
     Enum.each(@tables, fn table_name ->
+      name = Atom.to_string(table_name)
+      drop index(table_name, [:metadata])
+
       alter table(table_name) do
         remove :metadata
         add :metadata, :binary

--- a/apps/ewallet_db/priv/repo/migrations/20180307044742_add_encrypted_metadata.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180307044742_add_encrypted_metadata.exs
@@ -1,0 +1,65 @@
+defmodule EWalletDB.Repo.Migrations.AddEncryptedMetadata do
+  use Ecto.Migration
+  import Ecto.Query
+  alias EWalletDB.Repo
+
+  @tables [:balance, :minted_token, :transfer, :user]
+
+  def up do
+    Enum.each(@tables, fn table_name ->
+      alter table(table_name) do
+        add :encrypted_metadata, :binary
+      end
+
+      flush()
+      table_name |> Atom.to_string() |> migrate_to_encrypted_metadata()
+
+      alter table(table_name) do
+        remove :metadata
+        add :metadata, :map, null: false, default: "{}"
+      end
+    end)
+  end
+
+  def down do
+    Enum.each(@tables, fn table_name ->
+      alter table(table_name) do
+        remove :metadata
+        add :metadata, :binary
+      end
+
+      flush()
+      table_name |> Atom.to_string() |> migrate_to_metadata()
+
+      alter table(table_name) do
+        remove :encrypted_metadata
+      end
+    end)
+  end
+
+  defp migrate_to_encrypted_metadata(table_name) do
+    query = from(b in table_name,
+                 select: [b.id, b.metadata],
+                 lock: "FOR UPDATE")
+
+    for [id, metadata] <- Repo.all(query) do
+      query = from(b in table_name,
+                  where: b.id == ^id,
+                  update: [set: [encrypted_metadata: ^metadata]])
+      Repo.update_all(query, [])
+    end
+  end
+
+  defp migrate_to_metadata(table_name) do
+    query = from(b in table_name,
+                 select: [b.id, b.encrypted_metadata],
+                 lock: "FOR UPDATE")
+
+    for [id, encrypted_metadata] <- Repo.all(query) do
+      query = from(b in table_name,
+                  where: b.id == ^id,
+                  update: [set: [metadata: ^encrypted_metadata]])
+      Repo.update_all(query, [])
+    end
+  end
+end

--- a/apps/ewallet_db/priv/repo/migrations/20180307065600_add_metadata_to_account.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180307065600_add_metadata_to_account.exs
@@ -1,0 +1,14 @@
+defmodule EWalletDB.Repo.Migrations.AddMetadataToAccount do
+  use Ecto.Migration
+
+  def change do
+    alter table(:account) do
+      add :metadata, :map
+      add :encrypted_metadata, :binary
+      add :encryption_version, :binary
+    end
+
+    create index(:account, [:metadata], using: "gin")
+    create index(:account, [:encryption_version])
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/account_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/account_test.exs
@@ -5,6 +5,7 @@ defmodule EWalletDB.AccountTest do
 
   describe "Account factory" do
     test_has_valid_factory Account
+    test_encrypted_map_field Account, "account", :encrypted_metadata
   end
 
   describe "Account.insert/1" do
@@ -12,6 +13,7 @@ defmodule EWalletDB.AccountTest do
     test_insert_generate_timestamps Account
     test_insert_prevent_blank Account, :name
     test_insert_prevent_duplicate Account, :name
+    test_default_metadata_fields Account, "account"
 
     test "inserts a non-master account by default" do
       {:ok, account} = :account |> params_for() |> Account.insert

--- a/apps/ewallet_db/test/ewallet_db/balance_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/balance_test.exs
@@ -4,7 +4,7 @@ defmodule EWalletDB.BalanceTest do
 
   describe "Balance factory" do
     test_has_valid_factory Balance
-    test_encrypted_map_field Balance, "balance", :metadata
+    test_encrypted_map_field Balance, "balance", :encrypted_metadata
   end
 
   describe "Balance.insert/1" do
@@ -17,6 +17,7 @@ defmodule EWalletDB.BalanceTest do
     test_insert_prevent_blank Balance, :address
     test_insert_prevent_all_blank Balance, [:account, :user]
     test_insert_prevent_duplicate Balance, :address
+    test_default_metadata_fields Balance, "balance"
 
     test "allows insert if provided a user without account_id" do
       {res, _balance} =

--- a/apps/ewallet_db/test/ewallet_db/minted_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/minted_token_test.exs
@@ -4,7 +4,7 @@ defmodule EWalletDB.MintedTokenTest do
 
   describe "MintedToken factory" do
     test_has_valid_factory MintedToken
-    test_encrypted_map_field MintedToken, "minted_token", :metadata
+    test_encrypted_map_field MintedToken, "minted_token", :encrypted_metadata
   end
 
   describe "insert/1" do
@@ -16,6 +16,7 @@ defmodule EWalletDB.MintedTokenTest do
     test_insert_prevent_duplicate MintedToken, :symbol
     test_insert_prevent_duplicate MintedToken, :iso_code
     test_insert_prevent_duplicate MintedToken, :name
+    test_default_metadata_fields MintedToken, "minted_token"
 
     test "generates a friendly_id" do
       {:ok, minted_token} =

--- a/apps/ewallet_db/test/ewallet_db/transfer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transfer_test.exs
@@ -4,7 +4,7 @@ defmodule EWalletDB.TransferTest do
 
   describe "Transfer factory" do
     test_has_valid_factory Transfer
-    test_encrypted_map_field Transfer, "transfer", :metadata
+    test_encrypted_map_field Transfer, "transfer", :encrypted_metadata
     test_encrypted_map_field Transfer, "transfer", :payload
     test_encrypted_map_field Transfer, "transfer", :ledger_response
   end
@@ -40,6 +40,7 @@ defmodule EWalletDB.TransferTest do
     test_insert_generate_timestamps Transfer
     test_insert_prevent_blank Transfer, :payload
     test_insert_prevent_blank Transfer, :idempotency_token
+    test_default_metadata_fields Transfer, "transfer"
 
     test "inserts a transfer if it does not existing" do
       assert Repo.all(Transfer) == []

--- a/apps/ewallet_db/test/ewallet_db/user_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/user_test.exs
@@ -4,7 +4,7 @@ defmodule EWalletDB.UserTest do
 
   describe "User factory" do
     test_has_valid_factory User
-    test_encrypted_map_field User, "user", :metadata
+    test_encrypted_map_field User, "user", :encrypted_metadata
   end
 
   describe "insert/1" do
@@ -21,9 +21,9 @@ defmodule EWalletDB.UserTest do
 
     test_insert_generate_uuid User, :id
     test_insert_generate_timestamps User
-    test_insert_prevent_blank User, :metadata
     test_insert_prevent_duplicate User, :username
     test_insert_prevent_duplicate User, :provider_user_id
+    test_default_metadata_fields User, "user"
 
     # The test below can't use `test_insert_prevent_duplicate/3` with :email
     # because we need to use :admin factory to get proper data for admin user.

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -74,7 +74,8 @@ defmodule EWalletDB.Factory do
       metadata: %{
         "first_name" => sequence("John"),
         "last_name" => sequence("Doe")
-      }
+      },
+      encrypted_metadata: %{}
     }
   end
 

--- a/apps/ewallet_db/test/support/schema_case.ex
+++ b/apps/ewallet_db/test/support/schema_case.ex
@@ -356,6 +356,30 @@ defmodule EWalletDB.SchemaCase do
   end
 
   @doc """
+  Test schema's metadata and encrypted metadata
+  """
+  defmacro test_default_metadata_fields(schema, table) do
+    quote do
+      test "sets the metadata and encrypted metadata to default values" do
+        schema = unquote(schema)
+        table = unquote(table)
+
+        {_, record} =
+          schema
+          |> get_factory()
+          |> params_for(metadata: nil, encrypted_metadata: nil)
+          |> schema.insert()
+
+        {:ok, results} = SQL.query(EWalletDB.Repo,
+                                   "SELECT metadata, encrypted_metadata FROM \"#{table}\"", [])
+
+        assert record.metadata == %{}
+        assert record.encrypted_metadata == %{}
+      end
+    end
+  end
+
+  @doc """
   Test schema's field encryption for the given field
   """
   defmacro test_encrypted_map_field(schema, table, field) do

--- a/apps/local_ledger_db/lib/local_ledger_db/balance.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/balance.ex
@@ -12,7 +12,8 @@ defmodule LocalLedgerDB.Balance do
 
   schema "balance" do
     field :address, :string
-    field :metadata, Cloak.EncryptedMapField
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
     field :encryption_version, :binary
     has_many :transactions, Transaction
     timestamps()
@@ -23,7 +24,7 @@ defmodule LocalLedgerDB.Balance do
   """
   def changeset(%Balance{} = balance, attrs) do
     balance
-    |> cast(attrs, [:address, :metadata, :encryption_version])
+    |> cast(attrs, [:address, :metadata, :encrypted_metadata, :encryption_version])
     |> validate_required([:address])
     |> unique_constraint(:address)
     |> put_change(:encryption_version, Cloak.version)
@@ -62,7 +63,7 @@ defmodule LocalLedgerDB.Balance do
   Retrieve a balance from the database using the specified address
   or insert a new one before returning it.
   """
-  def get_or_insert(%{"address" => address, "metadata" => _} = attrs) do
+  def get_or_insert(%{"address" => address} = attrs) do
     case get(address) do
       nil ->
         insert(attrs)
@@ -84,7 +85,7 @@ defmodule LocalLedgerDB.Balance do
   query is made to get the current database record, be it the one inserted right
   before or one inserted by another concurrent process.
   """
-  def insert(%{"address" => address, "metadata" => _} = attrs) do
+  def insert(%{"address" => address} = attrs) do
     changeset = Balance.changeset(%Balance{}, attrs)
     opts = [on_conflict: :nothing, conflict_target: :address]
 

--- a/apps/local_ledger_db/lib/local_ledger_db/balance.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/balance.ex
@@ -25,7 +25,7 @@ defmodule LocalLedgerDB.Balance do
   def changeset(%Balance{} = balance, attrs) do
     balance
     |> cast(attrs, [:address, :metadata, :encrypted_metadata, :encryption_version])
-    |> validate_required([:address])
+    |> validate_required([:address, :metadata, :encrypted_metadata])
     |> unique_constraint(:address)
     |> put_change(:encryption_version, Cloak.version)
   end

--- a/apps/local_ledger_db/lib/local_ledger_db/entry.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/entry.ex
@@ -26,7 +26,7 @@ defmodule LocalLedgerDB.Entry do
   def changeset(%Entry{} = entry, attrs) do
     entry
     |> cast(attrs, [:metadata, :encrypted_metadata, :encryption_version, :correlation_id])
-    |> validate_required([:correlation_id])
+    |> validate_required([:correlation_id, :metadata, :encrypted_metadata])
     |> cast_assoc(:transactions, required: true)
     |> unique_constraint(:correlation_id)
     |> put_change(:encryption_version, Cloak.version)

--- a/apps/local_ledger_db/lib/local_ledger_db/entry.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/entry.ex
@@ -10,7 +10,8 @@ defmodule LocalLedgerDB.Entry do
   @primary_key {:id, Ecto.UUID, autogenerate: true}
 
   schema "entry" do
-    field :metadata, Cloak.EncryptedMapField
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
     field :encryption_version, :binary
     field :correlation_id, :string
     has_many :transactions, Transaction
@@ -24,7 +25,7 @@ defmodule LocalLedgerDB.Entry do
   """
   def changeset(%Entry{} = entry, attrs) do
     entry
-    |> cast(attrs, [:metadata, :encryption_version, :correlation_id])
+    |> cast(attrs, [:metadata, :encrypted_metadata, :encryption_version, :correlation_id])
     |> validate_required([:correlation_id])
     |> cast_assoc(:transactions, required: true)
     |> unique_constraint(:correlation_id)

--- a/apps/local_ledger_db/lib/local_ledger_db/minted_token.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/minted_token.ex
@@ -11,7 +11,8 @@ defmodule LocalLedgerDB.MintedToken do
 
   schema "minted_token" do
     field :friendly_id, :string
-    field :metadata, Cloak.EncryptedMapField
+    field :metadata, :map, default: %{}
+    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
     field :encryption_version, :binary
     has_many :transactions, Transaction
     timestamps()
@@ -22,7 +23,7 @@ defmodule LocalLedgerDB.MintedToken do
   """
   def changeset(%MintedToken{} = minted_token, attrs) do
     minted_token
-    |> cast(attrs, [:friendly_id, :metadata, :encryption_version])
+    |> cast(attrs, [:friendly_id, :metadata, :encrypted_metadata, :encryption_version])
     |> validate_required([:friendly_id])
     |> unique_constraint(:friendly_id)
     |> put_change(:encryption_version, Cloak.version)
@@ -32,7 +33,7 @@ defmodule LocalLedgerDB.MintedToken do
   Retrieve a minted token from the database using the specified friendly_id
   or insert a new one before returning it.
   """
-  def get_or_insert(%{"friendly_id" => friendly_id, "metadata" => _} = attrs) do
+  def get_or_insert(%{"friendly_id" => friendly_id} = attrs) do
     case get(friendly_id) do
       nil ->
         insert(attrs)
@@ -54,7 +55,7 @@ defmodule LocalLedgerDB.MintedToken do
   query is made to get the current database record, be it the one inserted right
   before or one inserted by another concurrent process.
   """
-  def insert(%{"friendly_id" => friendly_id, "metadata" => _} = attrs) do
+  def insert(%{"friendly_id" => friendly_id} = attrs) do
     changeset = MintedToken.changeset(%MintedToken{}, attrs)
     opts = [on_conflict: :nothing, conflict_target: :friendly_id]
 

--- a/apps/local_ledger_db/lib/local_ledger_db/minted_token.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/minted_token.ex
@@ -24,7 +24,7 @@ defmodule LocalLedgerDB.MintedToken do
   def changeset(%MintedToken{} = minted_token, attrs) do
     minted_token
     |> cast(attrs, [:friendly_id, :metadata, :encrypted_metadata, :encryption_version])
-    |> validate_required([:friendly_id])
+    |> validate_required([:friendly_id, :metadata, :encrypted_metadata])
     |> unique_constraint(:friendly_id)
     |> put_change(:encryption_version, Cloak.version)
   end

--- a/apps/local_ledger_db/priv/repo/migrations/20180307072417_add_encrypted_metadata.exs
+++ b/apps/local_ledger_db/priv/repo/migrations/20180307072417_add_encrypted_metadata.exs
@@ -1,10 +1,10 @@
 # credo:disable-for-this-file
-defmodule EWalletDB.Repo.Migrations.AddEncryptedMetadata do
+defmodule LocalLedgerDB.Repo.Migrations.AddEncryptedMetadata do
   use Ecto.Migration
   import Ecto.Query
-  alias EWalletDB.Repo
+  alias LocalLedgerDB.Repo
 
-  @tables [:balance, :minted_token, :transfer, :user]
+  @tables [:balance, :entry, :minted_token]
 
   def up do
     Enum.each(@tables, fn table_name ->

--- a/apps/local_ledger_db/test/local_ledger_db/balance_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/balance_test.exs
@@ -30,10 +30,10 @@ defmodule LocalLedgerDB.BalanceTest do
     test "saves the encrypted metadata" do
       :balance |> build(%{metadata: %{e_id: "123"}}) |> Repo.insert
 
-      {:ok, results} = SQL.query(Repo, "SELECT * FROM balance", [])
+      {:ok, results} = SQL.query(Repo, "SELECT encrypted_metadata FROM balance", [])
 
       row = Enum.at(results.rows, 0)
-      assert <<"SBX", 1, _::binary>> = Enum.at(row, 2)
+      assert <<"SBX", 1, _::binary>> = Enum.at(row, 0)
     end
   end
 

--- a/apps/local_ledger_db/test/local_ledger_db/entry_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/entry_test.exs
@@ -51,9 +51,9 @@ defmodule LocalLedgerDB.EntryTest do
   test "saves the encrypted metadata" do
     :entry |> build(%{metadata: %{e_id: "123"}}) |> Repo.insert
 
-    {:ok, results} = SQL.query(Repo, "SELECT * FROM entry", [])
+    {:ok, results} = SQL.query(Repo, "SELECT encrypted_metadata FROM entry", [])
 
     row = Enum.at(results.rows, 0)
-    assert <<"SBX", 1, _::binary>> = Enum.at(row, 1)
+    assert <<"SBX", 1, _::binary>> = Enum.at(row, 0)
   end
 end

--- a/apps/local_ledger_db/test/local_ledger_db/minted_token_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/minted_token_test.exs
@@ -65,7 +65,7 @@ defmodule LocalLedgerDB.MintedTokenTest do
     |> build(%{metadata: %{e_id: "123"}})
     |> Repo.insert
 
-    {:ok, results} = SQL.query(Repo, "SELECT metadata FROM minted_token", [])
+    {:ok, results} = SQL.query(Repo, "SELECT encrypted_metadata FROM minted_token", [])
 
     row = Enum.at(results.rows, 0)
     assert <<"SBX", 1, _::binary>> = Enum.at(row, 0)


### PR DESCRIPTION
Issue/Task Number: T58

# Overview

This PR transforms the metadata into a non-encrypted field and adds `encrypted_metadata` for data that should not be stored in clear in the databases.

# Changes

- Create Migration to migrate the current `metadata` to `encrypted_metadata` and change its type to `map`.
- Update the eWallet schemas with the new fields
- Update the LocalLedger schemas with the new fields
- Remove `metadata` as a mandatory field in all endpoints
- Update all serializers to include those two fields (when available)

# Usage

Get the branch and run the migrations on your current database. If anything comes up, let me know.

# Impact

No special requirement except keeping an eye on the current metadata being migrated correctly.

# Note 

The support for `encrypted_metadata` in the APIs as well as the Swagger docs will be added in a future PR.