### PR TITLE
Add transaction consumption current count

### DIFF
--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
@@ -9,7 +9,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
   alias EWalletDB.TransactionRequest
 
   def serialize(%TransactionRequest{} = transaction_request) do
-    transaction_request = Repo.preload(transaction_request, :minted_token)
+    transaction_request = Repo.preload(transaction_request, [:minted_token, :consumptions])
 
     %{
       object: "transaction_request",
@@ -25,6 +25,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
       user_id: transaction_request.user_id,
       account_id: transaction_request.account_id,
       require_confirmation: transaction_request.require_confirmation,
+      current_consumptions_count: length(transaction_request.consumptions),
       max_consumptions: transaction_request.max_consumptions,
       consumption_lifetime: transaction_request.consumption_lifetime,
       expiration_reason: transaction_request.expiration_reason,

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
@@ -8,6 +8,8 @@ defmodule EWallet.Web.V1.TransactionRequestSerializerTest do
     test "serializes into correct V1 transaction_request format" do
       request = insert(:transaction_request)
       transaction_request = TransactionRequest.get(request.id, preload: [:minted_token])
+      insert(:transaction_consumption, transaction_request_id: request.id)
+      insert(:transaction_consumption, transaction_request_id: request.id)
 
       expected = %{
         object: "transaction_request",
@@ -31,6 +33,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializerTest do
         expiration_reason: nil,
         expired_at: nil,
         max_consumptions: nil,
+        current_consumptions_count: 2,
         created_at: Date.to_iso8601(transaction_request.inserted_at),
         updated_at: Date.to_iso8601(transaction_request.updated_at)
       }

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -43,6 +43,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           "expiration_reason" => nil,
           "expired_at" => nil,
           "max_consumptions" => nil,
+          "current_consumptions_count" => 0,
           "metadata" => %{},
           "created_at" => Date.to_iso8601(request.inserted_at),
           "updated_at" => Date.to_iso8601(request.updated_at)
@@ -90,6 +91,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           "expiration_reason" => nil,
           "expired_at" => nil,
           "max_consumptions" => nil,
+          "current_consumptions_count" => 0,
           "created_at" => Date.to_iso8601(request.inserted_at),
           "updated_at" => Date.to_iso8601(request.updated_at)
         }
@@ -235,6 +237,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           "expiration_reason" => nil,
           "expired_at" => nil,
           "max_consumptions" => nil,
+          "current_consumptions_count" => 0,
           "created_at" => Date.to_iso8601(request.inserted_at),
           "updated_at" => Date.to_iso8601(request.updated_at)
         }
@@ -277,6 +280,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           "expiration_reason" => nil,
           "expired_at" => nil,
           "max_consumptions" => nil,
+          "current_consumptions_count" => 0,
           "type" => "send",
           "status" => "valid",
           "user_id" => user.id,


### PR DESCRIPTION
Issue/Task Number: T198

# Overview

@mederic-p requested a way to see how many consumptions had been made for a request. This PR fixes that.

# Changes

- Add `current_consumptions_count`