### PR TITLE
Add `mix omg.deps` to get fullstack deps

### DIFF
--- a/apps/ewallet/lib/mix/tasks/omg.deps.ex
+++ b/apps/ewallet/lib/mix/tasks/omg.deps.ex
@@ -1,7 +1,16 @@
 defmodule Mix.Tasks.Omg.Deps do
+  @moduledoc """
+  Retrieve dependencies for back-end and front-end apps in one go.
+
+  ## Examples
+
+  Simply run the following command:
+
+      mix omg.deps
+  """
   use Mix.Task
 
-  @shortdoc "Retrieve dependencies for both back-end and front-end apps"
+  @shortdoc "Retrieve dependencies for back-end and front-end apps in one go"
 
   def run(args) do
     Mix.shell().info("Fetching backend depedencies...")

--- a/apps/ewallet/lib/mix/tasks/omg.deps.ex
+++ b/apps/ewallet/lib/mix/tasks/omg.deps.ex
@@ -1,0 +1,24 @@
+defmodule Mix.Tasks.Omg.Deps do
+  use Mix.Task
+
+  @shortdoc "Retrieve dependencies for both back-end and front-end apps"
+
+  def run(args) do
+    Mix.shell().info("Fetching backend depedencies...")
+    deps_backend(args)
+
+    Mix.shell().info("Fetching frontend depedencies...")
+    deps_frontend()
+  end
+
+  def deps_backend(args) do
+    Mix.Task.run("deps.get", args)
+  end
+
+  def deps_frontend do
+    System.cmd("yarn", ["install", "--non-interactive", "--color=always"],
+                       cd: Path.expand("../../../../admin_panel/assets/", __DIR__),
+                       into: IO.stream(:stdio, :line),
+                       stderr_to_stdout: true)
+  end
+end

--- a/apps/ewallet/lib/mix/tasks/omg.deps.ex
+++ b/apps/ewallet/lib/mix/tasks/omg.deps.ex
@@ -25,9 +25,12 @@ defmodule Mix.Tasks.Omg.Deps do
   end
 
   def deps_frontend do
-    System.cmd("yarn", ["install", "--non-interactive", "--color=always"],
-                       cd: Path.expand("../../../../admin_panel/assets/", __DIR__),
-                       into: IO.stream(:stdio, :line),
-                       stderr_to_stdout: true)
+    System.cmd(
+      "yarn",
+      ["install", "--non-interactive", "--color=always"],
+      cd: Path.expand("../../../../admin_panel/assets/", __DIR__),
+      into: IO.stream(:stdio, :line),
+      stderr_to_stdout: true
+    )
   end
 end


### PR DESCRIPTION
Issue/Task Number: T122

# Overview

This PR adds the ability to run a single command, `mix omg.deps`, to fetch back-end and front-end dependencies in one go.

# Changes

- Add new `mix omg.deps` task

# Implementation Details

The actual command for the Elixir's mix task is `mix deps.get` but I decided to not include `.get` for easier typing and should align better with the muscle memory we have for `mix omg.server`.

# Usage

Run `mix omg.deps` on the app's root directory.

# Impact

Usual deployment
