### PR TITLE
Serve fallback message when assets are missing & API key injection

### DIFF
--- a/apps/admin_panel/assets/src/omisego/config.js
+++ b/apps/admin_panel/assets/src/omisego/config.js
@@ -1,5 +1,5 @@
 export const ADMIN_PANEL_BASE_DIR = "/admin";
 
 export const ADMIN_API_BASE_URL = "/admin/api";
-export const ADMIN_API_KEY_ID = process.env.ADMIN_API_KEY_ID;
-export const ADMIN_API_KEY = process.env.ADMIN_API_KEY;
+export const ADMIN_API_KEY_ID = window.admin_api_conf.api_key_id;
+export const ADMIN_API_KEY = window.admin_api_conf.api_key;

--- a/apps/admin_panel/assets/src/omisego/config.js
+++ b/apps/admin_panel/assets/src/omisego/config.js
@@ -1,5 +1,5 @@
 export const ADMIN_PANEL_BASE_DIR = "/admin";
 
 export const ADMIN_API_BASE_URL = "/admin/api";
-export const ADMIN_API_KEY_ID = window.admin_api_conf.api_key_id;
-export const ADMIN_API_KEY = window.admin_api_conf.api_key;
+export const ADMIN_API_KEY_ID = window.adminConfig.apiKeyId;
+export const ADMIN_API_KEY = window.adminConfig.apiKey;

--- a/apps/admin_panel/config/config.exs
+++ b/apps/admin_panel/config/config.exs
@@ -8,6 +8,7 @@ use Mix.Config
 # General application configuration
 config :admin_panel,
   namespace: AdminPanel,
+  dist_path: Path.expand("../priv/dist/", __DIR__),
   webpack_watch: false
 
 # Configures the endpoint

--- a/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
+++ b/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
@@ -60,5 +60,5 @@ defmodule AdminPanel.PageController do
     </script>
     """
   end
-  defp api_key_script(_not_api_key), do: ""
+  defp api_key_script(_), do: "<!-- No API key found -->" # For troubleshooting purposes
 end

--- a/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
+++ b/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
@@ -2,9 +2,28 @@ defmodule AdminPanel.PageController do
   use AdminPanel, :controller
   alias Plug.Conn
 
+  @not_found_message """
+    The assets are not available. If you think this is incorrect,
+    please make sure that the front-end assets have been built.
+    """
+
   def index(conn, _params) do
+    index_path =
+      case conn do
+        %{private: %{override_dist_path: dist_path}} ->
+          Path.join(dist_path, "index.html")
+        _ ->
+          dist_path = Application.get_env(:admin_panel, :dist_path)
+          Path.join(dist_path, "index.html")
+      end
+
     conn
     |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> Conn.send_file(200, Application.app_dir(:admin_panel, "priv/dist/index.html"))
+    |> Conn.send_file(200, index_path)
+  rescue
+    File.Error ->
+      conn
+      |> put_resp_header("content-type", "text/plain; charset=utf-8")
+      |> Conn.send_resp(:not_found, @not_found_message)
   end
 end

--- a/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
+++ b/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
@@ -1,5 +1,8 @@
 defmodule AdminPanel.PageController do
   use AdminPanel, :controller
+  import Ecto.Query
+  import EWalletDB.SoftDelete
+  alias EWalletDB.{APIKey, Repo}
   alias Plug.Conn
 
   @not_found_message """
