### PR TITLE
Fix 500 error when assigning a user with invalid email format

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -89,6 +89,10 @@ defmodule AdminAPI.V1.ErrorHandler do
       code: "membership:not_found",
       description: "The user is not assigned to the provided account"
     },
+    invalid_email: %{
+      code: "user:invalid_email",
+      description: "The format of the provided email is invalid"
+    },
     invite_not_found: %{
       code: "user:invite_not_found",
       description: "There is no invite corresponding to the provided email and token"

--- a/apps/admin_api/test/admin_api/v1/controllers/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_membership_controller_test.exs
@@ -103,6 +103,20 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
       assert response["data"] == %{}
     end
 
+    test "returns an error if the email format is invalid" do
+      response = user_request("/account.assign_user", %{
+        email: "invalid_format",
+        account_id: insert(:account).id,
+        role_name: insert(:role).name,
+        redirect_url: "https://invite_url/?email={email}&token={token}"
+      })
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "user:invalid_email"
+      assert response["data"]["description"] == "The format of the provided email is invalid"
+    end
+
     test "returns an error if the given user id does not exist" do
       response = user_request("/account.assign_user", %{
         user_id: UUID.generate(),


### PR DESCRIPTION
Issue/Task Number: T44

# Overview

This PR fixes 500 error when `/admin/api/account.assign_user` is requested with an invalid email format.

# Changes

- Changed all error returns from an atom to `{:error, _}` for consistency in handling them
- Added a test that submits /admin/api/account.assign_user with an invalid email format

# Implementation Details

Instead of adding another `else` condition, I refactored so that the `else` cases should always return `{:error, _}`. This makes some statements a little more wordy but overall producing less conditions in the logic, which should be better.

# Usage

Try make an authenticated call to /admin/api/account.assign_user with an invalid email (e.g. an email without @ sign). The response should return `success: false` with the error code `user:invalid_email`.

# Impact

Usual deployment. No extra steps.