### PR TITLE
Remove parent_id as mandatory for account creation

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
@@ -74,8 +74,11 @@ defmodule AdminAPI.V1.AccountController do
 
   The requesting user must have write permission on the given parent account.
   """
-  def create(conn, %{"parent_id" => parent_id} = attrs) do
+  def create(conn, attrs) do
+    parent_id = attrs["parent_id"] || Account.get_master_account().id
+
     with :ok            <- permit(:create, conn.assigns.user.id, parent_id),
+         attrs          <- Map.put(attrs, "parent_id", parent_id),
          {:ok, account} <- Account.insert(attrs)
     do
       render(conn, :account, %{account: account})

--- a/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
@@ -88,6 +88,24 @@ defmodule AdminAPI.V1.AccountControllerTest do
       assert response["success"] == true
       assert response["data"]["object"] == "account"
       assert response["data"]["name"] == request_data.name
+      assert response["data"]["parent_id"] == parent.external_id
+      assert response["data"]["metadata"] == %{"something" => "interesting"}
+      assert response["data"]["encrypted_metadata"] == %{"something" => "secret"}
+    end
+
+    test "creates a new account with no parent_id" do
+      parent       = Account.get_master_account()
+      request_data = params_for(:account, %{
+        parent_id: parent.external_id,
+        metadata: %{something: "interesting"},
+        encrypted_metadata: %{something: "secret"}
+      })
+      response     = user_request("/account.create", request_data)
+
+      assert response["success"] == true
+      assert response["data"]["object"] == "account"
+      assert response["data"]["name"] == request_data.name
+      assert response["data"]["parent_id"] == parent.external_id
       assert response["data"]["metadata"] == %{"something" => "interesting"}
       assert response["data"]["encrypted_metadata"] == %{"something" => "secret"}
     end


### PR DESCRIPTION
Issue/Task Number: T200

# Overview

The `parent_id` should not be mandatory to create account.

# Changes

- Remove `parent_id` as mandatory from account creation in Admin API.
