### PR TITLE
Fix build where mix dependencies are being resolved twice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,7 @@ RUN set -xe && \
         if { mix local.rebar --force } \
         if { mix deps.get } \
         mix compile \
-        rm -rf /tmp/ewallet \
-    " && \
-    mix local.hex --force && \
-    mix local.rebar --force && \
-    mix deps.get && \
-    MIX_ENV=prod mix compile
+        rm -rf /tmp/ewallet"
 
 RUN set -xe && \
     SERVICE_DIR=/etc/services.d/ewallet/ && \


### PR DESCRIPTION
Fix a build process where mix deps and compilation are being done twice, once with `ewallet` user and again with `root` user.