### PR TITLE
Remove UrlDispatcher redirects and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
-public/uploads
-apps/admin_api/public
+# Ignore files inside the uploads folder
+/public/uploads/*
+!/public/uploads/test.txt
+
 .env
 .DS_Store

--- a/apps/url_dispatcher/lib/url_dispatcher/plug.ex
+++ b/apps/url_dispatcher/lib/url_dispatcher/plug.ex
@@ -1,7 +1,7 @@
 defmodule UrlDispatcher.Plug do
   @moduledoc false
   import Plug.Conn, only: [resp: 3, halt: 1, put_status: 2]
-  import Phoenix.Controller, only: [json: 2, redirect: 2]
+  import Phoenix.Controller, only: [json: 2]
   alias Plug.Static
 
   @public_folders ~w(uploads swagger)
@@ -13,19 +13,12 @@ defmodule UrlDispatcher.Plug do
     conn
     |> put_status(200)
     |> json(%{status: true})
-    |> halt()
   end
 
-  # Redirect all endpoints without trailing slash to one with trailing slash.
-  defp handle_request("/api", conn), do: redirect(conn, to: "/api/")
-  defp handle_request("/admin/api", conn), do: redirect(conn, to: "/admin/api/")
-  defp handle_request("/admin", conn), do: redirect(conn, to: "/admin/")
-  defp handle_request("/public", conn), do: redirect(conn, to: "/public/")
-
-  defp handle_request("/api/" <> _, conn), do: EWalletAPI.Endpoint.call(conn, [])
-  defp handle_request("/admin/api/" <> _, conn), do: AdminAPI.Endpoint.call(conn, [])
-  defp handle_request("/admin/" <> _, conn), do: AdminPanel.Endpoint.call(conn, [])
-  defp handle_request("/public/" <> _, conn) do
+  defp handle_request("/api" <> _, conn), do: EWalletAPI.Endpoint.call(conn, [])
+  defp handle_request("/admin/api" <> _, conn), do: AdminAPI.Endpoint.call(conn, [])
+  defp handle_request("/admin" <> _, conn), do: AdminPanel.Endpoint.call(conn, [])
+  defp handle_request("/public" <> _, conn) do
     opts = Static.init([
       at: "/public",
       from: Path.join(Application.get_env(:ewallet, :root), "public"),

--- a/apps/url_dispatcher/test/test_helper.exs
+++ b/apps/url_dispatcher/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/url_dispatcher/test/url_dispatcher/plug_test.exs
+++ b/apps/url_dispatcher/test/url_dispatcher/plug_test.exs
@@ -39,7 +39,7 @@ defmodule UrlDispatcher.PlugTest do
     end
 
     test "returns a 200 response when requesting a file in /public folder" do
-      conn = request("/public/uploads/robots.txt")
+      conn = request("/public/uploads/test.txt")
 
       assert conn.halted # Plug.Static returns `%Plug.Conn{halted: true}` on success
       assert conn.status == 200

--- a/apps/url_dispatcher/test/url_dispatcher/plug_test.exs
+++ b/apps/url_dispatcher/test/url_dispatcher/plug_test.exs
@@ -1,0 +1,56 @@
+defmodule UrlDispatcher.PlugTest do
+  use ExUnit.Case
+  use Plug.Test
+  alias UrlDispatcher.Plug
+
+  defp request(path) do
+    :get
+    |> conn(path)
+    |> Plug.call([])
+  end
+
+  describe "call/2" do
+    test "returns success status when requesting /" do
+      conn = request("/")
+
+      refute conn.halted
+      assert conn.status == 200
+      assert conn.resp_body == ~s({"status":true})
+    end
+
+    test "returns a 200 response when requesting /api" do
+      conn = request("/api")
+      refute conn.halted
+      assert conn.status == 200
+    end
+
+    test "returns a 200 response when requesting /admin/api" do
+      conn = request("/admin/api")
+      refute conn.halted
+      assert conn.status == 200
+    end
+
+    test "returns a 404 response and halts when requesting an unknown endpoint" do
+      conn = request("/unknown_endpoint")
+
+      assert conn.halted
+      assert conn.status == 404
+      assert conn.resp_body == "The url could not be resolved."
+    end
+
+    test "returns a 200 response when requesting a file in /public folder" do
+      conn = request("/public/uploads/robots.txt")
+
+      assert conn.halted # Plug.Static returns `%Plug.Conn{halted: true}` on success
+      assert conn.status == 200
+    end
+
+    test "returns a 404 response and halts when requesting an unknown file /public" do
+      conn = request("/unknown_endpoint")
+
+      assert conn.halted
+      assert conn.status == 404
+      assert conn.resp_body == "The url could not be resolved."
+    end
+  end
+end

--- a/public/uploads/test.txt
+++ b/public/uploads/test.txt
@@ -1,0 +1,1 @@
+This file lies in /public/uploads folder for health checking that static files are being served.


### PR DESCRIPTION
Issue/Task Number: T37, T38

# Overview

This PR removes the non-trailing slash redirect and add simple tests to make sure the urls are being forwarded correctly.

# Changes

- Remove redirects for urls without trailing slashes
- Added basic http status tests for all the url prefixes handled by `UrlDispatcher`

# Implementation Details

I simply removed handling of the non-trailing slash version of the urls and removed trailing slashes from the actual dispatchers. Since Phoenix's router is agnostic about trailing slashes, both urls with and without trailing slashes are still served.

The good part is that curl will now work with or without trialing slashes without having to add `curl -L ...`

# Usage

Try call urls such as `/api`, `/admin`, `/admin/api` via curl. They will no longer require `-L` flag to redirect.

# Impact

N/A