### PR TITLE
SearchParser supports mapped fields

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
@@ -15,9 +15,9 @@ defmodule AdminAPI.V1.AccountController do
 
   # The fields that are allowed to be searched.
   # Note that these values here *must be the DB column names*
-  # Because requests cannot customize which fields to search (yet!),
-  # `@mapped_fields` don't affect them.
+  # If the request provides different names, map it via `@mapped_fields` first.
   @search_fields [:id, :name, :description]
+
   # The fields that are allowed to be sorted.
   # Note that the values here *must be the DB column names*.
   # If the request provides different names, map it via `@mapped_fields` first.
@@ -34,7 +34,7 @@ defmodule AdminAPI.V1.AccountController do
     with :ok <- permit(:all, conn.assigns.user.id, nil) do
       accounts =
         Account
-        |> SearchParser.to_query(attrs, @search_fields)
+        |> SearchParser.to_query(attrs, @search_fields, @mapped_fields)
         |> SortParser.to_query(attrs, @sort_fields, @mapped_fields)
         |> Paginator.paginate_attrs(attrs)
 

--- a/apps/ewallet/test/ewallet/web/search_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/search_parser_test.exs
@@ -183,10 +183,10 @@ defmodule EWallet.Web.SearchParserTest do
     test "returns records mapped to a different field" do
       account = prepare_test_accounts() |> Enum.at(0)
 
-      attrs = %{"search_terms" => %{"id" => account.external_id}}
+      attrs = %{"search_terms" => %{"mapped_id" => account.id}}
       result =
         Account
-        |> SearchParser.to_query(attrs, [:external_id], %{"id" => "external_id"})
+        |> SearchParser.to_query(attrs, [:id], %{"mapped_id" => "id"})
         |> Repo.all()
 
       assert Enum.count(result) == 1

--- a/apps/ewallet/test/ewallet/web/search_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/search_parser_test.exs
@@ -180,7 +180,20 @@ defmodule EWallet.Web.SearchParserTest do
       assert Enum.empty?(result)
     end
 
-    test "returns original query if search_term is missing" do
+    test "returns records mapped to a different field" do
+      account = prepare_test_accounts() |> Enum.at(0)
+
+      attrs = %{"search_terms" => %{"id" => account.external_id}}
+      result =
+        Account
+        |> SearchParser.to_query(attrs, [:external_id], %{"id" => "external_id"})
+        |> Repo.all()
+
+      assert Enum.count(result) == 1
+      assert Enum.at(result, 0).name == account.name
+    end
+
+    test "returns original query if search_terms is missing" do
       original = Account
       attrs    = %{"search_terms" => %{"wrong_attr" => "Name Match 1"}}
       result   = SearchParser.to_query(original, attrs, [:name])


### PR DESCRIPTION
Issue/Task Number: T10

# Overview

This PR adds field mapping to `SearchParser`

# Changes

- Updated `SearchParser.to_query/3` to support mapping of requested fields into actual fields in the database.

# Implementation Details

Simply added a new function clause that takes in a map which is used to determine what fields are to be mapped.

# Usage

Calling endpoints that allow `search_terms` should now allow mapped fields e.g. `created_at` to be mapped and searched in the database field `inserted_at`.

# Impact

Usual deployment.