### PR TITLE
Implement account level limit

### DIFF
--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -1672,8 +1672,6 @@ components:
                 type: string
               description:
                 type: string
-              master:
-                type: string
               parent_id:
                 type: string
               metadata:
@@ -1685,7 +1683,6 @@ components:
             example:
               name: "Account Name"
               description: "The account description"
-              master: false
               parent_id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
               metadata: {}
               encrypted_metadata: {}
@@ -1703,8 +1700,6 @@ components:
                 type: string
               description:
                 type: string
-              master:
-                type: string
               metadata:
                 type: object
               encrypted_metadata:
@@ -1713,12 +1708,10 @@ components:
               - id
               - name
               - description
-              - master
             example:
               id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
               name: "Account Name"
               description: "The account description"
-              master: true
               metadata: {}
               encrypted_metadata: {}
     AccountListUsersBody:

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -1662,7 +1662,7 @@ components:
             example:
               id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
     AccountCreateBody:
-      description: The parameters to use for creating a new account
+      description: The parameters to use for creating a new account.
       required: true
       content:
         application/vnd.omisego.v1+json:
@@ -1674,6 +1674,8 @@ components:
                 type: string
               master:
                 type: string
+              parent_id:
+                type: string
               metadata:
                 type: object
               encrypted_metadata:
@@ -1683,7 +1685,8 @@ components:
             example:
               name: "Account Name"
               description: "The account description"
-              master: true
+              master: false
+              parent_id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
               metadata: {}
               encrypted_metadata: {}
     AccountUpdateBody:

--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -37,6 +37,7 @@ defmodule EWalletDB.Account do
     timestamps()
   end
 
+  @spec changeset(account :: %Account{}, attrs :: map()) :: Ecto.Changeset.t
   defp changeset(%Account{} = account, attrs) do
     account
     |> cast(attrs, [:name, :description, :parent_id, :metadata, :encrypted_metadata])
@@ -47,6 +48,7 @@ defmodule EWalletDB.Account do
     |> assoc_constraint(:parent)
   end
 
+  @spec avatar_changeset(changeset :: Ecto.Changeset.t, attrs :: map()) :: Ecto.Changeset.t
   defp avatar_changeset(changeset, attrs) do
     changeset
     |> cast_attachments(attrs, [:avatar])
@@ -55,6 +57,7 @@ defmodule EWalletDB.Account do
   @doc """
   Create a new account with the passed attributes, as well as a primary and a burn balances.
   """
+  @spec insert(attrs :: map()) :: {:ok, %Account{}} | {:error, Ecto.Changeset.t}
   def insert(attrs) do
     multi =
       Multi.new
@@ -78,6 +81,8 @@ defmodule EWalletDB.Account do
   @doc """
   Updates an account with the provided attributes.
   """
+  @spec update(account :: %Account{}, attrs :: map()) ::
+    {:ok, %Account{}} | {:error, Ecto.Changeset.t}
   def update(%Account{} = account, attrs) do
     changeset = changeset(account, attrs)
 
@@ -92,6 +97,8 @@ defmodule EWalletDB.Account do
   @doc """
   Inserts a balance for the given account.
   """
