### PR TITLE
Add minting token endpoints

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -25,6 +25,7 @@ defmodule AdminAPI.V1.Router do
     post "/minted_token.all", MintedTokenController, :all
     post "/minted_token.get", MintedTokenController, :get
     post "/minted_token.create", MintedTokenController, :create
+    post "/minted_token.mint", MintedTokenController, :mint
 
     # Transaction endpoints
     post "/transaction.all", TransactionController, :all

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -1644,7 +1644,7 @@ components:
           application/vnd.omisego.v1+json:
             schema:
               properties:
-                minted_token_id:
+                id:
                   type: string
                 amount:
                   type: integer

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -168,6 +168,22 @@ paths:
           $ref: "#/components/responses/MintedTokenResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
+  # Endpoint to create a new minted token
+  /minted_token.mint:
+    post:
+      tags:
+        - Minted Token
+      summary: Mint an existing minted token
+      operationId: minted_token_mint
+      security:
+        - UserAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/MintedTokenMintBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/MintedTokenResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
   ############################
   #         ACCOUNTS         #
   ############################
@@ -1620,6 +1636,24 @@ components:
                 name: "Bitcoin"
                 description: "desc"
                 subunit_to_unit: 100
+    # Request body for minting a minted token
+    MintedTokenMintBody:
+        description: The parameters to create a minted token. Note that if amount is specified, the token will be minted automatically.
+        required: true
+        content:
+          application/vnd.omisego.v1+json:
+            schema:
+              properties:
+                minted_token_id:
+                  type: string
+                amount:
+                  type: integer
+              required:
+                - id
+                - amount
+              example:
+                id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+                amount: 1000
     # Request body for listing accounts
     AccountAllBody:
       description: The parameters to use for listing the accounts

--- a/apps/admin_api/test/admin_api/v1/controllers/minted_token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/minted_token_controller_test.exs
@@ -228,7 +228,7 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided. `amount` must be greater than %{number}."
+      assert response["data"]["description"] == "Invalid parameter provided `amount` must be greater than %{number}."
       assert response["data"]["messages"] == %{"amount" => ["number"]}
     end
 
@@ -243,7 +243,7 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided. `amount` must be greater than %{number}."
+      assert response["data"]["description"] == "Invalid parameter provided `amount` must be greater than %{number}."
       assert response["data"]["messages"] == %{"amount" => ["number"]}
     end
   end

--- a/apps/ewallet_db/lib/ewallet_db/mint.ex
+++ b/apps/ewallet_db/lib/ewallet_db/mint.ex
@@ -27,9 +27,16 @@ defmodule EWalletDB.Mint do
 
   defp changeset(%Mint{} = minted_token, attrs) do
     minted_token
-    |> cast(attrs, [:description, :amount, :minted_token_id, :confirmed, :transfer_id])
-    |> validate_required([:amount, :minted_token_id, :transfer_id])
+    |> cast(attrs, [:description, :amount, :minted_token_id, :confirmed])
+    |> validate_required([:amount, :minted_token_id])
+    |> validate_number(:amount, greater_than: 0)
     |> assoc_constraint(:minted_token)
+  end
+
+  defp update_changeset(%Mint{} = minted_token, attrs) do
+    minted_token
+    |> cast(attrs, [:transfer_id])
+    |> validate_required([:transfer_id])
     |> assoc_constraint(:transfer)
   end
 
@@ -40,6 +47,22 @@ defmodule EWalletDB.Mint do
     %Mint{}
     |> changeset(attrs)
     |> Repo.insert()
+  end
+
+  @doc """
+  Updates a mint with the provided attributes.
+  """
+  @spec update(mint :: %Mint{}, attrs :: map()) ::
+    {:ok, %Mint{}} | {:error, Ecto.Changeset.t}
+  def update(%Mint{} = mint, attrs) do
+    changeset = update_changeset(mint, attrs)
+
+    case Repo.update(changeset) do
+      {:ok, mint} ->
+        {:ok, mint}
+      result ->
+        result
+    end
   end
 
   @doc """


### PR DESCRIPTION
Issue/Task Number: T192

# Overview

The possibility to mint tokens (add more in circulation) was missing from the Admin API. This PR fixes that.

# Changes

- Add a new endpoint: `minted_token.mint`
- Add tests
- Update swagger docs

# Implementation Details

Not much to describe here, just a new endpoint using the existing minting mechanism.

# Usage

Give it an ID and an amount and you should be able to mint.

