### PR TITLE
Fix docs urls in the seeder

### DIFF
--- a/apps/ewallet/priv/repo/report_minimum.exs
+++ b/apps/ewallet/priv/repo/report_minimum.exs
@@ -7,8 +7,8 @@ base_url = Application.get_env(:ewallet_db, :base_url) || "https://example.com"
 
 # Prepare URLs
 admin_panel_url          = base_url <> "/admin"
-ewallet_swagger_ui_url   = base_url <> "/api/swagger"
-admin_api_swagger_ui_url = base_url <> "/admin/api/swagger"
+ewallet_swagger_ui_url   = base_url <> "/api/docs"
+admin_api_swagger_ui_url = base_url <> "/admin/api/docs"
 
 # Prepare the seeded data
 api_key_id              = Application.get_env(:ewallet, :seed_admin_api_key).id

--- a/apps/ewallet/priv/repo/report_sample.exs
+++ b/apps/ewallet/priv/repo/report_sample.exs
@@ -5,13 +5,13 @@ alias EWallet.CLI
 base_url = Application.get_env(:ewallet_db, :base_url) || "https://example.com"
 
 # eWallet API
-ewallet_swagger_ui_url = base_url <> "/api/swagger"
+ewallet_swagger_ui_url = base_url <> "/api/docs"
 ewallet_key         = Application.get_env(:ewallet, :seed_ewallet_key)
 ewallet_api_key     = Application.get_env(:ewallet, :seed_ewallet_api_key)
 ewallet_auth_token  = Application.get_env(:ewallet, :seed_ewallet_auth_token)
 
 # Admin API
-admin_api_swagger_ui_url = base_url <> "/admin/api/swagger"
+admin_api_swagger_ui_url = base_url <> "/admin/api/docs"
 admin_api_key         = Application.get_env(:ewallet, :seed_admin_api_key)
 admin_user            = Application.get_env(:ewallet, :seed_admin_user)
 admin_auth_token      = Application.get_env(:ewallet, :seed_admin_auth_token)


### PR DESCRIPTION
Issue/Task Number: N/A

# Overview

The seeder's output still refers to `*/swagger` instead of `*/docs`.

# Changes

- Replace `*/swagger` with `*/docs`

# Implementation Details

N/A

# Usage

Running `mix seed` and `mix seed --sample` should return urls with `*/docs` instead of `*/swagger`.

# Impact

Usual deployment.