### PR TITLE
Set HOME after dropping privileges before running migration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,17 @@ podTemplate(
                     sh("kubectl rollout status --namespace=staging deployment/ewallet")
 
                     def podID = getPodID('--namespace=staging -l app=ewallet')
-                    sh("kubectl exec ${podID} --namespace=staging s6-setuidgid ewallet mix ecto.migrate")
+
+                    sh(
+                        """
+                        kubectl exec ${podID} --namespace=staging -- \
+                            /bin/execlineb -P -c " \
+                                s6-setuidgid ewallet \
+                                s6-env HOME=/tmp/ewallet \
+                                mix ecto.migrate \
+                            " \
+                        """.stripIndent()
+                    )
                 }
             }
         } else if (env.BRANCH_NAME == 'master') {


### PR DESCRIPTION
Fix staging deploy failure. This is due to `s6-setuidgid` will only set the UID/GID and leave updating user env to the user. When mix tried to look for the `.erlang` during migration, it will look at `$HOME` (`/root`) which failed due to lack of permissions. This fix simply add `s6-env HOME=/tmp/ewallet` to the migration command (as well as explicitly calling `execlineb`).