### PR TITLE
Fix ecto warning when running migrations

### DIFF
--- a/apps/admin_panel/config/config.exs
+++ b/apps/admin_panel/config/config.exs
@@ -8,6 +8,7 @@ use Mix.Config
 # General application configuration
 config :admin_panel,
   namespace: AdminPanel,
+  ecto_repos: [],
   dist_path: Path.expand("../priv/dist/", __DIR__),
   webpack_watch: false
 


### PR DESCRIPTION
Issue/Task Number: T153

# Overview

Adds `ecto_repos: []` to the admin panel's config.exs

# Changes

- Add `ecto_repos: []` to `apps/admin_panel/config/config.exs`

# Implementation Details

With #120, admin_panel app now requires a database connection. Ecto requires an empty `:ecto_repos` config even that the database connection is handled by `EWalletDB.Repo`.

# Usage

Run `mix ecto.migrate` should not cause the following warning:

```
==> admin_panel
warning: could not find repositories for application :admin_panel.

You can avoid this warning by passing the -r flag or by setting the
repositories managed by this application in your config/config.exs:

    config :admin_panel, ecto_repos: [...]

The configuration may be an empty list if it does not define any repo.
```

# Impact

N/A
