### PR TITLE
Disable check_origin for web socket Endpoint

### DIFF
--- a/apps/ewallet_api/config/prod.exs
+++ b/apps/ewallet_api/config/prod.exs
@@ -1,5 +1,9 @@
 use Mix.Config
 
+config :ewallet_api, EWalletAPI.V1.Endpoint,
+  debug_errors: true,
+  check_origin: false
+
 # For production, we often load configuration from external
 # sources, such as your system environment. For this reason,
 # you won't find the :http configuration below, but set inside


### PR DESCRIPTION
Issue/Task Number: T181

# Overview

Currently getting the following error when trying to use the websockets in staging:

```
03:04:00.062 [error] Could not check origin for Phoenix.Socket transport.

This happens when you are attempting a socket connection to
a different host than the one configured in your config/
files. For example, in development the host is configured
to "localhost" but you may be trying to access it from
"127.0.0.1". To fix this issue, you may either:

  1. update [url: [host: ...]] to your actual host in the
     config file for your current environment (recommended)

  2. pass the :check_origin option when configuring your
     endpoint or when configuring the transport in your
     UserSocket module, explicitly outlining which origins
     are allowed:

        check_origin: ["https://example.com",
                       "//another.com:888", "//other.com"]
```

This PR disables the `check_origin` by setting it to `false` to allow anyone to connect.

# Changes

- Disable `check_origin`
- Set `debut_errors` to debug websockets

# Impact

Anyone will be able to connect to the websocket and try to authenticate.