### PR TITLE
Client's request embedding for transaction request consumption

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/serializers/membership_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/membership_serializer.ex
@@ -2,6 +2,7 @@ defmodule AdminAPI.V1.MembershipSerializer do
   @moduledoc """
   Serializes membership(s) into V1 response format.
   """
+  alias Ecto.Association.NotLoaded
   alias AdminAPI.V1.UserSerializer
   alias EWalletDB.User
 
@@ -17,4 +18,6 @@ defmodule AdminAPI.V1.MembershipSerializer do
     |> Map.put(:account_role, membership.role.name)
     |> Map.put(:status, User.get_status(membership.user))
   end
+  def serialize(%NotLoaded{}), do: nil
+  def serialize(nil), do: nil
 end

--- a/apps/admin_api/lib/admin_api/v1/serializers/user_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/user_serializer.ex
@@ -2,13 +2,15 @@ defmodule AdminAPI.V1.UserSerializer do
   @moduledoc """
   Serializes user(s) into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.{Date, Paginator, V1.PaginatorSerializer}
   alias EWalletDB.Uploaders.Avatar
+  alias EWalletDB.User
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
-  def serialize(user) when is_map(user) do
+  def serialize(%User{} = user) do
     %{
       object: "user",
       id: user.id,
@@ -22,4 +24,6 @@ defmodule AdminAPI.V1.UserSerializer do
       updated_at: Date.to_iso8601(user.updated_at)
     }
   end
+  def serialize(%NotLoaded{}), do: nil
+  def serialize(nil), do: nil
 end

--- a/apps/admin_api/test/admin_api/v1/serializers/membership_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/membership_serializer_test.exs
@@ -1,6 +1,7 @@
 defmodule AdminAPI.V1.MembershipSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias AdminAPI.V1.MembershipSerializer
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.Date
   alias EWalletDB.User
 
@@ -35,6 +36,14 @@ defmodule AdminAPI.V1.MembershipSerializerTest do
       }
 
       assert MembershipSerializer.to_user_json(membership) == expected
+    end
+
+    test "serializes to nil if membership is not given" do
+      assert MembershipSerializer.serialize(nil) == nil
+    end
+
+    test "serializes to nil if membership is not loaded" do
+      assert MembershipSerializer.serialize(%NotLoaded{}) == nil
     end
 
     test "serializes a list of memberships into a list of users json" do

--- a/apps/admin_api/test/admin_api/v1/serializers/user_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/user_serializer_test.exs
@@ -1,6 +1,7 @@
 defmodule AdminAPI.V1.UserSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias AdminAPI.V1.UserSerializer
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.{Date, Paginator}
 
   describe "serialize/1" do
@@ -29,6 +30,14 @@ defmodule AdminAPI.V1.UserSerializerTest do
       }
 
       assert UserSerializer.serialize(user) == expected
+    end
+
+    test "serializes to nil if user is not given" do
+      assert UserSerializer.serialize(nil) == nil
+    end
+
+    test "serializes to nil if user is not loaded" do
+      assert UserSerializer.serialize(%NotLoaded{}) == nil
     end
 
     test "serializes a user paginator into a list object" do

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/account_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/account_serializer.ex
@@ -2,6 +2,7 @@ defmodule EWallet.Web.V1.AccountSerializer do
   @moduledoc """
   Serializes account(s) into V1 response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWallet.Web.{Paginator, Date}
   alias EWalletDB.Account
@@ -16,7 +17,7 @@ defmodule EWallet.Web.V1.AccountSerializer do
       data: Enum.map(accounts, &serialize/1)
     }
   end
-  def serialize(account) when is_map(account) do
+  def serialize(%Account{} = account)do
     %{
       object: "account",
       id: account.id,
@@ -31,7 +32,6 @@ defmodule EWallet.Web.V1.AccountSerializer do
       updated_at: Date.to_iso8601(account.updated_at)
     }
   end
