### PR TITLE
Fix tests randomly failing due to DB return sequence

### DIFF
--- a/apps/ewallet/lib/ewallet/helper.ex
+++ b/apps/ewallet/lib/ewallet/helper.ex
@@ -19,4 +19,15 @@ defmodule EWallet.Helper do
   rescue
     ArgumentError -> atom_list
   end
+
+  @doc """
+  Checks if all `elements` exist within the `enumerable`.
+
+  Membership is tested with the match (`===`) operator.
+  """
+  def members?(enumerable, elements) do
+    Enum.all?(elements, fn(element) ->
+      Enum.member?(enumerable, element)
+    end)
+  end
 end

--- a/apps/ewallet/test/ewallet/helper_test.exs
+++ b/apps/ewallet/test/ewallet/helper_test.exs
@@ -13,4 +13,14 @@ defmodule EWallet.HelperTest do
       assert Helper.to_existing_atoms(["exists", "doesnt_exist_anywhere_z93Gh4g0f"]) == [:exists]
     end
   end
+
+  describe "members?/2" do
+    test "returns true if all elements exist in the enumerable" do
+      assert Helper.members?([1, 2, 3, 4, 5], [3, 4])
+    end
+
+    test "returns false if not all elements exist in the enumerable" do
+      refute Helper.members?([3, 4], [1, 2, 3, 4, 5])
+    end
+  end
 end


### PR DESCRIPTION
Issue/Task Number: T158

# Overview

Tests are randomly failing due to list assertions on returns that are not always sorted in the same order.

# Changes

- Added `EWallet.Helper.members?/2`
- Changed `AdminAPI.V1.SelfControllerTest` to use `EWallet.Helper.members?/2` instead of direct comparison of the lists.

# Implementation Details

We could easily fix this by adding an `order_by` to the query but this changes the nature of the query so it's not desirable. This fix instead creates a function `EWallet.Helper.members?/2` that checks if an enumerable is a subset of another regardless of the list order. It is less efficient than sorting the query, but in return it gives us tests with no extra side effects.

# Usage

Run `mix test` especially during CI process. Test failures from incorrect ordering should disappear.

# Impact

N/A