### PR TITLE
Make Admin API Keys optional

### DIFF
--- a/apps/admin_api/config/config.exs
+++ b/apps/admin_api/config/config.exs
@@ -9,7 +9,8 @@ use Mix.Config
 config :admin_api,
   namespace: AdminAPI,
   ecto_repos: [],
-  sender_email: System.get_env("SENDER_EMAIL") || "admin@localhost"
+  sender_email: System.get_env("SENDER_EMAIL") || "admin@localhost",
+  enable_client_auth: System.get_env("ENABLE_ADMIN_CLIENT_AUTH") || "false"
 
 # Configs for the endpoint
 config :admin_api,

--- a/apps/admin_api/config/config.exs
+++ b/apps/admin_api/config/config.exs
@@ -10,7 +10,7 @@ config :admin_api,
   namespace: AdminAPI,
   ecto_repos: [],
   sender_email: System.get_env("SENDER_EMAIL") || "admin@localhost",
-  enable_client_auth: System.get_env("ENABLE_ADMIN_CLIENT_AUTH") || "false"
+  enable_client_auth: System.get_env("ENABLE_ADMIN_CLIENT_AUTH") == "true"
 
 # Configs for the endpoint
 config :admin_api,

--- a/apps/admin_api/config/test.exs
+++ b/apps/admin_api/config/test.exs
@@ -6,6 +6,9 @@ config :admin_api, AdminAPI.Endpoint,
   secret_key_base: "G1DLBdjjJSoSiQRa5Gf8YrWUx5yrX+JFmZx+UBk829W1+e0oJ9TYrW/GkIgrAdfm",
   server: false
 
+config :admin_api,
+  enable_client_auth: "true"
+
 # Configs for Bamboo emailing library
 config :admin_api, AdminAPI.Mailer,
   adapter: Bamboo.TestAdapter

--- a/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
@@ -11,10 +11,18 @@ defmodule AdminAPI.V1.ClientAuthPlug do
 
   def init(opts), do: opts
 
-  def call(conn, _opts) do
-    conn
-    |> parse_header()
-    |> authenticate()
+  def call(conn, opts) do
+    auth = Keyword.get(opts, :enable_client_auth,
+                       Application.get_env(:admin_api, :enable_client_auth))
+
+    case auth do
+      "true" ->
+        conn
+        |> parse_header()
+        |> authenticate()
+      _ ->
+        assign(conn, :authenticated, :client)
+    end
   end
 
   defp parse_header(conn) do

--- a/apps/admin_api/lib/admin_api/v1/plugs/user_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/user_auth_plug.ex
@@ -18,29 +18,48 @@ defmodule AdminAPI.V1.UserAuthPlug do
 
   def init(opts), do: opts
 
-  def call(conn, _opts) do
+  def call(conn, opts) do
+    auth = Keyword.get(opts, :enable_client_auth,
+                       Application.get_env(:admin_api, :enable_client_auth))
+
+    case auth do
+      "true" ->
+        conn
+        |> parse_header()
+        |> ClientAuthPlug.authenticate()
+        |> authenticate_token()
+      _ ->
+        conn
+        |> parse_header()
+        |> authenticate_token()
+    end
+  end
+
+  defp get_header(conn) do
     conn
-    |> parse_header()
-    |> ClientAuthPlug.authenticate()
-    |> authenticate_token()
+    |> get_req_header("authorization")
+    |> List.first()
   end
 
   defp parse_header(conn) do
-    header =
-      conn
-      |> get_req_header("authorization")
-      |> List.first()
-
-    with header when not is_nil(header) <- header,
+    with header when not is_nil(header) <- get_header(conn),
          [scheme, content] <- String.split(header, " ", parts: 2),
          true <- scheme in ["OMGAdmin"],
          {:ok, decoded} <- Base.decode64(content),