-  def serialize(nil) do
-    nil
-  end
+  def serialize(%NotLoaded{}), do: nil
+  def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/address_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/address_serializer.ex
@@ -2,15 +2,17 @@ defmodule EWallet.Web.V1.AddressSerializer do
   @moduledoc """
   Serializes address data into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.BalanceSerializer
 
-  def serialize(address) do
+  def serialize(address) when is_map(address) do
     %{
       object: "address",
       balances: serialize_balances(address.balances),
       address: address.address,
     }
   end
+  def serialize(%NotLoaded{}), do: nil
 
   defp serialize_balances(balances) do
     Enum.map(balances, &BalanceSerializer.serialize/1)

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/api_key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/api_key_serializer.ex
@@ -2,6 +2,7 @@ defmodule EWallet.Web.V1.APIKeySerializer do
   @moduledoc """
   Serializes API key(s) into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWallet.Web.{Date, Paginator}
 
@@ -20,4 +21,5 @@ defmodule EWallet.Web.V1.APIKeySerializer do
       deleted_at: Date.to_iso8601(api_key.deleted_at)
     }
   end
+  def serialize(%NotLoaded{}), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/balance_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/balance_serializer.ex
@@ -2,13 +2,15 @@ defmodule EWallet.Web.V1.BalanceSerializer do
   @moduledoc """
   Serializes balance data into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.MintedTokenSerializer
 
-  def serialize(balance) do
+  def serialize(balance) when is_map(balance) do
     %{
       object: "balance",
       minted_token: MintedTokenSerializer.serialize(balance.minted_token),
       amount: balance.amount
     }
   end
+  def serialize(%NotLoaded{}), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
@@ -2,12 +2,14 @@ defmodule EWallet.Web.V1.KeySerializer do
   @moduledoc """
   Serializes key(s) into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWallet.Web.{Date, Paginator}
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+  def serialize(%NotLoaded{}), do: nil
   def serialize(key) when is_map(key) do
     %{
       object: "key",

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/minted_token_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/minted_token_serializer.ex
@@ -2,12 +2,14 @@ defmodule EWallet.Web.V1.MintedTokenSerializer do
   @moduledoc """
   Serializes minted token(s) into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWallet.Web.{Date, Paginator}
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+  def serialize(%NotLoaded{}), do: nil
   def serialize(minted_tokens) when is_list(minted_tokens),
     do: Enum.map(minted_tokens, &serialize/1)
   def serialize(minted_token) when is_map(minted_token) do

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_consumption_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_consumption_serializer.ex
@@ -3,22 +3,34 @@ defmodule EWallet.Web.V1.TransactionRequestConsumptionSerializer do
   Serializes transaction request consumption data into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.V1.MintedTokenSerializer
   alias EWallet.Web.Date
+  alias EWallet.Web.V1.{
+    AccountSerializer,
+    MintedTokenSerializer,
+    TransactionSerializer,
+    TransactionRequestSerializer
+  }
+  alias EWalletAPI.V1.UserSerializer
+  alias EWalletDB.TransactionRequestConsumption
 
-  def serialize(consumption) when is_map(consumption) do
+  def serialize(%TransactionRequestConsumption{} = consumption) do
     %{
       object: "transaction_request_consumption",
       id: consumption.id,
       status: consumption.status,
       amount: consumption.amount,
+      minted_token_id: consumption.minted_token.friendly_id,
       minted_token: MintedTokenSerializer.serialize(consumption.minted_token),
       correlation_id: consumption.correlation_id,
       idempotency_token: consumption.idempotency_token,
       transaction_id: consumption.transfer_id,
+      transaction: TransactionSerializer.serialize(consumption.transfer),
       user_id: consumption.user_id,
+      user: UserSerializer.serialize(consumption.user),
       account_id: consumption.account_id,
+      account: AccountSerializer.serialize(consumption.account),
       transaction_request_id: consumption.transaction_request_id,
+      transaction_request: TransactionRequestSerializer.serialize(consumption.transaction_request),
       address: consumption.balance_address,
       created_at: Date.to_iso8601(consumption.inserted_at),
       updated_at: Date.to_iso8601(consumption.updated_at)

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_consumption_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_consumption_serializer.ex
@@ -2,10 +2,11 @@ defmodule EWallet.Web.V1.TransactionRequestConsumptionSerializer do
   @moduledoc """
   Serializes transaction request consumption data into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.MintedTokenSerializer
   alias EWallet.Web.Date
 
-  def serialize(consumption) do
+  def serialize(consumption) when is_map(consumption) do
     %{
       object: "transaction_request_consumption",
       id: consumption.id,
@@ -23,4 +24,5 @@ defmodule EWallet.Web.V1.TransactionRequestConsumptionSerializer do
       updated_at: Date.to_iso8601(consumption.updated_at)
     }
   end
+  def serialize(%NotLoaded{}), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
@@ -2,10 +2,11 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
   @moduledoc """
   Serializes transaction request data into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.MintedTokenSerializer
   alias EWallet.Web.Date
 
-  def serialize(transaction_request) do
+  def serialize(transaction_request) when is_map(transaction_request) do
     %{
       object: "transaction_request",
       id: transaction_request.id,
@@ -21,4 +22,5 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
       updated_at: Date.to_iso8601(transaction_request.updated_at)
     }
   end
+  def serialize(%NotLoaded{}), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
@@ -5,12 +5,17 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
   alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.MintedTokenSerializer
   alias EWallet.Web.Date
+  alias EWalletDB.Repo
+  alias EWalletDB.TransactionRequest
 
-  def serialize(transaction_request) when is_map(transaction_request) do
+  def serialize(%TransactionRequest{} = transaction_request) do
+    transaction_request = Repo.preload(transaction_request, :minted_token)
+
     %{
       object: "transaction_request",
       id: transaction_request.id,
       type: transaction_request.type,
+      minted_token_id: transaction_request.minted_token.friendly_id,
       minted_token: MintedTokenSerializer.serialize(transaction_request.minted_token),
       amount: transaction_request.amount,
       address: transaction_request.balance_address,

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_serializer.ex
@@ -2,12 +2,14 @@ defmodule EWallet.Web.V1.TransactionSerializer do
   @moduledoc """
   Serializes minted token(s) into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.{PaginatorSerializer, MintedTokenSerializer}
   alias EWallet.Web.{Date, Paginator}
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+  def serialize(%NotLoaded{}), do: nil
   def serialize(transaction) when is_map(transaction) do
     serialized_minted_token = MintedTokenSerializer.serialize(transaction.minted_token)
 

--- a/apps/ewallet/test/ewallet/web/v1/serializers/account_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/account_serializer_test.exs
@@ -1,5 +1,6 @@
 defmodule EWallet.Web.V1.AccountSerializerTest do
   use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.AccountSerializer
   alias EWallet.Web.{Paginator, Date}
   alias EWalletDB.Account
@@ -96,6 +97,10 @@ defmodule EWallet.Web.V1.AccountSerializerTest do
 
     test "serializes to nil if account is not given" do
       assert AccountSerializer.serialize(nil) == nil
+    end
+
+    test "serializes to nil if account is not loaded" do
+      assert AccountSerializer.serialize(%NotLoaded{}) == nil
     end
 
     test "serializes an empty account paginator into a list object" do

--- a/apps/ewallet/test/ewallet/web/v1/serializers/key_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/key_serializer_test.exs
@@ -1,5 +1,6 @@
 defmodule EWallet.Web.V1.KeySerializerTest do
   use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.KeySerializer
   alias EWallet.Web.{Date, Paginator}
 
@@ -19,6 +20,10 @@ defmodule EWallet.Web.V1.KeySerializerTest do
       }
 
       assert KeySerializer.serialize(key) == expected
