### PR TITLE
Add SENDER_EMAIL to env docs

### DIFF
--- a/docs/setup/env.md
+++ b/docs/setup/env.md
@@ -62,6 +62,7 @@ Strategies available:
 
 To enable emails in the eWallet (for forget password or inviting admins), you'll need to set the following environment variables:
 
+- `SENDER_EMAIL`: The email address to appear as the sender.
 - `SMTP_HOST`: Your email server domain name.
 - `SMTP_PORT`: The port used to connect to your email server.
 - `SMTP_USER`: Identifier to use your email server.


### PR DESCRIPTION
Issue/Task Number: T177

# Overview

This PR adds to the env documentation that the sender email address can be configured via `SENDER_EMAIL` environment variable.

# Changes

- Add `SENDER_EMAIL` to `docs/env.md`

# Implementation Details

N/A

# Usage

N/A

# Impact

N/A