-         [key_id, key, user_id, token] <- String.split(decoded, ":", parts: 4) do
-      conn
-      |> put_private(:auth_api_key_id, key_id) # Used by ClientAuthPlug.authenticate/1
-      |> put_private(:auth_api_key, key) # Used by ClientAuthPlug.authenticate/1
-      |> put_private(:auth_user_id, user_id)
-      |> put_private(:auth_auth_token, token)
+         keys <- String.split(decoded, ":", parts: 4)
+    do
+      case keys do
+        [key_id, key, user_id, token] ->
+          conn
+          |> put_private(:auth_api_key_id, key_id)
+          |> put_private(:auth_api_key, key)
+          |> put_private(:auth_user_id, user_id)
+          |> put_private(:auth_auth_token, token)
+        [user_id, token] ->
+          conn
+          |> put_private(:auth_user_id, user_id)
+          |> put_private(:auth_auth_token, token)
+      end
     else
       _ ->
         conn

--- a/apps/admin_api/lib/admin_api/v1/plugs/user_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/user_auth_plug.ex
@@ -16,13 +16,13 @@ defmodule AdminAPI.V1.UserAuthPlug do
   alias EWalletDB.{AuthToken, User}
   alias AdminAPI.V1.ClientAuthPlug
 
-  def init(opts), do: opts
+  def init(opts) do
+    Keyword.put_new(opts, :enable_client_auth,
+                          Application.get_env(:admin_api, :enable_client_auth))
+  end
 
   def call(conn, opts) do
-    auth = Keyword.get(opts, :enable_client_auth,
-                       Application.get_env(:admin_api, :enable_client_auth))
-
-    case auth do
+    case Keyword.get(opts, :enable_client_auth) do
       "true" ->
         conn
         |> parse_header()

--- a/apps/admin_api/test/admin_api/v1/plugs/client_auth_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/client_auth_plug_test.exs
@@ -4,6 +4,12 @@ defmodule AdminAPI.V1.ClientAuthPlugTest do
   alias Ecto.UUID
 
   describe "ClientAuthPlug.call/2" do
+    test "assigns authenticated conn info when auth is not enabled" do
+      conn = test_with_no_auth()
+      refute conn.halted
+      assert conn.assigns.authenticated == :client
+    end
+
     test "assigns authenticated conn info if the api_key_id and api_key match the db record" do
       conn = test_with("OMGAdmin", @api_key_id, @api_key)
       assert_success(conn)
@@ -49,6 +55,11 @@ defmodule AdminAPI.V1.ClientAuthPlugTest do
     build_conn()
     |> put_auth_header(type, data)
     |> ClientAuthPlug.call([])
+  end
+
+  defp test_with_no_auth do
+    build_conn()
+    |> ClientAuthPlug.call([enable_client_auth: false])
   end
 
   defp assert_success(conn) do

--- a/apps/admin_api/test/admin_api/v1/plugs/user_auth_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/user_auth_plug_test.exs
@@ -4,6 +4,13 @@ defmodule AdminAPI.V1.UserAuthPlugTest do
   alias Ecto.UUID
 
   describe "UserAuthPlug.call/2" do
+    test "assigns authenticated conn info if the token is correct without admin " do
+      conn = test_with("OMGAdmin", @user_id, @auth_token)
+
+      refute conn.halted
+      assert_success(conn)
+    end
+
     test "assigns authenticated conn info if the token is correct" do
       conn = test_with("OMGAdmin", @api_key_id, @api_key, @user_id, @auth_token)
 
@@ -67,6 +74,12 @@ defmodule AdminAPI.V1.UserAuthPlugTest do
     build_conn()
     |> put_auth_header(type, [api_key_id, api_key, user_id, auth_token])
     |> UserAuthPlug.call([])
+  end
+
+  defp test_with(type, user_id, auth_token) do
+    build_conn()
+    |> put_auth_header(type, [user_id, auth_token])
+    |> UserAuthPlug.call([enable_client_auth: false])
   end
 
   defp assert_success(conn) do


### PR DESCRIPTION
Issue/Task Number: T179

# Overview

This PR makes the admin API Keys optional (disabled by default).

# Changes

- Add a new ENV variable: `ENABLE_ADMIN_CLIENT_AUTH`, `"false"` by default.
- It stays enabled for the tests, but some tests were added to test it.