+    end
+
+    test "serializes to nil if the key is not loaded" do
+      assert KeySerializer.serialize(%NotLoaded{}) == nil
     end
 
     test "serializes a key paginator into a list object" do

--- a/apps/ewallet/test/ewallet/web/v1/serializers/minted_token_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/minted_token_serializer_test.exs
@@ -1,5 +1,6 @@
 defmodule EWallet.Web.V1.MintedTokenSerializerTest do
   use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.MintedTokenSerializer
 
   describe "serialize/1 for single minted_token" do
@@ -19,6 +20,10 @@ defmodule EWallet.Web.V1.MintedTokenSerializerTest do
       }
 
       assert MintedTokenSerializer.serialize(minted_token) == expected
+    end
+
+    test "serializes to nil if the minted_token is not loaded" do
+      assert MintedTokenSerializer.serialize(%NotLoaded{}) == nil
     end
   end
 

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_consumption_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_consumption_serializer_test.exs
@@ -1,8 +1,15 @@
 defmodule EWallet.Web.V1.TransactionRequestConsumptionSerializerTest do
   use EWallet.Web.SerializerCase, :v1
+  alias EWalletAPI.V1.UserSerializer
   alias EWalletDB.TransactionRequestConsumption
-  alias EWallet.Web.V1.{TransactionRequestConsumptionSerializer, MintedTokenSerializer}
   alias EWallet.Web.Date
