### PR TITLE
Improve insufficient funds error

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -140,8 +140,8 @@ defmodule AdminAPI.V1.ErrorHandler do
   Handles response of insufficient funds error.
   Duplicate from eWalletAPI ErrorHandler, will be refactored in error merge.
   """
-  def handle_error(conn, :insufficient_funds, d) do
-    handle_error(conn, "transaction:insufficient_funds", d)
+  def handle_error(conn, :insufficient_funds, data) do
+    handle_error(conn, "transaction:insufficient_funds", data)
   end
   def handle_error(conn, "transaction:insufficient_funds", %{
     "address" => address,

--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -7,6 +7,7 @@ defmodule AdminAPI.V1.ErrorHandler do
   import Plug.Conn, only: [halt: 1]
   alias Ecto.Changeset
   alias EWallet.Web.V1.{ErrorSerializer, ResponseSerializer}
+  alias EWalletDB.MintedToken
 
   @errors %{
     invalid_auth_scheme: %{
@@ -130,8 +131,35 @@ defmodule AdminAPI.V1.ErrorHandler do
 
     respond(conn, code, description, messages)
   end
+
   def handle_error(conn, :invalid_parameter, description) do
     respond(conn, @errors.invalid_parameter.code, description)
+  end
+
+  @doc """
+  Handles response of insufficient funds error.
+  Duplicate from eWalletAPI ErrorHandler, will be refactored in error merge.
+  """
+  def handle_error(conn, :insufficient_funds, d) do
+    handle_error(conn, "transaction:insufficient_funds", d)
+  end
+  def handle_error(conn, "transaction:insufficient_funds", %{
+    "address" => address,
+    "current_amount" => current_amount,
+    "amount_to_debit" => amount_to_debit,
+    "friendly_id" => friendly_id
+  }) do
+    minted_token = MintedToken.get(friendly_id)
+    current_amount = :erlang.float_to_binary(current_amount / minted_token.subunit_to_unit,
+                                             [:compact, {:decimals, 1}])
+    amount_to_debit = :erlang.float_to_binary(amount_to_debit / minted_token.subunit_to_unit,
+                                             [:compact, {:decimals, 18}])
+
+    description = "The specified balance (#{address}) does not contain enough funds. " <>
+                  "Available: #{current_amount} #{friendly_id} - Attempted debit: " <>
+                  "#{amount_to_debit} #{friendly_id}"
+
+    respond(conn, "transaction:insufficient_funds", description)
   end
 
   @doc """

--- a/apps/ewallet/test/ewallet/gates/transaction_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_gate_test.exs
@@ -129,11 +129,10 @@ defmodule EWallet.TransactionGateTest do
       {balance1, balance2, token} = insert_addresses_records()
       attrs = build_addresses_attrs(idempotency_token, balance1, balance2, token)
 
-      {status, transfer, code, description} = TransactionGate.process_with_addresses(attrs)
+      {status, transfer, code, _description} = TransactionGate.process_with_addresses(attrs)
       assert status == :error
       assert transfer.status == Transfer.failed
       assert code == "transaction:insufficient_funds"
-      assert "The specified balance" <> _ = description
 
       transfer = Transfer.get_by(%{idempotency_token: idempotency_token})
       assert transfer.idempotency_token == idempotency_token
@@ -149,7 +148,12 @@ defmodule EWallet.TransactionGateTest do
 
       assert %{
         "code" => "transaction:insufficient_funds",
-        "description" => "The specified balance" <> _
+        "description" => %{
+          "address" => _,
+          "current_amount" => _,
+          "amount_to_debit" => _,
+          "friendly_id" => _
+        }
       } = transfer.ledger_response
       assert transfer.metadata == %{"some" => "data"}
     end
@@ -323,11 +327,10 @@ defmodule EWallet.TransactionGateTest do
       attrs = build_debit_credit_attrs(idempotency_token, inserted_account,
                                        inserted_user, inserted_token)
 
-      {status, transfer, code, description} = TransactionGate.process_credit_or_debit(attrs)
+      {status, transfer, code, _description} = TransactionGate.process_credit_or_debit(attrs)
       assert transfer.status == "failed"
       assert status == :error
       assert code == "transaction:insufficient_funds"
-      assert "The specified balance" <> _ = description
 
       transfer = Transfer.get_by(%{idempotency_token: idempotency_token})
       assert transfer.idempotency_token == idempotency_token
@@ -343,7 +346,12 @@ defmodule EWallet.TransactionGateTest do
       }
       assert %{
         "code" => "transaction:insufficient_funds",
-        "description" => "The specified balance" <> _
+        "description" => %{
+          "address" => _,
+          "current_amount" => _,
+          "amount_to_debit" => _,
+          "friendly_id" => _
+        }
       } = transfer.ledger_response
       assert transfer.metadata == %{"some" => "data"}
     end

--- a/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
@@ -70,8 +70,13 @@
 
       assert transfer.status == Transfer.failed
       assert transfer.ledger_response["code"] == "transaction:insufficient_funds"