@@ -8,22 +11,54 @@ defmodule AdminPanel.PageController do
     """
 
   def index(conn, _params) do
-    index_path =
-      case conn do
-        %{private: %{override_dist_path: dist_path}} ->
-          Path.join(dist_path, "index.html")
-        _ ->
-          dist_path = Application.get_env(:admin_panel, :dist_path)
-          Path.join(dist_path, "index.html")
-      end
+    content =
+      conn
+      |> index_file_path()
+      |> File.read!()
+      |> inject_api_key()
 
     conn
     |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> Conn.send_file(200, index_path)
+    |> Conn.send_resp(200, content)
   rescue
     File.Error ->
       conn
       |> put_resp_header("content-type", "text/plain; charset=utf-8")
       |> Conn.send_resp(:not_found, @not_found_message)
   end
+
+  defp index_file_path(%{private: %{override_dist_path: dist_path}}) do
+    Path.join(dist_path, "index.html")
+  end
+  defp index_file_path(_conn) do
+    :admin_panel
+    |> Application.get_env(:dist_path)
+    |> Path.join("index.html")
+  end
+
+  defp inject_api_key(content) do
+    String.replace(content, ~s("app"></div>), api_key_script(), insert_replaced: 0)
+  end
+
+  defp api_key_script do
+    APIKey
+    |> exclude_deleted()
+    |> limit(1)
+    |> Repo.get_by(%{owner_app: "admin_api"})
+    |> api_key_script()
+  end
+
+  defp api_key_script(%APIKey{} = api_key) do
+    """
+    <script>
+      var admin_api_conf = {};
+
+      admin_api_conf.api_key_id = "#{api_key.id}";
+      admin_api_conf.api_key = "#{api_key.key}";
+
+      window.admin_api_conf = admin_api_conf;
+    </script>
+    """
+  end
+  defp api_key_script(_not_api_key), do: ""
 end

--- a/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
+++ b/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
@@ -51,12 +51,12 @@ defmodule AdminPanel.PageController do
   defp api_key_script(%APIKey{} = api_key) do
     """
     <script>
-      var admin_api_conf = {};
+      var adminConfig = {};
 
-      admin_api_conf.api_key_id = "#{api_key.id}";
-      admin_api_conf.api_key = "#{api_key.key}";
+      adminConfig.apiKeyId = "#{api_key.id}";
+      adminConfig.apiKey = "#{api_key.key}";
 
-      window.admin_api_conf = admin_api_conf;
+      window.adminConfig = adminConfig;
     </script>
     """
   end

--- a/apps/admin_panel/mix.exs
+++ b/apps/admin_panel/mix.exs
@@ -44,7 +44,8 @@ defmodule AdminPanel.Mixfile do
   defp deps do
     [
       {:phoenix, "~> 1.3.0"},
-      {:cowboy, "~> 1.0"}
+      {:cowboy, "~> 1.0"},
+      {:ewallet_db, in_umbrella: true}
     ]
   end
 end

--- a/apps/admin_panel/test/admin_panel/controllers/page_controller_test.exs
+++ b/apps/admin_panel/test/admin_panel/controllers/page_controller_test.exs
@@ -9,10 +9,21 @@ defmodule AdminPanel.PageControllerTest do
     test "returns the main front-end app page" do
       response =
         build_conn()
+        |> put_private(:override_dist_path, Path.join(__DIR__, "../test_assets/dist/"))
         |> get("/admin")
         |> html_response(:ok)
 
       assert response =~ "<title>Admin Panel</title>"
+    end
+
+    test "returns :not_found if the index file could not be found" do
+      response =
+        build_conn()
+        |> put_private(:override_dist_path, Path.join(__DIR__, "../incorrect-path"))
+        |> get("/admin")
+        |> text_response(:not_found)
+
+      assert response =~ "The assets are not available."
     end
   end
 
@@ -23,6 +34,7 @@ defmodule AdminPanel.PageControllerTest do
     test "returns the main app page" do
       response =
         build_conn()
+        |> put_private(:override_dist_path, Path.join(__DIR__, "../test_assets/dist/"))
         |> get("/admin/any-path")
         |> html_response(:ok)
 

--- a/apps/admin_panel/test/admin_panel/controllers/page_controller_test.exs
+++ b/apps/admin_panel/test/admin_panel/controllers/page_controller_test.exs
@@ -46,6 +46,7 @@ defmodule AdminPanel.PageControllerTest do
         |> html_response(:ok)
 
       assert response =~ "<title>Admin Panel</title>"
+      assert response =~ "<!-- No API key found -->"
       refute response =~ "var admin_api_conf"
     end
 

--- a/apps/admin_panel/test/admin_panel/test_assets/dist/index.html
+++ b/apps/admin_panel/test/admin_panel/test_assets/dist/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Admin Panel</title>
+  </head>
+  <body>
+    This file is created as a test stub, so that tests do not need
+    to refer to `priv/dist/index.html` which may not be available
+    if the front-end assets has not been built.
+  </body>
+</html>

--- a/apps/admin_panel/test/admin_panel/test_assets/dist/index.html
+++ b/apps/admin_panel/test/admin_panel/test_assets/dist/index.html
@@ -7,5 +7,6 @@
     This file is created as a test stub, so that tests do not need
     to refer to `priv/dist/index.html` which may not be available
     if the front-end assets has not been built.
+    <div id="app" class="app"></div>
   </body>
 </html>

--- a/apps/admin_panel/test/test_helper.exs
+++ b/apps/admin_panel/test/test_helper.exs
@@ -1,1 +1,3 @@
+{:ok, _} = Application.ensure_all_started(:ex_machina)
 ExUnit.start()
+Ecto.Adapters.SQL.Sandbox.mode(EWalletDB.Repo, :manual)

--- a/apps/ewallet/priv/repo/report_minimum.exs
+++ b/apps/ewallet/priv/repo/report_minimum.exs
@@ -16,15 +16,6 @@ api_key                 = Application.get_env(:ewallet, :seed_admin_api_key).key
 admin                   = Application.get_env(:ewallet, :seed_admin_user)
 {:ok, admin_auth_token} = AuthToken.generate(admin, :admin_api)
 
-# Prepare admin_panel's `.env` file
-dotenv_path = "apps/admin_panel/assets/.env"
-File.cwd!
-|> Path.join(dotenv_path)
-|> File.write!("""
-  ADMIN_API_KEY_ID=#{api_key_id}
-  ADMIN_API_KEY=#{api_key}
-  """)
-
 # Output the seeding result
 CLI.heading("Setting up the OmiseGO eWallet Server")
 
@@ -37,9 +28,6 @@ CLI.print("""
   ## Manage your eWallet system via the Admin Panel
 
   We have just seeded your eWallet system with an API key and an Admin Panel user.