+  alias EWallet.Web.V1.{
+    AccountSerializer,
+    MintedTokenSerializer,
+    TransactionSerializer,
+    TransactionRequestConsumptionSerializer,
+    TransactionRequestSerializer
+  }
 
   describe "serialize/1 for single transaction request consumption" do
     test "serializes into correct V1 transaction_request consumption format" do
@@ -14,13 +21,19 @@ defmodule EWallet.Web.V1.TransactionRequestConsumptionSerializerTest do
         id: consumption.id,
         status: consumption.status,
         amount: consumption.amount,
+        minted_token_id: consumption.minted_token.friendly_id,
         minted_token: MintedTokenSerializer.serialize(consumption.minted_token),
         correlation_id: consumption.correlation_id,
         idempotency_token: consumption.idempotency_token,
         transaction_id: consumption.transfer_id,
+        transaction: TransactionSerializer.serialize(consumption.transfer),
         user_id: consumption.user_id,
+        user: UserSerializer.serialize(consumption.user),
         account_id: nil,
+        account: AccountSerializer.serialize(consumption.account),
         transaction_request_id: consumption.transaction_request_id,
+        transaction_request:
+          TransactionRequestSerializer.serialize(consumption.transaction_request),
         address: consumption.balance_address,
         created_at: Date.to_iso8601(consumption.inserted_at),
         updated_at: Date.to_iso8601(consumption.updated_at)

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
@@ -13,6 +13,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializerTest do
         object: "transaction_request",
         id: transaction_request.id,
         type: transaction_request.type,
+        minted_token_id: transaction_request.minted_token.friendly_id,
         minted_token: MintedTokenSerializer.serialize(transaction_request.minted_token),
         amount: transaction_request.amount,
         user_id: transaction_request.user_id,

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
@@ -1,5 +1,6 @@
 defmodule EWallet.Web.V1.TransactionSerializerTest do
   use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.{TransactionSerializer, MintedTokenSerializer}
   alias EWallet.Web.Date
   alias EWalletDB.Repo
@@ -36,6 +37,10 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
       }
 
       assert TransactionSerializer.serialize(transaction) == expected
+    end
+
+    test "serializes to nil if the tranasction is not loaded" do
+      assert TransactionSerializer.serialize(%NotLoaded{}) == nil
     end
   end
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_consumption_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_consumption_controller.ex
@@ -2,6 +2,17 @@ defmodule EWalletAPI.V1.TransactionRequestConsumptionController do
   use EWalletAPI, :controller
   import EWalletAPI.V1.ErrorHandler
   alias EWallet.TransactionConsumptionGate
+  alias EWalletDB.Repo
+
+  # The fields that are allowed to be preloaded.
+  # These fields must be one of the schema's association names.
+  @preloadable [:account, :minted_token, :transaction, :transaction_request, :user]
+
+  # The fields in `@preloadable` that are preloaded regardless of the request.
+  # These fields must be one of the schema's association names.
+  @always_preload [:minted_token]
+
+  plug :response_preload
 
   def consume(%{assigns: %{user: _}} = conn, attrs) do
     attrs = Map.put(attrs, "idempotency_token", conn.assigns.idempotency_token)
@@ -27,7 +38,31 @@ defmodule EWalletAPI.V1.TransactionRequestConsumptionController do
   end
   defp respond({:ok, consumption}, conn) do
     render(conn, :transaction_request_consumption, %{
-      transaction_request_consumption: consumption
+      transaction_request_consumption: preload_embed(conn, consumption)
     })
   end
+
+  defp preload_embed(conn, item), do: Repo.preload(item, conn.assigns.embed)
+
+  def response_preload(conn, _plug_opts) do
+    embeds =
+      case conn.body_params["embed"] do
+        embeds when is_list(embeds) -> to_existing_atoms!(embeds)
+        _                           -> []
+      end
+
+    # We could use `preloads -- (preloads -- preloadable)` but the complexity is O(N^3)
+    # and we're dealing with user inputs here, so it's better to convert to `MapSet`
+    # before operating on the lists.
+    preloads    = MapSet.new(embeds ++ @always_preload)
+    preloadable = MapSet.new(@preloadable)
+    filtered    = MapSet.intersection(preloads, preloadable)
+
+    case MapSet.size(filtered) do
+      n when n > 0 -> assign(conn, :embed, MapSet.to_list(filtered))
+      _            -> assign(conn, :embed, [])
+    end
+  end
+
+  defp to_existing_atoms!(strings), do: Enum.map(strings, &String.to_existing_atom/1)
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/serializers/user_serializer.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/serializers/user_serializer.ex
@@ -2,8 +2,10 @@ defmodule EWalletAPI.V1.UserSerializer do
   @moduledoc """
   Serializes user data into V1 JSON response format.
   """
