### PR TITLE
Seeder fallbacks to example.com if base_url is not set

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
@@ -156,13 +156,13 @@ defmodule AdminAPI.V1.AccountControllerTest do
       assert response["success"]
       assert response["data"]["object"] == "account"
       assert response["data"]["avatar"]["large"] =~
-             "http://example.com/public/uploads/test/account/avatars/#{account.id}/large.png?v="
+             "http://localhost:4000/public/uploads/test/account/avatars/#{account.id}/large.png?v="
       assert response["data"]["avatar"]["original"] =~
-             "http://example.com/public/uploads/test/account/avatars/#{account.id}/original.jpg?v="
+             "http://localhost:4000/public/uploads/test/account/avatars/#{account.id}/original.jpg?v="
       assert response["data"]["avatar"]["small"] =~
-             "http://example.com/public/uploads/test/account/avatars/#{account.id}/small.png?v="
+             "http://localhost:4000/public/uploads/test/account/avatars/#{account.id}/small.png?v="
       assert response["data"]["avatar"]["thumb"] =~
-             "http://example.com/public/uploads/test/account/avatars/#{account.id}/thumb.png?v="
+             "http://localhost:4000/public/uploads/test/account/avatars/#{account.id}/thumb.png?v="
     end
 
     test "removes the avatar from an account" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_controller_test.exs
@@ -112,13 +112,13 @@ defmodule AdminAPI.V1.AdminControllerTest do
       assert response["data"]["object"] == "user"
       assert response["data"]["email"] == admin.email
       assert response["data"]["avatar"]["large"] =~
-             "http://example.com/public/uploads/test/user/avatars/#{uuid}/large.png?v="
+             "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/large.png?v="
       assert response["data"]["avatar"]["original"] =~
-             "http://example.com/public/uploads/test/user/avatars/#{uuid}/original.jpg?v="
+             "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/original.jpg?v="
       assert response["data"]["avatar"]["small"] =~
-             "http://example.com/public/uploads/test/user/avatars/#{uuid}/small.png?v="
+             "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/small.png?v="
       assert response["data"]["avatar"]["thumb"] =~
-             "http://example.com/public/uploads/test/user/avatars/#{uuid}/thumb.png?v="
+             "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/thumb.png?v="
     end
 
     test "removes the avatar from a user" do

--- a/apps/ewallet/priv/repo/report_minimum.exs
+++ b/apps/ewallet/priv/repo/report_minimum.exs
@@ -1,8 +1,11 @@
 alias EWallet.CLI
 alias EWalletDB.AuthToken
 
+# :prod environment does not have a default :base_url value and should not have one.
+# But we have a fallback value here so we can generate a friendly output message for seeding.
+base_url = Application.get_env(:ewallet_db, :base_url) || "https://example.com"
+
 # Prepare URLs
-base_url                 = Application.get_env(:ewallet_db, :base_url)
 admin_panel_url          = base_url <> "/admin"
 ewallet_swagger_ui_url   = base_url <> "/api/swagger"
 admin_api_swagger_ui_url = base_url <> "/admin/api/swagger"

--- a/apps/ewallet/priv/repo/report_sample.exs
+++ b/apps/ewallet/priv/repo/report_sample.exs
@@ -1,6 +1,8 @@
 alias EWallet.CLI
 
-base_url            = Application.get_env(:ewallet_db, :base_url)
+# :prod environment does not have a default :base_url value and should not have one.
+# But we have a fallback value here so we can generate a friendly output message for seeding.
+base_url = Application.get_env(:ewallet_db, :base_url) || "https://example.com"
 
 # eWallet API
 ewallet_swagger_ui_url = base_url <> "/api/swagger"

--- a/apps/ewallet_db/config/config.exs
+++ b/apps/ewallet_db/config/config.exs
@@ -2,7 +2,8 @@ use Mix.Config
 
 config :ewallet_db,
   ecto_repos: [EWalletDB.Repo],
-  env: Mix.env
+  env: Mix.env,
+  base_url: System.get_env("BASE_URL") || "http://localhost:4000"
 
 import_config "#{Mix.env}.exs"
 

--- a/apps/ewallet_db/config/dev.exs
+++ b/apps/ewallet_db/config/dev.exs
@@ -4,9 +4,6 @@ config :ewallet_db, EWalletDB.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: System.get_env("DATABASE_URL") || "postgres://localhost/ewallet_dev"
 
-config :ewallet_db,
-  base_url: System.get_env("BASE_URL") || "http://localhost:4000"
-
 key = "j6fy7rZP9ASvf1bmywWGRjrmh8gKANrg40yWZ-rSKpI"
 
 config :cloak, Salty.SecretBox.Cloak,

--- a/apps/ewallet_db/config/test.exs
+++ b/apps/ewallet_db/config/test.exs
@@ -5,9 +5,6 @@ config :ewallet_db, EWalletDB.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: System.get_env("DATABASE_URL") || "postgres://localhost/ewallet_test"
 
-config :ewallet_db,
-  base_url: System.get_env("BASE_URL") || "http://example.com"
-
 # Uncomment this line to hide database requests when running tests
 config :logger, level: :warn
 


### PR DESCRIPTION
Issue/Task Number: T93

# Overview

This PR fixes #98. The seeder will fallback to "https://example.com" if `base_url` is not set, which can be usual for a system that's being setup for the first time.

# Changes

- Moved `:base_url` config assignment to `apps/ewallet_db/config/config.exs`
- Specifically prevent `:base_url` in `apps/ewallet_db/config/prod.exs` from having a default value
- Added fallback value for `:base_url` in seeder output

# Implementation Details

By doing the changes above, we guarantee that `:prod` environment will never accidentally set to a default value, while still allowing seeders to output a readable result.

# Usage

Run `mix seed` and `mix seed --sample` on `:prod` should produce urls with `https://example.com` as their base.

# Impact

Usual deployment. No extra steps.