-  To save your time, we have also configured the Admin Panel with the seeded API key.
-  If you want to, you can look up the configuration file at `#{dotenv_path}`.
-
   Now it's your turn to login to your Admin Panel with the following credentials:
 
     - Login URL : `#{admin_panel_url}`


### PR DESCRIPTION
Issue/Task Number: T136

# Overview

This PR adds a fallback message in case the front-end assets have not been built, improves the tests so that they reliably tests cases both when assets can be found and when they're not found, and auto-injects the API key pair from the backend to the admin panel.

# Changes

- Added `:dist_path` config to specify where to find the compiled frontend assets
- Add a fallback so that the admin panel serves a descriptive message if it cannot serve the assets.
- Update tests so they reliably tests both when the assets can be found and when they can't.
- Automatically injects API key ID and API key into the frontend app.

# Implementation Details

- `:dist_path` config is added so `AdminPanel.PageController` does not rely on a hardcoded path. This is useful for changing the path to the test assets when testing.
- **API key injection:** We decided to automatically inject the API key ID and API key from the backend Elixir subapp directly into the frontend serving page because:
  - The `.env` file needs to be set after a seed, this means extra steps to setup a system: 1) compile the apps 2) run the seed 3) configure `.env` with the seed information 4) compile frontend assets, instead of just 1) and 2)
  - Having to compile frontend assets with the `.env` file also means that server images can be prepared only with the backend, and the frontend will need to wait until runtime, which in inefficient.
  - The API key ID & API key for the Admin Panel is originally intended to be a client identifier, rather than a strong authenticator, so that we can do some quick and easy management of API clients (e.g. rate throttling, logging, etc.). All secure operations need to be conducted with the user authentication anyway. So this is acceptable as a temporary workaround to get the admin panel up and running while we wait to settle the discussion on the use of API keys in admin panel.

# Usage

Run the server with `mix omg.server` then delete the `/apps/admin_panel/assets/priv/dist/` folder. Instead of throwing error it should respond with a descriptive message that it could not find the assets.

Or delete the `/apps/admin_panel/assets/priv/dist/` folder, then run `mix test`. Instead of tests failing they should past now.

# Impact

Usual deployment.