+  alias Ecto.Association.NotLoaded
+  alias EWalletDB.User
 
-  def serialize(user) do
+  def serialize(%User{} = user) do
     %{
       object: "user",
       id: user.id,
@@ -13,4 +15,6 @@ defmodule EWalletAPI.V1.UserSerializer do
       encrypted_metadata: user.encrypted_metadata
     }
   end
+  def serialize(%NotLoaded{}), do: nil
+  def serialize(nil), do: nil
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -28,6 +28,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           "address" => balance.address,
           "correlation_id" => "123",
           "id" => request.id,
+          "minted_token_id" => minted_token.friendly_id,
           "minted_token" => %{
             "id" => minted_token.friendly_id,
             "name" => minted_token.name,
@@ -73,6 +74,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           "address" => balance.address,
           "correlation_id" => nil,
           "id" => request.id,
+          "minted_token_id" => minted_token.friendly_id,
           "minted_token" => %{
             "id" => minted_token.friendly_id,
             "name" => minted_token.name,
@@ -217,6 +219,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           "address" => balance.address,
           "correlation_id" => "123",
           "id" => request.id,
+          "minted_token_id" => minted_token.friendly_id,
           "minted_token" => %{
             "id" => minted_token.friendly_id,
             "name" => minted_token.name,
@@ -262,6 +265,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           "address" => balance.address,
           "correlation_id" => nil,
           "id" => request.id,
+          "minted_token_id" => minted_token.friendly_id,
           "minted_token" => %{
             "id" => minted_token.friendly_id,
             "name" => minted_token.name,

--- a/apps/ewallet_api/test/ewallet_api/v1/serializers/user_serializer_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/serializers/user_serializer_test.exs
@@ -1,20 +1,11 @@
 defmodule EWalletAPI.V1.UserSerializerTest do
   use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Association.NotLoaded
   alias EWalletAPI.V1.UserSerializer
-  alias Ecto.UUID
 
-  describe "V1.UserSerializer" do
+  describe "serialize/1" do
     test "serializes into correct V1 user format" do
-      user = %{
-        id: UUID.generate(),
-        username: "johndoe",
-        provider_user_id: "provider_id_1234",
-        metadata: %{
-          first_name: "John",
-          last_name: "Doe"
-        },
-        encrypted_metadata: %{}
-      }
+      user = insert(:user)
 
       expected = %{
         object: "user",
@@ -22,13 +13,21 @@ defmodule EWalletAPI.V1.UserSerializerTest do
         username: user.username,
         provider_user_id: user.provider_user_id,
         metadata: %{
-          first_name: "John",
-          last_name: "Doe"
+          "first_name" => user.metadata["first_name"],
+          "last_name" => user.metadata["last_name"]
         },
         encrypted_metadata: %{}
       }
 
       assert UserSerializer.serialize(user) == expected
+    end
+
+    test "serializes to nil if user is not given" do
+      assert UserSerializer.serialize(nil) == nil
+    end
+
+    test "serializes to nil if user is not loaded" do
+      assert UserSerializer.serialize(%NotLoaded{}) == nil
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_consumption_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_consumption_view_test.exs
@@ -1,37 +1,26 @@
 defmodule EWalletAPI.V1.TransactionRequestConsumptionViewTest do
   use EWalletAPI.ViewCase, :v1
-  alias EWalletDB.TransactionRequestConsumption
   alias EWalletAPI.V1.TransactionRequestConsumptionView
-  alias EWallet.Web.{Date, V1.MintedTokenSerializer}
+  alias EWalletDB.TransactionRequestConsumption
 
   describe "EWalletAPI.V1.TransactionRequestConsumptionView.render/2" do
     test "renders transaction_request_consumption.json with correct structure" do
       request = insert(:transaction_request_consumption)
       consumption = TransactionRequestConsumption.get(request.id, preload: [:minted_token])
 
-      expected = %{
-        version: @expected_version,
-        success: true,
-        data: %{
-          object: "transaction_request_consumption",
-          id: consumption.id,
-          status: consumption.status,
-          amount: consumption.amount,
-          minted_token: MintedTokenSerializer.serialize(consumption.minted_token),
-          correlation_id: consumption.correlation_id,
-          idempotency_token: consumption.idempotency_token,
-          transaction_id: consumption.transfer_id,
-          user_id: consumption.user_id,
-          account_id: consumption.account_id,
-          transaction_request_id: consumption.transaction_request_id,
-          address: consumption.balance_address,
-          created_at: Date.to_iso8601(consumption.inserted_at),
-          updated_at: Date.to_iso8601(consumption.updated_at)
-        }
-      }
+      result = render(TransactionRequestConsumptionView,
+                      "transaction_request_consumption.json",
+                      transaction_request_consumption: consumption)
 
-      assert render(TransactionRequestConsumptionView, "transaction_request_consumption.json",
-                    transaction_request_consumption: consumption) == expected
+      # The serializer tests should cover data transformation already, so we only test that
+      # the view builds the expected object and wraps the data into the expected response format.
+      assert %{
+          version: _,
+          success: _,
+          data: %{
+            object: "transaction_request_consumption",
+          }
+        } = result
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_view_test.exs
@@ -16,6 +16,7 @@ defmodule EWalletAPI.V1.TransactionRequestViewTest do
           object: "transaction_request",
           id: transaction_request.id,
           type: transaction_request.type,
+          minted_token_id: transaction_request.minted_token.friendly_id,
           minted_token: MintedTokenSerializer.serialize(transaction_request.minted_token),
           amount: transaction_request.amount,
           address: transaction_request.balance_address,

--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -120,7 +120,7 @@ defmodule EWalletDB.Account do
   def all(opts) do
     Account
     |> Repo.all()
-    |> Repo.preload(opts[:preload] || [])
+    |> preload_option(opts)
   end
 
   @doc """

--- a/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
@@ -4,6 +4,7 @@ defmodule EWalletDB.TransactionRequest do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  import EWalletDB.Helpers.Preloader
   import EWalletDB.Validator
   alias Ecto.UUID
   alias EWalletDB.{TransactionRequest, TransactionRequestConsumption,
@@ -72,7 +73,7 @@ defmodule EWalletDB.TransactionRequest do
       true ->
         TransactionRequest
         |> Repo.get(id)
-        |> Repo.preload(opts[:preload])
+        |> preload_option(opts)
       false -> nil
     end
   end


### PR DESCRIPTION
Issue/Task Number: T71

# Overview

This PR allows client to specify which extra association data to embed with the response.

# Changes

- Update all serializers to serialize `%Ecto.Association.NotLoaded{}` to nil
- Add `@embeddable` and `@always_embed` to TransactionRequestConsumptionController
- Embed the specified associations before sending the response

# Implementation Details

There were 3 options explored to handle when an association is not embedded:

```ex
# 1: Send nil
%{
  "success" => true, 
  "version" => "1",
  "data" => %{
    "parent"  => "data"
    "user_id" => "a43c801f-cc67-4047-bfb3-5cee967551de",
    "user"    => nil
  }
}

# 2: Send "not_loaded"
%{
  "success" => true, 
  "version" => "1",
  "data" => %{
    "parent"  => "data"
    "user_id" => "a43c801f-cc67-4047-bfb3-5cee967551de",
    "user"    => "not_loaded"
  }
}

# 3: Remove key completely
%{
  "success" => true, 
  "version" => "1",
  "data" => %{
    "parent"  => "data"
    "user_id" => "a43c801f-cc67-4047-bfb3-5cee967551de",
  }
}
```

We decided to go for 1 because:

1. `nil` is easy and performant for the client to handle, unlike option 2 that the client needs to check for a specific string.
2. The returned field keys are always consistent, unlike option 3.
3. The trade-off is that the client needs to distinguish between a nil that's caused by the association not embedded, or the object does not have an association, but this should be relatively straightforward since for all embeds, there will also be an `embed_id` in the response.

# Usage

Make a valid call to `/transaction_request.consume` and/or `/me.consume_transaction_request`

# Impact

Usual deployment. No extra steps required.