+  @spec insert_balance(account :: %Account{}, identifier :: String.t) ::
+    {:ok, %Balance{}} | {:error, Ecto.Changeset.t}
   def insert_balance(%Account{} = account, identifier) do
     %{
       account_id: account.id,
@@ -105,6 +112,7 @@ defmodule EWalletDB.Account do
   @doc """
   Stores an avatar for the given account.
   """
+  @spec store_avatar(account :: %Account{}, attrs :: map()) :: %Account{}
   def store_avatar(%Account{} = account, attrs) do
     attrs =
       case attrs["avatar"] do
@@ -124,6 +132,7 @@ defmodule EWalletDB.Account do
   @doc """
   Get all accounts.
   """
+  @spec all(opts :: keyword()) :: list(%Account{})
   def all(opts \\ [])
   def all(opts) do
     Account
@@ -134,6 +143,7 @@ defmodule EWalletDB.Account do
   @doc """
   Retrieves an account with the given ID.
   """
+  @spec get(id :: String.t, opts :: keyword()) :: %Account{} | nil
   def get(id, opts \\ []) do
     case UUID.cast(id) do
       {:ok, uuid} -> get_by([id: uuid], opts)
@@ -144,6 +154,7 @@ defmodule EWalletDB.Account do
   @doc """
   Retrieves an account using one or more fields.
   """
+  @spec get_by(fields :: map(), opts :: keyword()) :: %Account{}
   def get_by(fields, opts \\ []) do
     Account
     |> Repo.get_by(fields)
@@ -153,6 +164,7 @@ defmodule EWalletDB.Account do
   @doc """
   Returns whether the account is the master account.
   """
+  @spec master?(account :: %Account{}) :: boolean()
   def master?(account) do
     is_nil(account.parent_id)
   end
@@ -160,6 +172,7 @@ defmodule EWalletDB.Account do
   @doc """
   Get the master account for the current wallet setup.
   """
+  @spec get_preloaded_primary_balance(opts :: keyword()) :: %Account{}
   def get_master_account(opts \\ []) do
     Account
     |> where([a], is_nil(a.parent_id))
@@ -170,6 +183,7 @@ defmodule EWalletDB.Account do
   @doc """
   Retrieve the primary balance for an account with preloaded balances.
   """
+  @spec get_preloaded_primary_balance(account :: %Account{}) :: %Balance{}
   def get_preloaded_primary_balance(account) do
     Enum.find(account.balances, fn balance -> balance.identifier == Balance.primary end)
   end
@@ -177,6 +191,7 @@ defmodule EWalletDB.Account do
   @doc """
   Retrieve the primary balance for an account.
   """
+  @spec get_primary_balance(account :: %Account{}) :: %Balance{}
   def get_primary_balance(account) do
     get_balance_by_identifier(account, Balance.primary)
   end
@@ -184,6 +199,7 @@ defmodule EWalletDB.Account do
   @doc """
   Retrieve the default burn balance for an account.
   """
+  @spec get_default_burn_balance(account :: %Account{}) :: %Balance{}
   def get_default_burn_balance(account) do
     get_balance_by_identifier(account, Balance.burn)
   end
@@ -191,6 +207,7 @@ defmodule EWalletDB.Account do
   @doc """
   Retrieve a balance by name for the given account.
   """
+  @spec get_balance_by_identifier(account :: %Account{}, identifier :: String.t) :: %Balance{}
   def get_balance_by_identifier(account, identifier) do
     Balance
     |> where([b], b.identifier == ^identifier)
@@ -203,6 +220,7 @@ defmodule EWalletDB.Account do
 
   The master account has a relative depth of 0.
   """
+  @spec get_depth(account :: %Account{} | account_id :: String.t) :: non_neg_integer()
   def get_depth(%Account{} = account), do: get_depth(account.id)
   def get_depth(account_id) do
     case Account.get_master_account() do
@@ -215,6 +233,7 @@ defmodule EWalletDB.Account do
     end
   end
 
+  @spec query_depth(account_id :: String.t, parent_account_id :: String.t) :: Ecto.Query.t
   defp query_depth(account_id, parent_account_id) do
     # Traverses up the account tree and count each step up until it reaches the master account.
     from a in Account,

--- a/apps/ewallet_db/lib/ewallet_db/account_validator.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account_validator.ex
@@ -8,6 +8,7 @@ defmodule EWalletDB.AccountValidator do
   @doc """
   Validates that there can be only one master account in the system.
   """
+  @spec validate_parent_id(changeset :: Ecto.Changeset.t) :: Ecto.Changeset.t
   def validate_parent_id(changeset) do
     # Require a `parent_id` if:
     #   1. This changeset has `parent_id` == nil
@@ -35,6 +36,8 @@ defmodule EWalletDB.AccountValidator do
     - `2` : valid if the account is the master account, its direct children, or one more level down
     - ...
   """
+  @spec validate_account_level(changeset :: Ecto.Changeset.t,
+                               child_level_limit :: non_neg_integer()) :: Ecto.Changeset.t
   def validate_account_level(changeset, child_level_limit) do
     with {_, parent_id} <- fetch_field(changeset, :parent_id),
          depth          <- Account.get_depth(parent_id),


### PR DESCRIPTION
Issue/Task Number: T157

# Overview

To prevent unnecessary complexity without observing real-life use cases first, we have decided to limit the number of account levels to 1 (one master account with uncapped direct children).

# Changes

- Add a new function `Account.get_depth/1` that returns the depth of the given account relative to the master account.
- Add new validator `AccountValidator.validate_account_level/2` that checks that the inserting/updating account does not go beyond the given max account level.
- Add this new validator above to the Account's changeset.

# Implementation Details

N/A

# Usage

Call `/admin/api/account.create` or `/admin/api/account.update` and try to set the account's parent to a parent that already reached the maximum account level (i.e. you should not be able to create an account that does not have the master account as its parent).

# Impact

N/A