-      assert transfer.ledger_response["description"] == "The specified balance (#{attrs[:from]})" <>
-                            " does not contain enough funds. Available: 100000 #{attrs[:minted_token_friendly_id]} - Attempted debit: 1000000 #{attrs[:minted_token_friendly_id]}"
+      assert transfer.ledger_response["description"] == %{
+        "address" => attrs[:from],
+        "amount_to_debit" => 1_000_000,
+        "current_amount" => 100_000,
+        "friendly_id" => attrs[:minted_token_friendly_id]
+      }
+
       assert transfer.status == Transfer.failed
     end
   end

--- a/apps/ewallet_api/lib/ewallet_api/v1/error_handler.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/error_handler.ex
@@ -6,6 +6,7 @@ defmodule EWalletAPI.V1.ErrorHandler do
   import Phoenix.Controller, only: [json: 2]
   import Plug.Conn, only: [halt: 1]
   alias EWallet.Web.V1.{ErrorSerializer, ResponseSerializer}
+  alias EWalletDB.MintedToken
 
   @errors %{
     invalid_auth_scheme: %{
@@ -126,6 +127,31 @@ defmodule EWalletAPI.V1.ErrorHandler do
       error_fields(changeset)
 
     respond(conn, code, description, messages)
+  end
+
+  @doc """
+  Handles response of insufficient funds error.
+  """
+  def handle_error(conn, :insufficient_funds, d) do
+    handle_error(conn, "transaction:insufficient_funds", d)
+  end
+  def handle_error(conn, "transaction:insufficient_funds", %{
+    "address" => address,
+    "current_amount" => current_amount,
+    "amount_to_debit" => amount_to_debit,
+    "friendly_id" => friendly_id
+  }) do
+    minted_token = MintedToken.get(friendly_id)
+    current_amount = :erlang.float_to_binary(current_amount / minted_token.subunit_to_unit,
+                                             [:compact, {:decimals, 1}])
+    amount_to_debit = :erlang.float_to_binary(amount_to_debit / minted_token.subunit_to_unit,
+                                             [:compact, {:decimals, 18}])
+
+    description = "The specified balance (#{address}) does not contain enough funds. " <>
+                  "Available: #{current_amount} #{friendly_id} - Attempted debit: " <>
+                  "#{amount_to_debit} #{friendly_id}"
+
+    respond(conn, "transaction:insufficient_funds", description)
   end
 
   @doc """

--- a/apps/ewallet_api/lib/ewallet_api/v1/error_handler.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/error_handler.ex
@@ -132,8 +132,8 @@ defmodule EWalletAPI.V1.ErrorHandler do
   @doc """
   Handles response of insufficient funds error.
   """
-  def handle_error(conn, :insufficient_funds, d) do
-    handle_error(conn, "transaction:insufficient_funds", d)
+  def handle_error(conn, :insufficient_funds, data) do
+    handle_error(conn, "transaction:insufficient_funds", data)
   end
   def handle_error(conn, "transaction:insufficient_funds", %{
     "address" => address,

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -155,8 +155,8 @@ defmodule EWalletAPI.V1.TransferControllerTest do
         "data" => %{
           "code" => "transaction:insufficient_funds",
           "description" => "The specified balance (#{balance1.address}) does not " <>
-          "contain enough funds. Available: 0 #{minted_token.friendly_id} - " <>
-          "Attempted debit: 10000000 #{minted_token.friendly_id}",
+          "contain enough funds. Available: 0.0 #{minted_token.friendly_id} - " <>
+          "Attempted debit: 100000.0 #{minted_token.friendly_id}",
           "messages" => nil,
           "object" => "error"
         }
@@ -450,8 +450,8 @@ defmodule EWalletAPI.V1.TransferControllerTest do
         "data" => %{
           "code" => "transaction:insufficient_funds",
           "description" => "The specified balance (#{user_balance.address})" <>
-          " does not contain enough funds. Available: 0 " <>
-          "#{minted_token.friendly_id} - Attempted debit: 100000 " <>
+          " does not contain enough funds. Available: 0.0 " <>
+          "#{minted_token.friendly_id} - Attempted debit: 1000.0 " <>
           "#{minted_token.friendly_id}",
           "messages" => nil,
           "object" => "error"

--- a/apps/local_ledger_db/lib/local_ledger_db/errors/insufficient_funds_error.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/errors/insufficient_funds_error.ex
@@ -7,8 +7,11 @@ defmodule LocalLedgerDB.Errors.InsufficientFundsError do
     friendly_id: friendly_id,
     address: address
   }) do
-    "The specified balance (#{address}) does not contain enough funds. " <>
-    "Available: #{current_amount} #{friendly_id} - Attempted debit: " <>
-    "#{amount_to_debit} #{friendly_id}"
+    %{
+      address: address,
+      current_amount: current_amount,
+      amount_to_debit: amount_to_debit,
+      friendly_id: friendly_id
+    }
   end
 end


### PR DESCRIPTION
Issue/Task Number: T9

# Overview

This PR uses the `subunit_to_unit` from minted token to present more readable errors when funds are not sufficient for a transaction.

# Changes

- Move error message to eWalletAPI / AdminAPI for insufficient funds
- Format amounts as floats
- Update tests

# Implementation Details

In order to show the actual amount, we need the minted token which cannot be retrieved in the local ledger, therefore it was moved in the API. 

# Note

The code is duplicated in the error handlers, but the refactoring of the error handling is coming soon and will unify those.
