### PR TITLE
T65 - Prevent transactions between identical addresses

### DIFF
--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -105,6 +105,30 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       }
     end
 
+    test "returns a 'same_address' error when the addresses are the same" do
+      balance      = insert(:balance)
+      minted_token   = insert(:minted_token)
+
+      response = provider_request_with_idempotency("/transfer", UUID.generate(), %{
+         from_address: balance.address,
+         to_address: balance.address,
+         token_id: minted_token.friendly_id,
+         amount: 100_000 * minted_token.subunit_to_unit,
+         metadata: %{}
+       })
+
+      assert response == %{
+        "success" => false,
+        "version" => "1",
+        "data" => %{
+          "code" => "transaction:same_address",
+          "description" => "Found identical addresses in senders and receivers: #{balance.address}.",
+          "messages" => nil,
+          "object" => "error"
+        }
+      }
+    end
+
     test "returns insufficient_funds when the user is too poor" do
       balance1      = insert(:balance)
       balance2      = insert(:balance)

--- a/apps/local_ledger/lib/local_ledger/errors/same_address_error.ex
+++ b/apps/local_ledger/lib/local_ledger/errors/same_address_error.ex
@@ -1,0 +1,8 @@
+defmodule LocalLedger.Errors.SameAddressError do
+  defexception message: "Entry could not be created. Some of the addresses are identical."
+
+  def error_message(addresses) do
+    addresses = Enum.join(addresses, ", ")
+    "Found identical addresses in senders and receivers: #{addresses}."
+  end
+end

--- a/apps/local_ledger/test/local_ledger/entry_test.exs
+++ b/apps/local_ledger/test/local_ledger/entry_test.exs
@@ -138,6 +138,35 @@ defmodule LocalLedger.EntryTest do
       assert error.errors == [correlation_id: {"has already been taken", []}]
     end
 
+    test "returns a 'same address' error when the from/to addresses are identical" do
+      genesis()
+
+      res = Entry.insert(%{
+        "metadata" => %{},
+        "debits" => [%{
+          "address" => "mederic",
+          "metadata" => %{},
+          "amount" => 200
+        }],
+        "credits" => [%{
+          "address" => "mederic",
+          "metadata" => %{},
+          "amount" => 200
+        }],
+        "minted_token" => %{
+          "friendly_id" => "OMG:209d3f5b-eab4-4906-9697-c482009fc865",
+          "metadata" => %{}
+        },
+        "correlation_id" => UUID.generate
+      }, %{genesis: false})
+
+      assert res == {
+        :error,
+        "transaction:same_address",
+        "Found identical addresses in senders and receivers: mederic."
+      }
+    end
+
     test "returns an 'insufficient_funds' error when the debit balances don't have enough funds" do
       genesis()
 


### PR DESCRIPTION
Issue/Task Number: T65

# Overview

Currently, it is possible to create transactions between the same two addresses. This PR adds a mechanism preventing that.

# Changes

- Raise a `SameAddressError` error if the same address is found in both the debits and credits.

# Implementation Details

1. Extract the addresses for debits and credits.
2. Do an intersect and check if anything common was found.
3. Raise the `SameAddressError` if that's the case, else let the flow continue. 

# Usage

-

# Impact

-