### PR TITLE
Fix alert box overlap the logo on the login page

### DIFF
--- a/apps/admin_panel/assets/src/components/Alerter.jsx
+++ b/apps/admin_panel/assets/src/components/Alerter.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Alerter = ({ alert }) => (
-  <div>
+  <div className="alert-center">
     {alert.message ? (
       <div className={`alert ${alert.type}`}>
         {alert.message}

--- a/apps/admin_panel/assets/src/pages/public/PublicLayout.jsx
+++ b/apps/admin_panel/assets/src/pages/public/PublicLayout.jsx
@@ -11,8 +11,8 @@ const PublicLayout = ({ alert, children }) => (
     <div className="public-layout">
       <div>
         <PublicHeader />
+        <Alerter alert={alert} />
         <div className="public-layout__content">
-          <Alerter alert={alert} />
           <div>
             <div>
               {children}

--- a/apps/admin_panel/assets/src/styles/components/_alert.scss
+++ b/apps/admin_panel/assets/src/styles/components/_alert.scss
@@ -2,10 +2,15 @@
   text-align: center;
   margin-top: 1rem;
   margin-bottom: 2rem;
+  display: inline-block;
 }
 
 .alert-danger {
   border: 1px solid $red-alert;
+}
+
+.alert-center {
+  text-align: center;
 }
 
 .alert-success {


### PR DESCRIPTION
Issue/Task Number: `154-fix-alert-overlap-the-logo`
 
# Overview

The alert box on the login page doesn't look nice because it overlaps the logo. This PR will solve it.

# Changes

- A better alert box

**From**
![image](https://user-images.githubusercontent.com/4509570/37753850-9694edd0-2dd1-11e8-95e5-2c2e14140e0c.png)

**To**
![image](https://user-images.githubusercontent.com/4509570/37753737-fa22ad0c-2dd0-11e8-8dda-d4c38c8ed75e.png)

# Implementation Details

- Add `display: inline-block` to `.alert` class
- Create class `.alert-center`
- Apply `.alert-center` to the root of the `Alerter` component

# Usage

`N/A`

# Impact

`N/A`
