### PR TITLE
Customizable admin email in the seed

### DIFF
--- a/apps/ewallet/priv/repo/seeders/initial_user.exs
+++ b/apps/ewallet/priv/repo/seeders/initial_user.exs
@@ -4,7 +4,7 @@ alias EWallet.{CLI, Seeder}
 alias EWalletDB.{Account, Membership, Role, User}
 
 data = %{
-  email: "admin_master@example.com",
+  email: Application.get_env(:ewallet, :seed_admin_email),
   password: generate_key(16),
   metadata: %{},
   role_name: "admin"


### PR DESCRIPTION
Issue/Task Number: T121

# Overview

The seed is hardcoded to use `admin_master@example.com` which is not very useful for other than a demo setup. This PR makes that first admin's email address customizable during the start of `mix seed`.

# Changes

- Changed the seed to ask for email address input at the beginning of the seed.

# Implementation Details

I decided to use `Application.put_env/3` to persist the email address value across the seed scripts. This is probably not the best approach but it works and is quick to implement. Definitely don't want this to stick around after we do a refactor of the seed.

# Usage

Run `mix seed` you should see the prompt after:

```
$ mix seed
What email address should we set for your first admin user?
This email is required for logging into the admin panel.
If a user with this email already exists, it will escalate the user to admin role.

E-mail (admin@example.com):

# The seed continues after the email input ...
```

# Impact

Usual deployment.