### PR TITLE
Run Quantum in global mode

### DIFF
--- a/apps/ewallet_db/config/dev.exs
+++ b/apps/ewallet_db/config/dev.exs
@@ -14,6 +14,14 @@ config :cloak, Salty.SecretBox.Cloak,
 config :ewallet_db, EWalletDB.Scheduler,
   global: true,
   jobs: [
-    {"* * * * *", {EWalletDB.TransactionRequest, :expire_all, []}},
-    {"* * * * *", {EWalletDB.TransactionConsumption, :expire_all, []}}
+    expire_requests: [
+      schedule: "* * * * *",
+      task: {EWalletDB.TransactionRequest, :expire_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
+    ],
+    expire_consumptions: [
+      schedule: "* * * * *",
+      task: {EWalletDB.TransactionConsumption, :expire_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster} 
+    ]
   ]

--- a/apps/ewallet_db/config/dev.exs
+++ b/apps/ewallet_db/config/dev.exs
@@ -22,6 +22,6 @@ config :ewallet_db, EWalletDB.Scheduler,
     expire_consumptions: [
       schedule: "* * * * *",
       task: {EWalletDB.TransactionConsumption, :expire_all, []},
-      run_strategy: {Quantum.RunStrategy.Random, :cluster} 
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
     ]
   ]

--- a/apps/ewallet_db/config/dev.exs
+++ b/apps/ewallet_db/config/dev.exs
@@ -12,6 +12,7 @@ config :cloak, Salty.SecretBox.Cloak,
        keys: [%{tag: <<1>>, key: key, default: true}]
 
 config :ewallet_db, EWalletDB.Scheduler,
+  global: true,
   jobs: [
     {"* * * * *", {EWalletDB.TransactionRequest, :expire_all, []}},
     {"* * * * *", {EWalletDB.TransactionConsumption, :expire_all, []}}

--- a/apps/ewallet_db/config/prod.exs
+++ b/apps/ewallet_db/config/prod.exs
@@ -15,6 +15,7 @@ config :cloak, Salty.SecretBox.Cloak,
        keys: [%{tag: <<1>>, key: key, default: true}]
 
 config :ewallet_db, EWalletDB.Scheduler,
+  global: true,
   jobs: [
     {"* * * * *", {EWalletDB.TransactionRequest, :expire_all, []}},
     {"* * * * *", {EWalletDB.TransactionConsumption, :expire_all, []}}

--- a/apps/ewallet_db/config/prod.exs
+++ b/apps/ewallet_db/config/prod.exs
@@ -17,6 +17,14 @@ config :cloak, Salty.SecretBox.Cloak,
 config :ewallet_db, EWalletDB.Scheduler,
   global: true,
   jobs: [
-    {"* * * * *", {EWalletDB.TransactionRequest, :expire_all, []}},
-    {"* * * * *", {EWalletDB.TransactionConsumption, :expire_all, []}}
+    expire_requests: [
+      schedule: "* * * * *",
+      task: {EWalletDB.TransactionRequest, :expire_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
+    ],
+    expire_consumptions: [
+      schedule: "* * * * *",
+      task: {EWalletDB.TransactionConsumption, :expire_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster} 
+    ]
   ]

--- a/apps/ewallet_db/config/prod.exs
+++ b/apps/ewallet_db/config/prod.exs
@@ -25,6 +25,6 @@ config :ewallet_db, EWalletDB.Scheduler,
     expire_consumptions: [
       schedule: "* * * * *",
       task: {EWalletDB.TransactionConsumption, :expire_all, []},
-      run_strategy: {Quantum.RunStrategy.Random, :cluster} 
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
     ]
   ]

--- a/apps/local_ledger/config/dev.exs
+++ b/apps/local_ledger/config/dev.exs
@@ -3,5 +3,9 @@ use Mix.Config
 config :local_ledger, LocalLedger.Scheduler,
   global: true,
   jobs: [
-    {"0 2 * * *", {LocalLedger.CachedBalance, :cache_all, []}}
+    cache_all_balances: [
+      schedule: "0 2 * * *",
+      task: {LocalLedger.CachedBalance, :cache_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster} 
+    ]
   ]

--- a/apps/local_ledger/config/dev.exs
+++ b/apps/local_ledger/config/dev.exs
@@ -6,6 +6,6 @@ config :local_ledger, LocalLedger.Scheduler,
     cache_all_balances: [
       schedule: "0 2 * * *",
       task: {LocalLedger.CachedBalance, :cache_all, []},
-      run_strategy: {Quantum.RunStrategy.Random, :cluster} 
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
     ]
   ]

--- a/apps/local_ledger/config/dev.exs
+++ b/apps/local_ledger/config/dev.exs
@@ -1,4 +1,7 @@
 use Mix.Config
 
 config :local_ledger, LocalLedger.Scheduler,
-  jobs: [{"0 2 * * *", {LocalLedger.CachedBalance, :cache_all, []}}]
+  global: true,
+  jobs: [
+    {"0 2 * * *", {LocalLedger.CachedBalance, :cache_all, []}}
+  ]

--- a/apps/local_ledger/config/prod.exs
+++ b/apps/local_ledger/config/prod.exs
@@ -9,6 +9,10 @@ case System.get_env("BALANCE_CACHING_FREQUENCY") do
     config :local_ledger, LocalLedger.Scheduler,
       global: true,
       jobs: [
-        {frequency, {LocalLedger.CachedBalance, :cache_all, []}}
+        cache_all_balances: [
+          schedule: frequency,
+          task: {LocalLedger.CachedBalance, :cache_all, []},
+          run_strategy: {Quantum.RunStrategy.Random, :cluster} 
+        ]
       ]
 end

--- a/apps/local_ledger/config/prod.exs
+++ b/apps/local_ledger/config/prod.exs
@@ -7,5 +7,8 @@ case System.get_env("BALANCE_CACHING_FREQUENCY") do
   nil -> :ok
   frequency ->
     config :local_ledger, LocalLedger.Scheduler,
-      jobs: [{frequency, {LocalLedger.CachedBalance, :cache_all, []}}]
+      global: true,
+      jobs: [
+        {frequency, {LocalLedger.CachedBalance, :cache_all, []}}
+      ]
 end

--- a/apps/local_ledger/config/prod.exs
+++ b/apps/local_ledger/config/prod.exs
@@ -12,7 +12,7 @@ case System.get_env("BALANCE_CACHING_FREQUENCY") do
         cache_all_balances: [
           schedule: frequency,
           task: {LocalLedger.CachedBalance, :cache_all, []},
-          run_strategy: {Quantum.RunStrategy.Random, :cluster} 
+          run_strategy: {Quantum.RunStrategy.Random, :cluster}
         ]
       ]
 end


### PR DESCRIPTION
Issue/Task Number: T216

# Overview

Quantum has an option to work within a cluster and avoid duplicated jobs. This PR enables it.

# Changes

- Enable `global` mode for Quantum
