### PR TITLE
Fix docker setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $ docker run \
     omisego/ewallet:latest
 ```
 
-Then run `docker exec <container-id> mix ecto.create, ecto.migrate` to setup the database.
+Then run `docker exec <container-id> mix do ecto.create, ecto.migrate` to setup the database.
 
 ## Quick installation with Goban
 


### PR DESCRIPTION
Issue/Task Number: N/A

# Overview

Fixes a typo on docker instructions in the README. Thanks to "fumi" from Rocket Chat channel for spotting this issue.

# Changes

N/A

# Implementation Details

N/A

# Usage

N/A

# Impact

N/A