### PR TITLE
T201 Transaction Request Improvements

### DIFF
--- a/apps/ewallet/lib/ewallet/gates/transaction_consumption_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_consumption_gate.ex
@@ -157,7 +157,8 @@ defmodule EWallet.TransactionConsumptionGate do
   def confirm(id, approved, %User{} = user) do
     with {:ok, consumption} <- get(id),
          true <- consumption.transaction_request.user_id == user.id ||
-                 {:error, :not_transaction_request_owner}
+                 {:error, :not_transaction_request_owner},
+         {:ok, _} <- TransactionRequestGate.validate_request(consumption.transaction_request)
     do
       do_confirm(consumption, approved)
     else
@@ -168,7 +169,8 @@ defmodule EWallet.TransactionConsumptionGate do
   def confirm(id, approved, %Account{} = account) do
     with {:ok, consumption} <- get(id),
          true <- consumption.transaction_request.account_id == account.id ||
-                 {:error, :not_transaction_request_owner}
+                 {:error, :not_transaction_request_owner},
+         {:ok, _} <- TransactionRequestGate.validate_request(consumption.transaction_request)
     do
       do_confirm(consumption, approved)
     else

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -77,8 +77,8 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     max_consumptions_reached: %{
       code: "transaction_request:max_consumptions_reached",
-      description: "The specified transaction request has reached the allowed amount " <>
-                   "of consumptions."
+      description:
+        "The specified transaction request has reached the allowed amount of consumptions."
     },
     not_transaction_request_owner: %{
       code: "transaction_consumption:not_owner",

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -80,6 +80,10 @@ defmodule EWallet.Web.V1.ErrorHandler do
       description:
         "The specified transaction request has reached the allowed amount of consumptions."
     },
+    unauthorized_amount_override: %{
+      code: "transaction_request:unauthorized_amount_override",
+      description: "The amount for this transaction request cannot be overridden."
+    },
     not_transaction_request_owner: %{
       code: "transaction_consumption:not_owner",
       description: "The given consumption can only be approved by the transaction request owner."

--- a/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
@@ -6,7 +6,8 @@ defmodule EWalletDB.TransactionRequest do
   import Ecto.{Changeset, Query}
   import EWalletDB.Helpers.Preloader
   import EWalletDB.Validator
-  alias Ecto.UUID
+  alias Ecto.{UUID, Changeset}
+
   alias EWalletDB.{TransactionRequest, TransactionConsumption,
                    Repo, MintedToken, User, Balance, Helpers}
 
@@ -64,6 +65,7 @@ defmodule EWalletDB.TransactionRequest do
       :type, :status, :minted_token_id, :balance_address
     ])
     |> validate_required_exclusive([:account_id, :user_id])
+    |> validate_amount_if_disallow_override()
     |> validate_inclusion(:type, @types)
     |> validate_inclusion(:status, @statuses)
     |> unique_constraint(:correlation_id)
@@ -86,6 +88,18 @@ defmodule EWalletDB.TransactionRequest do
     |> cast(attrs, [:updated_at])
     |> validate_required([:updated_at])
   end
+
+  defp validate_amount_if_disallow_override(changeset) do
+    amount                = Changeset.get_field(changeset, :amount)
+    allow_amount_override = Changeset.get_field(changeset, :allow_amount_override)
+
+    validate_amount_if_disallow_override(changeset, allow_amount_override, amount)
+  end
+  defp validate_amount_if_disallow_override(changeset, false, nil) do
+    Changeset.add_error(changeset,
+                        :amount, "needs to be set if amount override is not allowed.")
+  end
+  defp validate_amount_if_disallow_override(changeset, _, _amount), do: changeset
 
   @doc """
   Gets a transaction request.

--- a/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
@@ -110,7 +110,36 @@ defmodule EWalletDB.TransactionRequestTest do
         :transaction_request
         |> params_for(type: "fake")
         |> TransactionRequest.insert()
+
       assert changeset.errors == [type: {"is invalid", [validation: :inclusion]}]
+    end
+
+    test "allows creation with an amount equal to nil" do
+      {res, _inserted} =
+        :transaction_request
+        |> params_for(amount: nil)
+        |> TransactionRequest.insert()
+
+      assert res == :ok
+    end
+
+    test "allows creation with 'allow_amount_override=true' and nil amount" do
+      {res, _inserted} =
+        :transaction_request
+        |> params_for(allow_amount_override: true, amount: nil)
+        |> TransactionRequest.insert()
+
+      assert res == :ok
+    end
+
+    test "prevents creation with 'allow_amount_override=false' and nil amount" do
+      {:error, changeset} =
+        :transaction_request
+        |> params_for(allow_amount_override: false, amount: nil)
+        |> TransactionRequest.insert()
+
+      assert changeset.errors == [{:amount,
+                                  {"needs to be set if amount override is not allowed.", []}}]
     end
   end
 


### PR DESCRIPTION
Issue/Task Number: T201

# Overview

This PR adds some minor changes to the transaction request flow.

# Changes

- Check the expiration date before approving or rejecting a consumption.
- Should not be able to create a transaction request if allow amount override is false and amount is nil.
- Unauthorized amount override error not handled by `ErrorHandler`.
- Remove newline from error description.
