### PR TITLE
Run and enforces `mix format`

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -20,8 +20,8 @@
         #
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
-      #
-        included: ["lib/", "src/", "web/", "apps/"],
+        #
+        included: ["lib/", "src/", "test/", "web/", "apps/"],
         excluded: [~r"/_build/", ~r"/deps/"]
       },
       #
@@ -48,6 +48,9 @@
       #     {Credo.Check.Design.DuplicatedCode, false}
       #
       checks: [
+        #
+        ## Consistency Checks
+        #
         {Credo.Check.Consistency.ExceptionNames},
         {Credo.Check.Consistency.LineEndings},
         {Credo.Check.Consistency.ParameterPatternMatching},
@@ -55,19 +58,20 @@
         {Credo.Check.Consistency.SpaceInParentheses},
         {Credo.Check.Consistency.TabsOrSpaces},
 
-        # For some checks, like AliasUsage, you can only customize the priority
+        #
+        ## Design Checks
+        #
+        # You can customize the priority of any check
         # Priority values are: `low, normal, high, higher`
         #
         {Credo.Check.Design.AliasUsage, priority: :low},
-
-        # For others you can set parameters
-
+        # For some checks, you can also set other parameters
+        #
         # If you don't want the `setup` and `test` macro calls in ExUnit tests
         # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
         # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
         #
         {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
-
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
@@ -75,6 +79,9 @@
         {Credo.Check.Design.TagTODO, exit_status: 2},
         {Credo.Check.Design.TagFIXME},
 
+        #
+        ## Readability Checks
+        #
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 100},
@@ -93,6 +100,9 @@
         {Credo.Check.Readability.Semicolons},
         {Credo.Check.Readability.SpaceAfterCommas},
 
+        #
+        ## Refactoring Opportunities
+        #
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.CondStatements},
         {Credo.Check.Refactor.CyclomaticComplexity},
@@ -102,10 +112,15 @@
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},
-        {Credo.Check.Refactor.PipeChainStart},
+        {Credo.Check.Refactor.PipeChainStart,
+         excluded_argument_types: [:atom, :binary, :fn, :keyword], excluded_functions: []},
         {Credo.Check.Refactor.UnlessWithElse},
 
+        #
+        ## Warnings
+        #
         {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck},
         {Credo.Check.Warning.IExPry},
         {Credo.Check.Warning.IoInspect},
         {Credo.Check.Warning.LazyLogging},
@@ -121,6 +136,7 @@
         {Credo.Check.Warning.UnusedTupleOperation},
         {Credo.Check.Warning.RaiseInsideRescue},
 
+        #
         # Controversial and experimental checks (opt-in, just remove `, false`)
         #
         {Credo.Check.Refactor.ABCSize, false},
@@ -129,14 +145,12 @@
         {Credo.Check.Warning.MapGetUnsafePass, false},
         {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
 
+        #
         # Deprecated checks (these will be deleted after a grace period)
         #
-        {Credo.Check.Readability.Specs, false},
-        {Credo.Check.Warning.NameRedeclarationByAssignment, false},
-        {Credo.Check.Warning.NameRedeclarationByCase, false},
-        {Credo.Check.Warning.NameRedeclarationByDef, false},
-        {Credo.Check.Warning.NameRedeclarationByFn, false},
+        {Credo.Check.Readability.Specs, false}
 
+        #
         # Custom checks can be created using `mix credo.gen.check`.
         #
       ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,7 @@
+[
+  inputs: [
+    "mix.exs",
+    "{config,lib,test}/**/*.{ex,exs}",
+    "apps/*/{config,lib,test}/**/*.{ex,exs}"
+  ]
+]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ podTemplate(
                         s6-env HOME=/tmp/ewallet \
                         s6-env MIX_ENV=test \
                         cd /app \
-                        mix do credo, ecto.create, ecto.migrate, test \
+                        mix do format --check-formatted, credo, ecto.create, ecto.migrate, test \
                     " \
                 """.stripIndent()
             )

--- a/apps/admin_api/config/config.exs
+++ b/apps/admin_api/config/config.exs
@@ -13,8 +13,7 @@ config :admin_api,
   enable_client_auth: System.get_env("ENABLE_ADMIN_CLIENT_AUTH") == "true"
 
 # Configs for the endpoint
-config :admin_api,
-  AdminAPI.Endpoint,
+config :admin_api, AdminAPI.Endpoint,
   secret_key_base: System.get_env("SECRET_KEY_BASE"),
   error_handler: AdminAPI.V1.ErrorHandler,
   render_errors: [
@@ -24,12 +23,10 @@ config :admin_api,
   ]
 
 # Config for Phoenix's generators
-config :admin_api, :generators,
-  context_app: false
+config :admin_api, :generators, context_app: false
 
 # Configs for Bamboo emailing library
-config :admin_api, AdminAPI.Mailer,
-  adapter: Bamboo.LocalAdapter
+config :admin_api, AdminAPI.Mailer, adapter: Bamboo.LocalAdapter
 
 # Config for CORSPlug
 #
@@ -41,18 +38,35 @@ config :admin_api, AdminAPI.Mailer,
 # Because of this the anonymous function is invoked right away through
 # `(fn -> ... end).()` in order for :origin to be assigned at compile time.
 config :cors_plug,
-  max_age: System.get_env("CORS_MAX_AGE") || 600, # Lowest common value of all browsers
-  headers: ["Authorization", "Content-Type", "Accept", "Origin",
-            "User-Agent", "DNT", "Cache-Control", "X-Mx-ReqToken",
-            "Keep-Alive", "X-Requested-With", "If-Modified-Since",
-            "X-CSRF-Token", "OMGAdmin-Account-ID"],
+  # Lowest common value of all browsers
+  max_age: System.get_env("CORS_MAX_AGE") || 600,
+  headers: [
+    "Authorization",
+    "Content-Type",
+    "Accept",
+    "Origin",
+    "User-Agent",
+    "DNT",
+    "Cache-Control",
+    "X-Mx-ReqToken",
+    "Keep-Alive",
+    "X-Requested-With",
+    "If-Modified-Since",
+    "X-CSRF-Token",
+    "OMGAdmin-Account-ID"
+  ],
   methods: ["POST"],
-  origin: (fn ->
-    case System.get_env("CORS_ORIGINS") do
-      nil -> [] # Disallow all origins if CORS_ORIGINS is not set
-      origins -> origins |> String.trim() |> String.split(~r{\s*,\s*})
-    end
-  end).()
+  origin:
+    (fn ->
+       case System.get_env("CORS_ORIGINS") do
+         # Disallow all origins if CORS_ORIGINS is not set
+         nil ->
+           []
+
+         origins ->
+           origins |> String.trim() |> String.split(~r{\s*,\s*})
+       end
+     end).()
 
 # Two configs need to be added to have a new EWallet Admin version:
 #
@@ -76,16 +90,16 @@ config :mime, :types, %{
 # Configs for Sentry exception reporting
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),
-  environment_name: Mix.env,
+  environment_name: Mix.env(),
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!,
+  root_source_code_path: File.cwd!(),
   tags: %{
-    env: Mix.env,
-    application: Mix.Project.config[:app]
+    env: Mix.env(),
+    application: Mix.Project.config()[:app]
   },
-  server_name: elem(:inet.gethostname, 1),
+  server_name: elem(:inet.gethostname(), 1),
   included_environments: [:prod]
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/apps/admin_api/config/test.exs
+++ b/apps/admin_api/config/test.exs
@@ -6,9 +6,7 @@ config :admin_api, AdminAPI.Endpoint,
   secret_key_base: "G1DLBdjjJSoSiQRa5Gf8YrWUx5yrX+JFmZx+UBk829W1+e0oJ9TYrW/GkIgrAdfm",
   server: false
 
-config :admin_api,
-  enable_client_auth: "true"
+config :admin_api, enable_client_auth: "true"
 
 # Configs for Bamboo emailing library
-config :admin_api, AdminAPI.Mailer,
-  adapter: Bamboo.TestAdapter
+config :admin_api, AdminAPI.Mailer, adapter: Bamboo.TestAdapter

--- a/apps/admin_api/lib/admin_api.ex
+++ b/apps/admin_api/lib/admin_api.ex
@@ -41,8 +41,9 @@ defmodule AdminAPI do
 
   def view do
     quote do
-      use Phoenix.View, root: "lib/admin_api/templates",
-                        namespace: AdminAPI
+      use Phoenix.View,
+        root: "lib/admin_api/templates",
+        namespace: AdminAPI
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 2, view_module: 1]

--- a/apps/admin_api/lib/admin_api/application.ex
+++ b/apps/admin_api/lib/admin_api/application.ex
@@ -11,7 +11,7 @@ defmodule AdminAPI.Application do
     # Define workers and child supervisors to be supervised
     children = [
       # Start the endpoint when the application starts
-      supervisor(AdminAPI.Endpoint, []),
+      supervisor(AdminAPI.Endpoint, [])
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/apps/admin_api/lib/admin_api/emails/forget_password_email.ex
+++ b/apps/admin_api/lib/admin_api/emails/forget_password_email.ex
@@ -6,7 +6,8 @@ defmodule AdminAPI.ForgetPasswordEmail do
 
   def create(request, redirect_url) do
     sender = Application.get_env(:admin_api, :sender_email)
-    link   =
+
+    link =
       redirect_url
       |> String.replace("{email}", request.user.email)
       |> String.replace("{token}", request.token)

--- a/apps/admin_api/lib/admin_api/endpoint.ex
+++ b/apps/admin_api/lib/admin_api/endpoint.ex
@@ -1,30 +1,34 @@
 defmodule AdminAPI.Endpoint do
   use Phoenix.Endpoint, otp_app: :admin_api
 
-  plug Plug.Static,
+  plug(
+    Plug.Static,
     at: "/public/",
-    from: Path.join(File.cwd!, "../../public/"),
+    from: Path.join(File.cwd!(), "../../public/"),
     only: ~w(uploads)
+  )
 
-  plug AdminAPI.AssetNotFoundPlug
+  plug(AdminAPI.AssetNotFoundPlug)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    plug Phoenix.CodeReloader
+    plug(Phoenix.CodeReloader)
   end
 
-  plug Plug.RequestId
-  plug Plug.Logger
+  plug(Plug.RequestId)
+  plug(Plug.Logger)
 
-  plug Plug.Parsers,
+  plug(
+    Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Poison
+  )
 
-  plug Plug.MethodOverride
-  plug Plug.Head
-  plug CORSPlug
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
+  plug(CORSPlug)
 
-  plug AdminAPI.Router
+  plug(AdminAPI.Router)
 end

--- a/apps/admin_api/lib/admin_api/global/controllers/status_controller.ex
+++ b/apps/admin_api/lib/admin_api/global/controllers/status_controller.ex
@@ -2,6 +2,6 @@ defmodule AdminAPI.StatusController do
   use AdminAPI, :controller
 
   def status(conn, _attrs) do
-    json conn, %{success: true}
+    json(conn, %{success: true})
   end
 end

--- a/apps/admin_api/lib/admin_api/global/plugs/asset_not_found_plug.ex
+++ b/apps/admin_api/lib/admin_api/global/plugs/asset_not_found_plug.ex
@@ -16,5 +16,6 @@ defmodule AdminAPI.AssetNotFoundPlug do
     |> send_resp(404, "")
     |> halt()
   end
+
   defp check_asset(conn, _), do: conn
 end

--- a/apps/admin_api/lib/admin_api/invites/invite_email.ex
+++ b/apps/admin_api/lib/admin_api/invites/invite_email.ex
@@ -6,7 +6,8 @@ defmodule AdminAPI.InviteEmail do
 
   def create(invite, redirect_url) do
     sender = Application.get_env(:admin_api, :sender_email)
-    link   =
+
+    link =
       redirect_url
       |> String.replace("{email}", invite.user.email)
       |> String.replace("{token}", invite.token)

--- a/apps/admin_api/lib/admin_api/invites/inviter.ex
+++ b/apps/admin_api/lib/admin_api/invites/inviter.ex
@@ -26,25 +26,28 @@ defmodule AdminAPI.Inviter do
   end
 
   defp validate_email(email) do
-    if EmailValidator.valid?(email), do: email, else: throw :invalid_email
+    if EmailValidator.valid?(email), do: email, else: throw(:invalid_email)
   end
 
   defp get_or_create_user(email) do
     case User.get_by_email(email) do
       %User{} = user ->
         check_active(user)
+
       nil ->
-        {:ok, user} = User.insert(%{
-          email: email,
-          password: Crypto.generate_key(32)
-        })
+        {:ok, user} =
+          User.insert(%{
+            email: email,
+            password: Crypto.generate_key(32)
+          })
+
         user
     end
   end
 
   defp check_active(user) do
     case User.get_status(user) do
-      :active -> throw :user_already_active
+      :active -> throw(:user_already_active)
       _ -> user
     end
   end

--- a/apps/admin_api/lib/admin_api/router.ex
+++ b/apps/admin_api/lib/admin_api/router.ex
@@ -4,7 +4,7 @@ defmodule AdminAPI.Router do
   alias AdminAPI.{StatusController, VersionedRouter}
 
   scope "/admin/api" do
-    get "/", StatusController, :status
-    forward "/", VersionedRouter
+    get("/", StatusController, :status)
+    forward("/", VersionedRouter)
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
@@ -41,12 +41,14 @@ defmodule AdminAPI.V1.AccountController do
       case accounts do
         %Paginator{} = paginator ->
           render(conn, :accounts, %{accounts: paginator})
+
         {:error, code, description} ->
           handle_error(conn, code, description)
       end
     else
       {:error, code} ->
         handle_error(conn, code)
+
       nil ->
         handle_error(conn, :account_id_not_found)
     end
@@ -56,13 +58,13 @@ defmodule AdminAPI.V1.AccountController do
   Retrieves a specific account by its id.
   """
   def get(conn, %{"id" => id}) do
-    with :ok                  <- permit(:get, conn.assigns.user.id, id),
-         %Account{} = account <- Account.get_by(id: id)
-    do
+    with :ok <- permit(:get, conn.assigns.user.id, id),
+         %Account{} = account <- Account.get_by(id: id) do
       render(conn, :account, %{account: account})
     else
       {:error, code} ->
         handle_error(conn, code)
+
       nil ->
         handle_error(conn, :account_id_not_found)
     end
@@ -81,14 +83,14 @@ defmodule AdminAPI.V1.AccountController do
         Account.get_master_account()
       end
 
-    with :ok            <- permit(:create, conn.assigns.user.id, parent.id),
-         attrs          <- Map.put(attrs, "parent_uuid", parent.uuid),
-         {:ok, account} <- Account.insert(attrs)
-    do
+    with :ok <- permit(:create, conn.assigns.user.id, parent.id),
+         attrs <- Map.put(attrs, "parent_uuid", parent.uuid),
+         {:ok, account} <- Account.insert(attrs) do
       render(conn, :account, %{account: account})
     else
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
+
       {:error, code} ->
         handle_error(conn, code)
     end
@@ -100,32 +102,33 @@ defmodule AdminAPI.V1.AccountController do
   The requesting user must have write permission on the given account.
   """
   def update(conn, %{"id" => account_id} = attrs) do
-    with :ok            <- permit(:update, conn.assigns.user.id, account_id),
+    with :ok <- permit(:update, conn.assigns.user.id, account_id),
          %{} = original <- Account.get(account_id) || {:error, :account_id_not_found},
-         {:ok, updated} <- Account.update(original, attrs)
-    do
+         {:ok, updated} <- Account.update(original, attrs) do
       render(conn, :account, %{account: updated})
     else
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
+
       {:error, code} ->
         handle_error(conn, code)
     end
   end
+
   def update(conn, _), do: handle_error(conn, :invalid_parameter)
 
   @doc """
   Uploads an image as avatar for a specific account.
   """
   def upload_avatar(conn, %{"id" => id, "avatar" => _} = attrs) do
-    with :ok           <- permit(:update, conn.assigns.user.id, id),
+    with :ok <- permit(:update, conn.assigns.user.id, id),
          %{} = account <- Account.get(id) || {:error, :account_id_not_found},
-         %{} = saved   <- Account.store_avatar(account, attrs)
-    do
+         %{} = saved <- Account.store_avatar(account, attrs) do
       render(conn, :account, %{account: saved})
     else
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
+
       {:error, code} ->
         handle_error(conn, code)
     end

--- a/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
@@ -10,20 +10,25 @@ defmodule AdminAPI.V1.AccountMembershipController do
   def list_users(conn, %{"account_id" => account_id}) do
     list_users(conn, Account.get(account_id, preload: [memberships: [:user, :role]]))
   end
+
   def list_users(conn, %Account{} = account) do
     render(conn, :memberships, %{memberships: account.memberships})
   end
+
   def list_users(conn, nil), do: handle_error(conn, :account_id_not_found)
   def list_users(conn, _), do: handle_error(conn, :invalid_parameter)
 
   @doc """
   Assigns the user to the given account and role.
   """
-  def assign_user(conn, %{
-    "account_id" => account_id,
-    "role_name" => role_name,
-    "redirect_url" => redirect_url
-  } = attrs) do
+  def assign_user(
+        conn,
+        %{
+          "account_id" => account_id,
+          "role_name" => role_name,
+          "redirect_url" => redirect_url
+        } = attrs
+      ) do
     with user when not is_tuple(user) <- get_user_or_email(attrs) || {:error, :user_id_not_found},
          %Account{} = account <- Account.get(account_id) || {:error, :account_id_not_found},
          %Role{} = role <- Role.get_by_name(role_name) || {:error, :role_name_not_found},
@@ -32,11 +37,13 @@ defmodule AdminAPI.V1.AccountMembershipController do
     else
       {:error, error} when is_atom(error) ->
         handle_error(conn, error)
+
       # Matches a different error format returned by Membership.assign_user/2
       {:error, changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
     end
   end
+
   def assign_user(conn, _attrs), do: handle_error(conn, :invalid_parameter)
 
   # Get user or email specifically for `assign_user/2` above.
@@ -52,13 +59,14 @@ defmodule AdminAPI.V1.AccountMembershipController do
   defp get_user_or_email(%{"user_id" => user_id}) do
     case User.get(user_id) do
       %User{} = user -> user
-      _              -> {:error, :user_id_not_found}
+      _ -> {:error, :user_id_not_found}
     end
   end
+
   defp get_user_or_email(%{"email" => email}) do
     case User.get_by_email(email) do
       %User{} = user -> user
-      nil            -> email
+      nil -> email
     end
   end
 
@@ -71,13 +79,15 @@ defmodule AdminAPI.V1.AccountMembershipController do
           |> Inviter.send_email(redirect_url)
 
         {:ok, invite}
+
       :active ->
         Membership.assign(user, account, role)
     end
   end
+
   defp assign_or_invite(email, account, role, redirect_url) when is_binary(email) do
     case Inviter.invite(email, account, role, redirect_url) do
-      {:ok, invite}       -> {:ok, invite.user}
+      {:ok, invite} -> {:ok, invite.user}
       {:error, _} = error -> error
     end
   end
@@ -86,9 +96,9 @@ defmodule AdminAPI.V1.AccountMembershipController do
   Unassigns the user from the given account.
   """
   def unassign_user(conn, %{
-    "user_id" => user_id,
-    "account_id" => account_id
-  }) do
+        "user_id" => user_id,
+        "account_id" => account_id
+      }) do
     with %User{} = user <- User.get(user_id) || {:error, :user_id_not_found},
          %Account{} = account <- Account.get(account_id) || {:error, :account_id_not_found},
          {:ok, _} <- Membership.unassign(user, account) do
@@ -97,5 +107,6 @@ defmodule AdminAPI.V1.AccountMembershipController do
       {:error, error} -> handle_error(conn, error)
     end
   end
+
   def unassign_user(conn, _attrs), do: handle_error(conn, :invalid_parameter)
 end

--- a/apps/admin_api/lib/admin_api/v1/controllers/admin_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/admin_controller.ex
@@ -54,6 +54,7 @@ defmodule AdminAPI.V1.AdminController do
     case User.get(id, UserQuery.where_has_membership()) do
       nil ->
         respond_single(nil, conn)
+
       user ->
         user
         |> User.store_avatar(attrs)
@@ -65,6 +66,7 @@ defmodule AdminAPI.V1.AdminController do
   defp respond_multiple(%Paginator{} = paged_users, conn) do
     render(conn, UserView, :users, %{users: paged_users})
   end
+
   defp respond_multiple({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
@@ -73,10 +75,12 @@ defmodule AdminAPI.V1.AdminController do
   defp respond_single(%User{} = user, conn) do
     render(conn, UserView, :user, %{user: user})
   end
+
   # Responds when the given params were invalid
   defp respond_single({:error, changeset}, conn) do
-     handle_error(conn, :invalid_parameter, changeset)
-   end
+    handle_error(conn, :invalid_parameter, changeset)
+  end
+
   # Responds when the admin is not found
   defp respond_single(nil, conn) do
     handle_error(conn, :user_id_not_found)

--- a/apps/admin_api/lib/admin_api/v1/controllers/api_key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/api_key_controller.ex
@@ -38,6 +38,7 @@ defmodule AdminAPI.V1.APIKeyController do
   defp respond_multiple(%Paginator{} = paginated, conn) do
     render(conn, :api_keys, %{api_keys: paginated})
   end
+
   defp respond_multiple({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
@@ -52,12 +53,14 @@ defmodule AdminAPI.V1.APIKeyController do
     |> APIKey.insert()
     |> respond_single(conn)
   end
+
   def create(conn, _), do: handle_error(conn, :invalid_parameter)
 
   # Respond when the API key is saved successfully
   defp respond_single({:ok, api_key}, conn) do
     render(conn, :api_key, %{api_key: api_key})
   end
+
   # Responds when the API key is saved unsucessfully
   defp respond_single({:error, changeset}, conn) do
     handle_error(conn, :invalid_parameter, changeset)
@@ -67,16 +70,18 @@ defmodule AdminAPI.V1.APIKeyController do
   Soft-deletes an existing API key by its id.
   """
   def delete(conn, %{"id" => id}) do
-    with false           <- self_delete?(id, conn),
+    with false <- self_delete?(id, conn),
          %APIKey{} = key <- APIKey.get(id) do
       do_delete(conn, key)
     else
       true ->
         handle_error(conn, :invalid_parameter, "The given API key is being used for this request")
+
       nil ->
         handle_error(conn, :api_key_not_found)
     end
   end
+
   def delete(conn, _), do: handle_error(conn, :invalid_parameter)
 
   defp self_delete?(id, conn) do
@@ -87,6 +92,7 @@ defmodule AdminAPI.V1.APIKeyController do
     case APIKey.delete(key) do
       {:ok, _key} ->
         render(conn, :empty_response)
+
       {:error, changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
     end

--- a/apps/admin_api/lib/admin_api/v1/controllers/auth_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/auth_controller.ex
@@ -9,19 +9,22 @@ defmodule AdminAPI.V1.AuthController do
   Returns with a newly generated authentication token if auth is successful.
   """
   def login(conn, %{
-    "email" => email,
-    "password" => password
-  }) when is_binary(email) and is_binary(password) do
+        "email" => email,
+        "password" => password
+      })
+      when is_binary(email) and is_binary(password) do
     conn
     |> UserAuthPlug.authenticate(email, password)
     |> respond_with_token()
   end
+
   def login(conn, _attrs), do: handle_error(conn, :invalid_parameter)
 
   defp respond_with_token(%{assigns: %{authenticated: :user}} = conn) do
     {:ok, auth_token} = AuthToken.generate(conn.assigns.user, :admin_api)
     render(conn, :auth_token, %{auth_token: auth_token, user: conn.assigns.user})
   end
+
   defp respond_with_token(conn) do
     handle_error(conn, :invalid_login_credentials)
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/invite_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/invite_controller.ex
@@ -8,11 +8,11 @@ defmodule AdminAPI.V1.InviteController do
   Validates the user's invite token and activates the user.
   """
   def accept(conn, %{
-    "email"                 => email,
-    "token"                 => token,
-    "password"              => password,
-    "password_confirmation" => password_confirmation,
-  }) do
+        "email" => email,
+        "token" => token,
+        "password" => password,
+        "password_confirmation" => password_confirmation
+      }) do
     email
     |> get_invite(token)
     |> validate_passwords(password, password_confirmation)
@@ -21,12 +21,13 @@ defmodule AdminAPI.V1.InviteController do
   catch
     {:error, error_code} when is_atom(error_code) -> handle_error(conn, error_code)
   end
+
   def accept(conn, _), do: handle_error(conn, :invalid_parameter)
 
   defp get_invite(email, token) do
     case Invite.get(email, token) do
       %Invite{} = invite -> invite
-                       _ -> throw {:error, :invite_not_found}
+      _ -> throw({:error, :invite_not_found})
     end
   end
 
@@ -34,7 +35,7 @@ defmodule AdminAPI.V1.InviteController do
     if password == password_confirmation do
       invite
     else
-      throw {:error, :passwords_mismatch}
+      throw({:error, :passwords_mismatch})
     end
   end
 

--- a/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
@@ -38,6 +38,7 @@ defmodule AdminAPI.V1.KeyController do
   defp respond_multiple(%Paginator{} = paginated_keys, conn) do
     render(conn, :keys, %{keys: paginated_keys})
   end
+
   defp respond_multiple({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
@@ -55,6 +56,7 @@ defmodule AdminAPI.V1.KeyController do
   defp respond_single({:ok, key}, conn) do
     render(conn, :key, %{key: key})
   end
+
   # Responds when the key is saved unsucessfully
   defp respond_single({:error, changeset}, conn) do
     handle_error(conn, :invalid_parameter, changeset)
@@ -67,19 +69,23 @@ defmodule AdminAPI.V1.KeyController do
     key = Key.get(:access_key, access_key)
     do_delete(conn, key)
   end
+
   def delete(conn, %{"id" => id}) do
     key = Key.get(id)
     do_delete(conn, key)
   end
+
   def delete(conn, _), do: handle_error(conn, :invalid_parameter)
 
   defp do_delete(conn, %Key{} = key) do
     case Key.delete(key) do
       {:ok, _key} ->
         render(conn, :empty_response)
+
       {:error, changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
     end
   end
+
   defp do_delete(conn, nil), do: handle_error(conn, :key_not_found)
 end

--- a/apps/admin_api/lib/admin_api/v1/controllers/reset_password_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/reset_password_controller.ex
@@ -6,7 +6,9 @@ defmodule AdminAPI.V1.ResetPasswordController do
 
   def reset(conn, %{"email" => email, "redirect_url" => redirect_url}) do
     case User.get_by_email(email) do
-      nil -> handle_error(conn, :user_email_not_found)
+      nil ->
+        handle_error(conn, :user_email_not_found)
+
       user ->
         user
         |> ForgetPasswordRequest.delete_all()
@@ -17,27 +19,32 @@ defmodule AdminAPI.V1.ResetPasswordController do
         render(conn, :empty, %{success: true})
     end
   end
+
   def reset(conn, _), do: handle_error(conn, :invalid_parameter)
 
-  def update(conn, %{
-    "email" => email,
-    "token" => token,
-    "password" => _,
-    "password_confirmation" => _
-  } = attrs) do
-    with %User{} = user                     <- get_user(email),
+  def update(
+        conn,
+        %{
+          "email" => email,
+          "token" => token,
+          "password" => _,
+          "password_confirmation" => _
+        } = attrs
+      ) do
+    with %User{} = user <- get_user(email),
          %ForgetPasswordRequest{} = request <- get_request(user, token),
-         {:ok, %User{} = user}              <- update_password(request, attrs)
-    do
+         {:ok, %User{} = user} <- update_password(request, attrs) do
       ForgetPasswordRequest.delete_all(user)
       render(conn, :empty, %{success: true})
     else
       error when is_atom(error) ->
         handle_error(conn, error)
+
       {:error, changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
     end
   end
+
   def update(conn, _), do: handle_error(conn, :invalid_parameter)
 
   defp get_user(email) do
@@ -49,9 +56,9 @@ defmodule AdminAPI.V1.ResetPasswordController do
   end
 
   defp update_password(request, %{
-    "password" => password,
-    "password_confirmation" => password_confirmation
-  }) do
+         "password" => password,
+         "password_confirmation" => password_confirmation
+       }) do
     User.update(request.user, %{
       password: password,
       password_confirmation: password_confirmation

--- a/apps/admin_api/lib/admin_api/v1/controllers/self_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/self_controller.ex
@@ -19,6 +19,7 @@ defmodule AdminAPI.V1.SelfController do
     case User.get_account(conn.assigns.user) do
       %Account{} = account ->
         render(conn, AccountView, :account, %{account: account})
+
       nil ->
         handle_error(conn, :user_account_not_found)
     end

--- a/apps/admin_api/lib/admin_api/v1/controllers/status_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/status_controller.ex
@@ -2,7 +2,7 @@ defmodule AdminAPI.V1.StatusController do
   use AdminAPI, :controller
 
   def index(conn, _attrs) do
-    json conn, %{success: true}
+    json(conn, %{success: true})
   end
 
   def server_error(_conn, _attrs) do

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_controller.ex
@@ -51,12 +51,14 @@ defmodule AdminAPI.V1.TransactionController do
     |> Repo.get_by(id: id)
     |> respond_single(conn)
   end
+
   def get(conn, _), do: handle_error(conn, :invalid_parameter)
 
   # Respond with a list of transactions
   defp respond_multiple(%Paginator{} = paged_transactions, conn) do
     render(conn, :transactions, %{transactions: paged_transactions})
   end
+
   defp respond_multiple({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
@@ -65,6 +67,7 @@ defmodule AdminAPI.V1.TransactionController do
   defp respond_single(%Transfer{} = transaction, conn) do
     render(conn, :transaction, %{transaction: transaction})
   end
+
   defp respond_single(nil, conn) do
     handle_error(conn, :transaction_id_not_found)
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/user_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/user_controller.ex
@@ -47,6 +47,7 @@ defmodule AdminAPI.V1.UserController do
   defp respond_multiple(%Paginator{} = paged_users, conn) do
     render(conn, :users, %{users: paged_users})
   end
+
   defp respond_multiple({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
@@ -55,8 +56,9 @@ defmodule AdminAPI.V1.UserController do
   defp respond_single(%User{} = user, conn), do: render(conn, :user, %{user: user})
   # Responds when the given params were invalid
   defp respond_single({:error, changeset}, conn) do
-     handle_error(conn, :invalid_parameter, changeset)
-   end
+    handle_error(conn, :invalid_parameter, changeset)
+  end
+
   # Responds when the user is not found
   defp respond_single(nil, conn), do: handle_error(conn, :user_id_not_found)
 end

--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -81,9 +81,9 @@ defmodule AdminAPI.V1.ErrorHandler do
   @doc """
   Returns a map of all the error atoms along with their code and description.
   """
-  @spec errors() :: %{required(atom()) => %{code: String.t, description: String.t}}
+  @spec errors() :: %{required(atom()) => %{code: String.t(), description: String.t()}}
   def errors do
-    Map.merge(EWalletErrorHandler.errors, @errors, fn _k, _shared, current ->
+    Map.merge(EWalletErrorHandler.errors(), @errors, fn _k, _shared, current ->
       current
     end)
   end
@@ -96,6 +96,7 @@ defmodule AdminAPI.V1.ErrorHandler do
     |> EWalletErrorHandler.build_error(attrs, errors())
     |> respond(conn)
   end
+
   def handle_error(conn, code) do
     code
     |> EWalletErrorHandler.build_error(errors())

--- a/apps/admin_api/lib/admin_api/v1/plugs/account_scope_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/account_scope_plug.ex
@@ -24,9 +24,12 @@ defmodule AdminAPI.V1.AccountScopePlug do
       assign(conn, :scoped_account_id, uuid)
     else
       # If the header is provided, it must be a UUID
-      :error -> handle_error(conn, :invalid_account_id)
+      :error ->
+        handle_error(conn, :invalid_account_id)
+
       # If the header is not provided, this plug does nothing
-      nil -> conn
+      nil ->
+        conn
     end
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
@@ -12,14 +12,15 @@ defmodule AdminAPI.V1.ClientAuthPlug do
   def init(opts), do: opts
 
   def call(conn, opts) do
-    auth = Keyword.get(opts, :enable_client_auth,
-                       Application.get_env(:admin_api, :enable_client_auth))
+    auth =
+      Keyword.get(opts, :enable_client_auth, Application.get_env(:admin_api, :enable_client_auth))
 
     case auth do
       "true" ->
         conn
         |> parse_header()
         |> authenticate()
+
       _ ->
         assign(conn, :authenticated, :client)
     end
@@ -50,10 +51,11 @@ defmodule AdminAPI.V1.ClientAuthPlug do
   @doc """
   Authenticates a client by using api_key_id and api_key in the connection (private values).
   """
-  def authenticate(%{assigns: %{authenticated: :false}} = conn), do: conn
+  def authenticate(%{assigns: %{authenticated: false}} = conn), do: conn
+
   def authenticate(conn) do
     api_key_id = conn.private[:auth_api_key_id]
-    api_key    = conn.private[:auth_api_key]
+    api_key = conn.private[:auth_api_key]
 
     case APIKey.authenticate(api_key_id, api_key, :admin_api) do
       %Account{} = account ->
@@ -61,6 +63,7 @@ defmodule AdminAPI.V1.ClientAuthPlug do
         |> assign(:authenticated, :client)
         |> assign(:api_key_id, api_key_id)
         |> assign(:account, account)
+
       false ->
         conn
         |> assign(:authenticated, false)

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -4,89 +4,89 @@ defmodule AdminAPI.V1.Router do
 
   # Pipeline for plugs to apply for all endpoints
   pipeline :api do
-    plug :accepts, ["json"]
+    plug(:accepts, ["json"])
   end
 
   # Pipeline for endpoints that require client authentication
   pipeline :client_api do
-    plug ClientAuthPlug
+    plug(ClientAuthPlug)
   end
 
   # Pipeline for endpoints that require user authentication
   pipeline :user_api do
-    plug UserAuthPlug
+    plug(UserAuthPlug)
   end
 
   # Authenticated endpoints
   scope "/", AdminAPI.V1 do
-    pipe_through [:api, :user_api]
+    pipe_through([:api, :user_api])
 
     # Minted Token endpoints
-    post "/minted_token.all", MintedTokenController, :all
-    post "/minted_token.get", MintedTokenController, :get
-    post "/minted_token.create", MintedTokenController, :create
-    post "/minted_token.mint", MintedTokenController, :mint
+    post("/minted_token.all", MintedTokenController, :all)
+    post("/minted_token.get", MintedTokenController, :get)
+    post("/minted_token.create", MintedTokenController, :create)
+    post("/minted_token.mint", MintedTokenController, :mint)
 
     # Transaction endpoints
-    post "/transaction.all", TransactionController, :all
-    post "/transaction.get", TransactionController, :get
+    post("/transaction.all", TransactionController, :all)
+    post("/transaction.get", TransactionController, :get)
 
     # Account endpoints
-    post "/account.all", AccountController, :all
-    post "/account.get", AccountController, :get
-    post "/account.create", AccountController, :create
-    post "/account.update", AccountController, :update
-    post "/account.upload_avatar", AccountController, :upload_avatar
+    post("/account.all", AccountController, :all)
+    post("/account.get", AccountController, :get)
+    post("/account.create", AccountController, :create)
+    post("/account.update", AccountController, :update)
+    post("/account.upload_avatar", AccountController, :upload_avatar)
 
     # Account membership endpoints
-    post "/account.list_users", AccountMembershipController, :list_users
-    post "/account.assign_user", AccountMembershipController, :assign_user
-    post "/account.unassign_user", AccountMembershipController, :unassign_user
+    post("/account.list_users", AccountMembershipController, :list_users)
+    post("/account.assign_user", AccountMembershipController, :assign_user)
+    post("/account.unassign_user", AccountMembershipController, :unassign_user)
 
     # User endpoints
-    post "/user.all", UserController, :all
-    post "/user.get", UserController, :get
+    post("/user.all", UserController, :all)
+    post("/user.get", UserController, :get)
 
     # Admin endpoints
-    post "/admin.all", AdminController, :all
-    post "/admin.get", AdminController, :get
-    post "/admin.upload_avatar", AdminController, :upload_avatar
+    post("/admin.all", AdminController, :all)
+    post("/admin.get", AdminController, :get)
+    post("/admin.upload_avatar", AdminController, :upload_avatar)
 
     # API Access endpoints
-    post "/access_key.all", KeyController, :all
-    post "/access_key.create", KeyController, :create
-    post "/access_key.delete", KeyController, :delete
+    post("/access_key.all", KeyController, :all)
+    post("/access_key.create", KeyController, :create)
+    post("/access_key.delete", KeyController, :delete)
 
-    post "/api_key.all", APIKeyController, :all
-    post "/api_key.create", APIKeyController, :create
-    post "/api_key.delete", APIKeyController, :delete
+    post("/api_key.all", APIKeyController, :all)
+    post("/api_key.create", APIKeyController, :create)
+    post("/api_key.delete", APIKeyController, :delete)
 
     # Self endpoints (operations on the currently authenticated user)
-    post "/me.get", SelfController, :get
-    post "/me.get_account", SelfController, :get_account
-    post "/me.get_accounts", SelfController, :get_accounts
-    post "/logout", AuthController, :logout
+    post("/me.get", SelfController, :get)
+    post("/me.get_account", SelfController, :get_account)
+    post("/me.get_accounts", SelfController, :get_accounts)
+    post("/logout", AuthController, :logout)
   end
 
   # Public endpoints (still protected by API key)
   scope "/", AdminAPI.V1 do
-    pipe_through [:api, :client_api]
+    pipe_through([:api, :client_api])
 
-    post "/login", AuthController, :login
-    post "/invite.accept", InviteController, :accept
+    post("/login", AuthController, :login)
+    post("/invite.accept", InviteController, :accept)
 
     # Forget Password endpoints
-    post "/password.reset", ResetPasswordController, :reset
-    post "/password.update", ResetPasswordController, :update
+    post("/password.reset", ResetPasswordController, :reset)
+    post("/password.update", ResetPasswordController, :update)
 
-    post "/status", StatusController, :index
-    post "/status.server_error", StatusController, :server_error
+    post("/status", StatusController, :index)
+    post("/status.server_error", StatusController, :server_error)
   end
 
   # Fallback endpoints. Handles all remaining routes
   # that are not handled by the scopes above.
   scope "/", AdminAPI.V1 do
-    pipe_through [:api]
-    match :*, "/*path", FallbackController, :not_found
+    pipe_through([:api])
+    match(:*, "/*path", FallbackController, :not_found)
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/serializers/auth_token_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/auth_token_serializer.ex
@@ -6,7 +6,7 @@ defmodule AdminAPI.V1.AuthTokenSerializer do
     %{
       object: "authentication_token",
       authentication_token: attrs.auth_token,
-      user_id: attrs.user.id,
+      user_id: attrs.user.id
     }
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/serializers/membership_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/membership_serializer.ex
@@ -12,12 +12,15 @@ defmodule AdminAPI.V1.MembershipSerializer do
       data: Enum.map(memberships, &serialize/1)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
+
   def serialize(membership) when is_map(membership) do
     membership.user
     |> UserSerializer.serialize()
     |> Map.put(:account_role, membership.role.name)
     |> Map.put(:status, User.get_status(membership.user))
   end
+
   def serialize(nil), do: nil
 end

--- a/apps/admin_api/lib/admin_api/v1/views/account_membership_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/account_membership_view.ex
@@ -8,6 +8,7 @@ defmodule AdminAPI.V1.AccountMembershipView do
     |> MembershipSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("empty.json", %{success: success}) do
     %{}
     |> ResponseSerializer.serialize(success: success)

--- a/apps/admin_api/lib/admin_api/v1/views/account_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/account_view.ex
@@ -7,6 +7,7 @@ defmodule AdminAPI.V1.AccountView do
     |> AccountSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("accounts.json", %{accounts: accounts}) do
     accounts
     |> AccountSerializer.serialize()

--- a/apps/admin_api/lib/admin_api/v1/views/api_key_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/api_key_view.ex
@@ -7,11 +7,13 @@ defmodule AdminAPI.V1.APIKeyView do
     |> APIKeySerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("api_keys.json", %{api_keys: api_keys}) do
     api_keys
     |> APIKeySerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("empty_response.json", _attrs) do
     ResponseSerializer.serialize(%{}, success: true)
   end

--- a/apps/admin_api/lib/admin_api/v1/views/key_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/key_view.ex
@@ -7,11 +7,13 @@ defmodule AdminAPI.V1.KeyView do
     |> KeySerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("keys.json", %{keys: keys}) do
     keys
     |> KeySerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("empty_response.json", _attrs) do
     ResponseSerializer.serialize(%{}, success: true)
   end

--- a/apps/admin_api/lib/admin_api/v1/views/minted_token_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/minted_token_view.ex
@@ -7,6 +7,7 @@ defmodule AdminAPI.V1.MintedTokenView do
     |> MintedTokenSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("minted_tokens.json", %{minted_tokens: minted_tokens}) do
     minted_tokens
     |> MintedTokenSerializer.serialize()

--- a/apps/admin_api/lib/admin_api/v1/views/transaction_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/transaction_view.ex
@@ -7,6 +7,7 @@ defmodule AdminAPI.V1.TransactionView do
     |> TransactionSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("transactions.json", %{transactions: transactions}) do
     transactions
     |> TransactionSerializer.serialize()

--- a/apps/admin_api/lib/admin_api/v1/views/user_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/user_view.ex
@@ -8,6 +8,7 @@ defmodule AdminAPI.V1.UserView do
     |> UserSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("users.json", %{users: users}) do
     users
     |> UserSerializer.serialize()

--- a/apps/admin_api/lib/admin_api/versioned_router.ex
+++ b/apps/admin_api/lib/admin_api/versioned_router.ex
@@ -21,6 +21,7 @@ defmodule AdminAPI.VersionedRouter do
     case get_accept_version(accept) do
       {:ok, router_module} ->
         dispatch_to_router(conn, opts, router_module)
+
       _ ->
         handle_invalid_version(conn, accept)
     end

--- a/apps/admin_api/test/admin_api/emails/forget_password_email_test.exs
+++ b/apps/admin_api/test/admin_api/emails/forget_password_email_test.exs
@@ -4,10 +4,10 @@ defmodule AdminAPI.ForgetPasswordEmailTest do
   alias EWalletDB.ForgetPasswordRequest
 
   setup do
-    user     = insert(:user, email: "example@mail.com")
+    user = insert(:user, email: "example@mail.com")
     _request = insert(:forget_password_request, token: "the_token", user_uuid: user.uuid)
-    request  = ForgetPasswordRequest.get(user, "the_token")
-    email    = ForgetPasswordEmail.create(request, "https://reset_url/?email={email}&token={token}")
+    request = ForgetPasswordRequest.get(user, "the_token")
+    email = ForgetPasswordEmail.create(request, "https://reset_url/?email={email}&token={token}")
 
     %{user: user, request: request, email: email}
   end

--- a/apps/admin_api/test/admin_api/global/controllers/status_controller_test.exs
+++ b/apps/admin_api/test/admin_api/global/controllers/status_controller_test.exs
@@ -3,8 +3,8 @@ defmodule AdminAPI.StatusControllerTest do
 
   describe "GET request to /" do
     test "returns status ok" do
-
-      response = build_conn()
+      response =
+        build_conn()
         |> get(@base_dir <> "/")
         |> json_response(:ok)
 

--- a/apps/admin_api/test/admin_api/invites/invite_email_test.exs
+++ b/apps/admin_api/test/admin_api/invites/invite_email_test.exs
@@ -5,9 +5,9 @@ defmodule AdminAPI.InviteEmailTest do
 
   defp create_email(email, token) do
     invite = insert(:invite, %{token: token})
-    _user  = insert(:admin, %{email: email, invite: invite})
+    _user = insert(:admin, %{email: email, invite: invite})
     invite = Repo.preload(invite, :user)
-    email  = InviteEmail.create(invite, "https://invite_url/?email={email}&token={token}")
+    email = InviteEmail.create(invite, "https://invite_url/?email={email}&token={token}")
 
     email
   end

--- a/apps/admin_api/test/admin_api/invites/inviter_test.exs
+++ b/apps/admin_api/test/admin_api/invites/inviter_test.exs
@@ -10,57 +10,58 @@ defmodule AdminAPI.InviterTest do
   describe "Inviter.invite/3" do
     test "sends email and returns the invite if successful" do
       account = insert(:account)
-      role    = insert(:role)
+      role = insert(:role)
 
       {res, invite} = Inviter.invite("test@example.com", account, role, @redirect_url)
 
-      assert res       == :ok
-      assert %Invite{} =  invite
-      assert_delivered_email InviteEmail.create(invite, @redirect_url)
+      assert res == :ok
+      assert %Invite{} = invite
+      assert_delivered_email(InviteEmail.create(invite, @redirect_url))
     end
 
     test "sends a new invite if this email has been invited before" do
       account = insert(:account)
-      role    = insert(:role)
+      role = insert(:role)
 
       {:ok, invite1} = Inviter.invite("test@example.com", account, role, @redirect_url)
       {:ok, invite2} = Inviter.invite("test@example.com", account, role, @redirect_url)
 
-      assert_delivered_email InviteEmail.create(invite1, @redirect_url)
-      assert_delivered_email InviteEmail.create(invite2, @redirect_url)
+      assert_delivered_email(InviteEmail.create(invite1, @redirect_url))
+      assert_delivered_email(InviteEmail.create(invite2, @redirect_url))
     end
 
     test "assigns the user to account and role" do
       account = insert(:account)
-      role    = insert(:role)
+      role = insert(:role)
 
       {:ok, invite} = Inviter.invite("test@example.com", account, role, @redirect_url)
-      memberships   = Membership.all_by_user(invite.user)
+      memberships = Membership.all_by_user(invite.user)
 
-      assert Enum.any?(memberships, fn(m) ->
-        m.account_uuid == account.uuid && m.role_uuid == role.uuid
-      end)
+      assert Enum.any?(memberships, fn m ->
+               m.account_uuid == account.uuid && m.role_uuid == role.uuid
+             end)
     end
 
     test "returns :invalid_email error if email is invalid" do
-      email   = "not-an-email"
+      email = "not-an-email"
       account = insert(:account)
-      role    = insert(:role)
+      role = insert(:role)
 
       {res, error} = Inviter.invite(email, account, role, @redirect_url)
 
-      assert res   == :error
+      assert res == :error
       assert error == :invalid_email
     end
 
     test "returns :user_already_active error if user is already active" do
-      _user   = insert(:admin, %{email: "activeuser@example.com"}) # This should already be an active user
+      # This should already be an active user
+      _user = insert(:admin, %{email: "activeuser@example.com"})
       account = insert(:account)
-      role    = insert(:role)
+      role = insert(:role)
 
       {res, error} = Inviter.invite("activeuser@example.com", account, role, @redirect_url)
 
-      assert res   == :error
+      assert res == :error
       assert error == :user_already_active
     end
   end
@@ -68,12 +69,12 @@ defmodule AdminAPI.InviterTest do
   describe "Inviter.send/3" do
     test "creates and sends the invite email" do
       invite = insert(:invite)
-      _user  = insert(:admin, %{invite: invite})
-      email  = Inviter.send_email(invite, @redirect_url)
+      _user = insert(:admin, %{invite: invite})
+      email = Inviter.send_email(invite, @redirect_url)
       invite = invite |> Repo.preload(:user)
 
       assert %Email{} = email
-      assert_delivered_email InviteEmail.create(invite, @redirect_url)
+      assert_delivered_email(InviteEmail.create(invite, @redirect_url))
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_membership_controller_test.exs
@@ -7,110 +7,120 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
   describe "/account.list_users" do
     test "returns a list of users with role and status" do
       account = insert(:account)
-      user    = insert(:user)
-      role    = insert(:role)
-      _       = insert(:membership, %{account: account, user: user, role: role})
+      user = insert(:user)
+      role = insert(:role)
+      _ = insert(:membership, %{account: account, user: user, role: role})
 
       assert user_request("/account.list_users", %{account_id: account.id}) ==
-        %{
-          "version" => "1",
-          "success" => true,
-          "data" => %{
-            "object" => "list",
-            "data" => [%{
-              "object" => "user",
-              "id" => user.id,
-              "socket_topic" => "user:#{user.id}",
-              "username" => user.username,
-              "provider_user_id" => user.provider_user_id,
-              "email" => user.email,
-              "metadata" => user.metadata,
-              "encrypted_metadata" => %{},
-              "created_at" => Date.to_iso8601(user.inserted_at),
-              "updated_at" => Date.to_iso8601(user.updated_at),
-              "account_role" => role.name,
-              "status" => to_string(User.get_status(user)),
-              "avatar" => %{"original" => nil, "large" => nil, "small" => nil, "thumb" => nil}
-            }]
-          }
-        }
+               %{
+                 "version" => "1",
+                 "success" => true,
+                 "data" => %{
+                   "object" => "list",
+                   "data" => [
+                     %{
+                       "object" => "user",
+                       "id" => user.id,
+                       "socket_topic" => "user:#{user.id}",
+                       "username" => user.username,
+                       "provider_user_id" => user.provider_user_id,
+                       "email" => user.email,
+                       "metadata" => user.metadata,
+                       "encrypted_metadata" => %{},
+                       "created_at" => Date.to_iso8601(user.inserted_at),
+                       "updated_at" => Date.to_iso8601(user.updated_at),
+                       "account_role" => role.name,
+                       "status" => to_string(User.get_status(user)),
+                       "avatar" => %{
+                         "original" => nil,
+                         "large" => nil,
+                         "small" => nil,
+                         "thumb" => nil
+                       }
+                     }
+                   ]
+                 }
+               }
     end
 
     test "returns an empty list if account has no users" do
       account = insert(:account)
 
       assert user_request("/account.list_users", %{account_id: account.id}) ==
-        %{
-          "version" => "1",
-          "success" => true,
-          "data" => %{
-            "object" => "list",
-            "data" => []
-          }
-        }
+               %{
+                 "version" => "1",
+                 "success" => true,
+                 "data" => %{
+                   "object" => "list",
+                   "data" => []
+                 }
+               }
     end
 
     test "returns account:id_not_found error if account id could not be found" do
       assert user_request("/account.list_users", %{account_id: "acc_12345678901234567890123456"}) ==
-        %{
-          "success" => false,
-          "version" => "1",
-          "data" => %{
-            "object" => "error",
-            "code" => "account:id_not_found",
-            "description" => "There is no account corresponding to the provided id",
-            "messages" => nil
-          }
-        }
+               %{
+                 "success" => false,
+                 "version" => "1",
+                 "data" => %{
+                   "object" => "error",
+                   "code" => "account:id_not_found",
+                   "description" => "There is no account corresponding to the provided id",
+                   "messages" => nil
+                 }
+               }
     end
 
     test "returns invalid_parameter error if account id is not provided" do
       assert user_request("/account.list_users", %{}) ==
-        %{
-          "success" => false,
-          "version" => "1",
-          "data" => %{
-            "object" => "error",
-            "code" => "client:invalid_parameter",
-            "description" => "Invalid parameter provided",
-            "messages" => nil
-          }
-        }
+               %{
+                 "success" => false,
+                 "version" => "1",
+                 "data" => %{
+                   "object" => "error",
+                   "code" => "client:invalid_parameter",
+                   "description" => "Invalid parameter provided",
+                   "messages" => nil
+                 }
+               }
     end
   end
 
   describe "/account.assign_user" do
     test "returns empty success if assigned with user_id successfully" do
-      response = user_request("/account.assign_user", %{
-        user_id: insert(:user).id,
-        account_id: insert(:account).id,
-        role_name: insert(:role).name,
-        redirect_url: "https://invite_url/?email={email}&token={token}"
-      })
+      response =
+        user_request("/account.assign_user", %{
+          user_id: insert(:user).id,
+          account_id: insert(:account).id,
+          role_name: insert(:role).name,
+          redirect_url: "https://invite_url/?email={email}&token={token}"
+        })
 
       assert response["success"] == true
       assert response["data"] == %{}
     end
 
     test "returns empty success if assigned with email successfully" do
-      response = user_request("/account.assign_user", %{
-        email: insert(:admin).email,
-        account_id: insert(:account).id,
-        role_name: insert(:role).name,
-        redirect_url: "https://invite_url/?email={email}&token={token}"
-      })
+      response =
+        user_request("/account.assign_user", %{
+          email: insert(:admin).email,
+          account_id: insert(:account).id,
+          role_name: insert(:role).name,
+          redirect_url: "https://invite_url/?email={email}&token={token}"
+        })
 
       assert response["success"] == true
       assert response["data"] == %{}
     end
 
     test "returns an error if the email format is invalid" do
-      response = user_request("/account.assign_user", %{
-        email: "invalid_format",
-        account_id: insert(:account).id,
-        role_name: insert(:role).name,
-        redirect_url: "https://invite_url/?email={email}&token={token}"
-      })
+      response =
+        user_request("/account.assign_user", %{
+          email: "invalid_format",
+          account_id: insert(:account).id,
+          role_name: insert(:role).name,
+          redirect_url: "https://invite_url/?email={email}&token={token}"
+        })
 
       assert response["success"] == false
       assert response["data"]["object"] == "error"
@@ -119,71 +129,82 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
     end
 
     test "returns an error if the given user id does not exist" do
-      response = user_request("/account.assign_user", %{
-        user_id: UUID.generate(),
-        account_id: insert(:account).id,
-        role_name: insert(:role).name,
-        redirect_url: "https://invite_url/?email={email}&token={token}"
-      })
+      response =
+        user_request("/account.assign_user", %{
+          user_id: UUID.generate(),
+          account_id: insert(:account).id,
+          role_name: insert(:role).name,
+          redirect_url: "https://invite_url/?email={email}&token={token}"
+        })
 
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
 
     test "returns an error if the given account id does not exist" do
-      response = user_request("/account.assign_user", %{
-        user_id: insert(:user).id,
-        account_id: "acc_12345678901234567890123456",
-        role_name: insert(:role).name,
-        redirect_url: "https://invite_url/?email={email}&token={token}"
-      })
+      response =
+        user_request("/account.assign_user", %{
+          user_id: insert(:user).id,
+          account_id: "acc_12345678901234567890123456",
+          role_name: insert(:role).name,
+          redirect_url: "https://invite_url/?email={email}&token={token}"
+        })
 
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "account:id_not_found"
-      assert response["data"]["description"] == "There is no account corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no account corresponding to the provided id"
     end
 
     test "returns an error if the given role does not exist" do
-      response = user_request("/account.assign_user", %{
-        user_id: insert(:user).id,
-        account_id: insert(:account).id,
-        role_name: "invalid_role",
-        redirect_url: "https://invite_url/?email={email}&token={token}"
-      })
+      response =
+        user_request("/account.assign_user", %{
+          user_id: insert(:user).id,
+          account_id: insert(:account).id,
+          role_name: "invalid_role",
+          redirect_url: "https://invite_url/?email={email}&token={token}"
+        })
 
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "role:name_not_found"
-      assert response["data"]["description"] == "There is no role corresponding to the provided name"
+
+      assert response["data"]["description"] ==
+               "There is no role corresponding to the provided name"
     end
   end
 
   describe "/account.unassign_user" do
     test "returns empty success if unassigned successfully" do
-      account     = insert(:account)
-      user        = insert(:user)
+      account = insert(:account)
+      user = insert(:user)
       _membership = insert(:membership, %{account: account, user: user})
 
-      response    = user_request("/account.unassign_user", %{
-        user_id: user.id,
-        account_id: account.id
-      })
+      response =
+        user_request("/account.unassign_user", %{
+          user_id: user.id,
+          account_id: account.id
+        })
 
       assert response["success"] == true
       assert response["data"] == %{}
     end
 
     test "returns an error if the user was not previously assigned to the account" do
-      user    = insert(:user)
+      user = insert(:user)
       account = insert(:account)
 
-      response = user_request("/account.unassign_user", %{
-        user_id: user.id,
-        account_id: account.id
-      })
+      response =
+        user_request("/account.unassign_user", %{
+          user_id: user.id,
+          account_id: account.id
+        })
 
       assert response["success"] == false
       assert response["data"]["object"] == "error"
@@ -192,27 +213,33 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
     end
 
     test "returns an error if the given user id does not exist" do
-      response = user_request("/account.unassign_user", %{
-        user_id: UUID.generate(),
-        account_id: insert(:account).id
-      })
+      response =
+        user_request("/account.unassign_user", %{
+          user_id: UUID.generate(),
+          account_id: insert(:account).id
+        })
 
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
 
     test "returns an error if the given account id does not exist" do
-      response = user_request("/account.unassign_user", %{
-        user_id: insert(:user).id,
-        account_id: "acc_12345678901234567890123456"
-      })
+      response =
+        user_request("/account.unassign_user", %{
+          user_id: insert(:user).id,
+          account_id: "acc_12345678901234567890123456"
+        })
 
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "account:id_not_found"
-      assert response["data"]["description"] == "There is no account corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no account corresponding to the provided id"
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_controller_test.exs
@@ -14,28 +14,29 @@ defmodule AdminAPI.V1.AdminControllerTest do
 
       # Asserts pagination data
       pagination = response["data"]["pagination"]
-      assert is_integer pagination["per_page"]
-      assert is_integer pagination["current_page"]
-      assert is_boolean pagination["is_last_page"]
-      assert is_boolean pagination["is_first_page"]
+      assert is_integer(pagination["per_page"])
+      assert is_integer(pagination["current_page"])
+      assert is_boolean(pagination["is_last_page"])
+      assert is_boolean(pagination["is_first_page"])
     end
 
     test "returns a list of admins according to search_term, sort_by and sort_direction" do
       account = insert(:account)
-      role    = insert(:role, %{name: "some_role"})
-      admin1  = insert(:admin, %{email: "admin1@omise.co"})
-      admin2  = insert(:admin, %{email: "admin2@omise.co"})
-      admin3  = insert(:admin, %{email: "admin3@omise.co"})
-      _user   = insert(:user, %{email: "user1@omise.co"})
+      role = insert(:role, %{name: "some_role"})
+      admin1 = insert(:admin, %{email: "admin1@omise.co"})
+      admin2 = insert(:admin, %{email: "admin2@omise.co"})
+      admin3 = insert(:admin, %{email: "admin3@omise.co"})
+      _user = insert(:user, %{email: "user1@omise.co"})
 
       insert(:membership, %{user: admin1, account: account, role: role})
       insert(:membership, %{user: admin2, account: account, role: role})
       insert(:membership, %{user: admin3, account: account, role: role})
 
       attrs = %{
-        "search_term" => "AdMiN", # Search is case-insensitive
-        "sort_by"     => "email",
-        "sort_dir"    => "desc"
+        # Search is case-insensitive
+        "search_term" => "AdMiN",
+        "sort_by" => "email",
+        "sort_dir" => "desc"
       }
 
       response = user_request("/admin.all", attrs)
@@ -51,9 +52,9 @@ defmodule AdminAPI.V1.AdminControllerTest do
 
   describe "/admin.get" do
     test "returns an admin by the given admin's ID" do
-      account     = insert(:account)
-      role        = insert(:role, %{name: "some_role"})
-      admin       = insert(:admin, %{email: "admin@omise.co"})
+      account = insert(:account)
+      role = insert(:role, %{name: "some_role"})
+      admin = insert(:admin, %{email: "admin@omise.co"})
       _membership = insert(:membership, %{user: admin, account: account, role: role})
 
       response = user_request("/admin.get", %{"id" => admin.id})
@@ -64,83 +65,98 @@ defmodule AdminAPI.V1.AdminControllerTest do
     end
 
     test "returns 'user:id_not_found' if the given ID is not an admin" do
-      user     = insert(:user)
+      user = insert(:user)
       response = user_request("/admin.get", %{"id" => user.id})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
 
     test "returns 'user:id_not_found' if the given ID was not found" do
-      response  = user_request("/admin.get", %{"id" => UUID.generate()})
+      response = user_request("/admin.get", %{"id" => UUID.generate()})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
 
     test "returns 'user:id_not_found' if the given ID format is invalid" do
-      response  = user_request("/admin.get", %{"id" => "not_valid_id_format"})
+      response = user_request("/admin.get", %{"id" => "not_valid_id_format"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
   end
 
   describe "/admin.upload_avatar" do
     test "uploads an avatar for the specified user" do
-      account     = insert(:account)
-      role        = insert(:role, %{name: "some_role"})
-      admin       = insert(:admin, %{email: "admin@omise.co"})
-      uuid        = admin.id
+      account = insert(:account)
+      role = insert(:role, %{name: "some_role"})
+      admin = insert(:admin, %{email: "admin@omise.co"})
+      uuid = admin.id
       _membership = insert(:membership, %{user: admin, account: account, role: role})
 
-      response = user_request("/admin.upload_avatar", %{
-        "id" => uuid,
-        "avatar" => %Plug.Upload{
-          path: "test/support/assets/test.jpg",
-          filename: "test.jpg"
-        }
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => uuid,
+          "avatar" => %Plug.Upload{
+            path: "test/support/assets/test.jpg",
+            filename: "test.jpg"
+          }
+        })
 
       assert response["success"]
       assert response["data"]["object"] == "user"
       assert response["data"]["email"] == admin.email
+
       assert response["data"]["avatar"]["large"] =~
-             "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/large.png?v="
+               "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/large.png?v="
+
       assert response["data"]["avatar"]["original"] =~
-             "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/original.jpg?v="
+               "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/original.jpg?v="
+
       assert response["data"]["avatar"]["small"] =~
-             "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/small.png?v="
+               "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/small.png?v="
+
       assert response["data"]["avatar"]["thumb"] =~
-             "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/thumb.png?v="
+               "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/thumb.png?v="
     end
 
     test "removes the avatar from a user" do
-      account     = insert(:account)
-      role        = insert(:role, %{name: "some_role"})
-      admin       = insert(:admin, %{email: "admin@omise.co"})
-      uuid        = admin.id
+      account = insert(:account)
+      role = insert(:role, %{name: "some_role"})
+      admin = insert(:admin, %{email: "admin@omise.co"})
+      uuid = admin.id
       _membership = insert(:membership, %{user: admin, account: account, role: role})
 
-      response = user_request("/admin.upload_avatar", %{
-        "id" => uuid,
-        "avatar" => %Plug.Upload{
-          path: "test/support/assets/test.jpg",
-          filename: "test.jpg"
-        }
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => uuid,
+          "avatar" => %Plug.Upload{
+            path: "test/support/assets/test.jpg",
+            filename: "test.jpg"
+          }
+        })
+
       assert response["success"]
 
-      response = user_request("/admin.upload_avatar", %{
-        "id" => uuid,
-        "avatar" => nil
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => uuid,
+          "avatar" => nil
+        })
+
       assert response["success"]
 
       admin = User.get(admin.id)
@@ -148,25 +164,29 @@ defmodule AdminAPI.V1.AdminControllerTest do
     end
 
     test "removes the avatar from a user with empty string" do
-      account     = insert(:account)
-      role        = insert(:role, %{name: "some_role"})
-      admin       = insert(:admin, %{email: "admin@omise.co"})
-      uuid        = admin.id
+      account = insert(:account)
+      role = insert(:role, %{name: "some_role"})
+      admin = insert(:admin, %{email: "admin@omise.co"})
+      uuid = admin.id
       _membership = insert(:membership, %{user: admin, account: account, role: role})
 
-      response = user_request("/admin.upload_avatar", %{
-        "id" => uuid,
-        "avatar" => %Plug.Upload{
-          path: "test/support/assets/test.jpg",
-          filename: "test.jpg"
-        }
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => uuid,
+          "avatar" => %Plug.Upload{
+            path: "test/support/assets/test.jpg",
+            filename: "test.jpg"
+          }
+        })
+
       assert response["success"]
 
-      response = user_request("/admin.upload_avatar", %{
-        "id" => uuid,
-        "avatar" => ""
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => uuid,
+          "avatar" => ""
+        })
+
       assert response["success"]
 
       admin = User.get(admin.id)
@@ -174,25 +194,29 @@ defmodule AdminAPI.V1.AdminControllerTest do
     end
 
     test "removes the avatar from a user with 'null' string" do
-      account     = insert(:account)
-      role        = insert(:role, %{name: "some_role"})
-      admin       = insert(:admin, %{email: "admin@omise.co"})
-      uuid        = admin.id
+      account = insert(:account)
+      role = insert(:role, %{name: "some_role"})
+      admin = insert(:admin, %{email: "admin@omise.co"})
+      uuid = admin.id
       _membership = insert(:membership, %{user: admin, account: account, role: role})
 
-      response = user_request("/admin.upload_avatar", %{
-        "id" => uuid,
-        "avatar" => %Plug.Upload{
-          path: "test/support/assets/test.jpg",
-          filename: "test.jpg"
-        }
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => uuid,
+          "avatar" => %Plug.Upload{
+            path: "test/support/assets/test.jpg",
+            filename: "test.jpg"
+          }
+        })
+
       assert response["success"]
 
-      response = user_request("/admin.upload_avatar", %{
-        "id" => uuid,
-        "avatar" => "null"
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => uuid,
+          "avatar" => "null"
+        })
+
       assert response["success"]
 
       admin = User.get(admin.id)
@@ -200,49 +224,59 @@ defmodule AdminAPI.V1.AdminControllerTest do
     end
 
     test "returns 'user:id_not_found' if the given ID is not an admin" do
-      user     = insert(:user)
-      response = user_request("/admin.upload_avatar", %{
-        "id" => user.id,
-        "avatar" => %Plug.Upload{
-          path: "test/support/assets/test.jpg",
-          filename: "test.jpg"
-        }
-      })
+      user = insert(:user)
+
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => user.id,
+          "avatar" => %Plug.Upload{
+            path: "test/support/assets/test.jpg",
+            filename: "test.jpg"
+          }
+        })
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
 
     test "returns 'user:id_not_found' if the given ID was not found" do
-      response  = user_request("/admin.upload_avatar", %{
-        "id" => "usr_12345678901234567890123456",
-        "avatar" => %Plug.Upload{
-          path: "test/support/assets/test.jpg",
-          filename: "test.jpg"
-        }
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => "usr_12345678901234567890123456",
+          "avatar" => %Plug.Upload{
+            path: "test/support/assets/test.jpg",
+            filename: "test.jpg"
+          }
+        })
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
 
     test "returns 'user:id_not_found' if the given ID format is invalid" do
-      response  = user_request("/admin.upload_avatar", %{
-        "id" => "not_valid_id_format",
-        "avatar" => %Plug.Upload{
-          path: "test/support/assets/test.jpg",
-          filename: "test.jpg"
-        }
-      })
+      response =
+        user_request("/admin.upload_avatar", %{
+          "id" => "not_valid_id_format",
+          "avatar" => %Plug.Upload{
+            path: "test/support/assets/test.jpg",
+            filename: "test.jpg"
+          }
+        })
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/api_key_controller_test.exs
@@ -9,41 +9,41 @@ defmodule AdminAPI.V1.APIKeyControllerTest do
       [api_key1, api_key2] = APIKey |> ensure_num_records(2) |> Preloader.preload(:account)
 
       assert user_request("/api_key.all") ==
-        %{
-          "version" => "1",
-          "success" => true,
-          "data" => %{
-            "object" => "list",
-            "data" => [
-              %{
-                "object" => "api_key",
-                "id" => api_key1.id,
-                "key" => api_key1.key,
-                "account_id" => api_key1.account.id,
-                "owner_app" => api_key1.owner_app,
-                "created_at" => Date.to_iso8601(api_key1.inserted_at),
-                "updated_at" => Date.to_iso8601(api_key1.updated_at),
-                "deleted_at" => Date.to_iso8601(api_key1.deleted_at)
-              },
-              %{
-                "object" => "api_key",
-                "id" => api_key2.id,
-                "key" => api_key2.key,
-                "account_id" => api_key2.account.id,
-                "owner_app" => api_key2.owner_app,
-                "created_at" => Date.to_iso8601(api_key2.inserted_at),
-                "updated_at" => Date.to_iso8601(api_key2.updated_at),
-                "deleted_at" => Date.to_iso8601(api_key2.deleted_at)
-              }
-            ],
-            "pagination" => %{
-              "current_page" => 1,
-              "per_page" => 10,
-              "is_first_page" => true,
-              "is_last_page" => true
-            }
-          }
-        }
+               %{
+                 "version" => "1",
+                 "success" => true,
+                 "data" => %{
+                   "object" => "list",
+                   "data" => [
+                     %{
+                       "object" => "api_key",
+                       "id" => api_key1.id,
+                       "key" => api_key1.key,
+                       "account_id" => api_key1.account.id,
+                       "owner_app" => api_key1.owner_app,
+                       "created_at" => Date.to_iso8601(api_key1.inserted_at),
+                       "updated_at" => Date.to_iso8601(api_key1.updated_at),
+                       "deleted_at" => Date.to_iso8601(api_key1.deleted_at)
+                     },
+                     %{
+                       "object" => "api_key",
+                       "id" => api_key2.id,
+                       "key" => api_key2.key,
+                       "account_id" => api_key2.account.id,
+                       "owner_app" => api_key2.owner_app,
+                       "created_at" => Date.to_iso8601(api_key2.inserted_at),
+                       "updated_at" => Date.to_iso8601(api_key2.updated_at),
+                       "deleted_at" => Date.to_iso8601(api_key2.deleted_at)
+                     }
+                   ],
+                   "pagination" => %{
+                     "current_page" => 1,
+                     "per_page" => 10,
+                     "is_first_page" => true,
+                     "is_last_page" => true
+                   }
+                 }
+               }
     end
 
     test "responds with a list of api keys when given params" do
@@ -59,113 +59,113 @@ defmodule AdminAPI.V1.APIKeyControllerTest do
       }
 
       assert user_request("/api_key.all", attrs) ==
-        %{
-          "version" => "1",
-          "success" => true,
-          "data" => %{
-            "object" => "list",
-            "data" => [
-              %{
-                "object"     => "api_key",
-                "id"         => api_key.id,
-                "key"        => api_key.key,
-                "account_id" => api_key.account.id,
-                "owner_app"  => api_key.owner_app,
-                "created_at" => Date.to_iso8601(api_key.inserted_at),
-                "updated_at" => Date.to_iso8601(api_key.updated_at),
-                "deleted_at" => Date.to_iso8601(api_key.deleted_at)
-              }
-            ],
-            "pagination" => %{
-              "current_page"  => 1,
-              "per_page"      => 1,
-              "is_first_page" => true,
-              "is_last_page"  => false
-            }
-          }
-        }
+               %{
+                 "version" => "1",
+                 "success" => true,
+                 "data" => %{
+                   "object" => "list",
+                   "data" => [
+                     %{
+                       "object" => "api_key",
+                       "id" => api_key.id,
+                       "key" => api_key.key,
+                       "account_id" => api_key.account.id,
+                       "owner_app" => api_key.owner_app,
+                       "created_at" => Date.to_iso8601(api_key.inserted_at),
+                       "updated_at" => Date.to_iso8601(api_key.updated_at),
+                       "deleted_at" => Date.to_iso8601(api_key.deleted_at)
+                     }
+                   ],
+                   "pagination" => %{
+                     "current_page" => 1,
+                     "per_page" => 1,
+                     "is_first_page" => true,
+                     "is_last_page" => false
+                   }
+                 }
+               }
     end
   end
 
   describe "/api_key.create" do
     test "responds with an API key on success" do
-      response       = user_request("/api_key.create", %{owner_app: "some_app"})
-      api_key        = get_last_inserted(APIKey)
+      response = user_request("/api_key.create", %{owner_app: "some_app"})
+      api_key = get_last_inserted(APIKey)
 
       assert response == %{
-        "version" => "1",
-        "success" => true,
-        "data" => %{
-          "object"     => "api_key",
-          "id"         => api_key.id,
-          "key"        => api_key.key,
-          "account_id" => Account.get_master_account().id,
-          "owner_app"  => "some_app",
-          "created_at" => Date.to_iso8601(api_key.inserted_at),
-          "updated_at" => Date.to_iso8601(api_key.updated_at),
-          "deleted_at" => Date.to_iso8601(api_key.deleted_at)
-        }
-      }
+               "version" => "1",
+               "success" => true,
+               "data" => %{
+                 "object" => "api_key",
+                 "id" => api_key.id,
+                 "key" => api_key.key,
+                 "account_id" => Account.get_master_account().id,
+                 "owner_app" => "some_app",
+                 "created_at" => Date.to_iso8601(api_key.inserted_at),
+                 "updated_at" => Date.to_iso8601(api_key.updated_at),
+                 "deleted_at" => Date.to_iso8601(api_key.deleted_at)
+               }
+             }
     end
 
     test "returns error if owner_app is not provided" do
       response = user_request("/api_key.create", %{owner_app: nil})
 
       assert response == %{
-        "version" => "1",
-        "success" => false,
-        "data" => %{
-          "object" => "error",
-          "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided `owner_app` can't be blank.",
-          "messages" => %{
-            "owner_app" => ["required"]
-          }
-        }
-      }
+               "version" => "1",
+               "success" => false,
+               "data" => %{
+                 "object" => "error",
+                 "code" => "client:invalid_parameter",
+                 "description" => "Invalid parameter provided `owner_app` can't be blank.",
+                 "messages" => %{
+                   "owner_app" => ["required"]
+                 }
+               }
+             }
     end
   end
 
   describe "/api_key.delete" do
     test "responds with an empty success if provided a valid id" do
-      api_key  = insert(:api_key)
+      api_key = insert(:api_key)
       response = user_request("/api_key.delete", %{id: api_key.id})
 
       assert response == %{
-        "version" => "1",
-        "success" => true,
-        "data" => %{}
-      }
+               "version" => "1",
+               "success" => true,
+               "data" => %{}
+             }
     end
 
     test "responds with an error if the provided id is not found" do
       response = user_request("/api_key.delete", %{id: "wrong_id"})
 
       assert response == %{
-        "version" => "1",
-        "success" => false,
-        "data" => %{
-          "code" => "api_key:not_found",
-          "description" => "The API key could not be found",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "version" => "1",
+               "success" => false,
+               "data" => %{
+                 "code" => "api_key:not_found",
+                 "description" => "The API key could not be found",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "responds with an error if the given id is used for making the deletion request" do
       response = user_request("/api_key.delete", %{id: @api_key_id})
 
       assert response == %{
-        "version" => "1",
-        "success" => false,
-        "data" => %{
-          "code" => "client:invalid_parameter",
-          "description" => "The given API key is being used for this request",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "version" => "1",
+               "success" => false,
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "The given API key is being used for this request",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/auth_controller_test.exs
@@ -4,7 +4,7 @@ defmodule AdminAPI.V1.AuthControllerTest do
 
   describe "/login" do
     test "responds with a new auth token if the given email and password are valid" do
-      response   = client_request("/login", %{email: @user_email, password: @password})
+      response = client_request("/login", %{email: @user_email, password: @password})
       auth_token = get_last_inserted(AuthToken)
 
       expected = %{
@@ -13,7 +13,7 @@ defmodule AdminAPI.V1.AuthControllerTest do
         "data" => %{
           "object" => "authentication_token",
           "authentication_token" => auth_token.token,
-          "user_id" => @user_id,
+          "user_id" => @user_id
         }
       }
 
@@ -21,7 +21,8 @@ defmodule AdminAPI.V1.AuthControllerTest do
     end
 
     test "returns an error if the given email does not exist" do
-      response = client_request("/login", %{email: "wrong_email@example.com", password: @password})
+      response =
+        client_request("/login", %{email: "wrong_email@example.com", password: @password})
 
       expected = %{
         "version" => @expected_version,

--- a/apps/admin_api/test/admin_api/v1/controllers/invite_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/invite_controller_test.exs
@@ -4,17 +4,17 @@ defmodule AdminAPI.V1.InviteControllerTest do
 
   defp request(email, token, password, password_confirmation) do
     client_request("/invite.accept", %{
-      "email"                 => email,
-      "token"                 => token,
-      "password"              => password,
+      "email" => email,
+      "token" => token,
+      "password" => password,
       "password_confirmation" => password_confirmation
     })
   end
 
   describe "InviteController.accept/2" do
     test "returns success if invite is accepted successfully" do
-      invite   = insert(:invite)
-      user     = insert(:admin, %{invite: invite})
+      invite = insert(:invite)
+      user = insert(:admin, %{invite: invite})
       response = request(user.email, invite.token, "some_password", "some_password")
 
       expected = %{
@@ -39,32 +39,34 @@ defmodule AdminAPI.V1.InviteControllerTest do
     end
 
     test "returns :invite_not_found error if the email has not been invited" do
-      invite   = insert(:invite)
-      _user    = insert(:admin, %{invite: invite})
+      invite = insert(:invite)
+      _user = insert(:admin, %{invite: invite})
       response = request("unknown@example.com", invite.token, "some_password", "some_password")
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:invite_not_found"
+
       assert response["data"]["description"] ==
-        "There is no invite corresponding to the provided email and token"
+               "There is no invite corresponding to the provided email and token"
     end
 
     test "returns :invite_not_found error if the token is incorrect" do
-      invite   = insert(:invite)
-      user     = insert(:admin, %{invite: invite})
+      invite = insert(:invite)
+      user = insert(:admin, %{invite: invite})
       response = request(user.email, "wrong_token", "some_password", "some_password")
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:invite_not_found"
+
       assert response["data"]["description"] ==
-        "There is no invite corresponding to the provided email and token"
+               "There is no invite corresponding to the provided email and token"
     end
 
     test "returns :passwords_mismatch error if the passwords do not match" do
-      invite   = insert(:invite)
-      user     = insert(:admin, %{invite: invite})
+      invite = insert(:invite)
+      user = insert(:admin, %{invite: invite})
       response = request(user.email, invite.token, "some_password", "mismatch_password")
 
       refute response["success"]
@@ -75,10 +77,11 @@ defmodule AdminAPI.V1.InviteControllerTest do
 
     test "returns :invalid_parameter error if a required parameter is missing" do
       invite = insert(:invite)
-      user   = insert(:admin, %{invite: invite})
+      user = insert(:admin, %{invite: invite})
 
       # Missing passwords
-      response = client_request("/invite.accept", %{"email" => user.email, "token" => invite.token})
+      response =
+        client_request("/invite.accept", %{"email" => user.email, "token" => invite.token})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/key_controller_test.exs
@@ -9,54 +9,57 @@ defmodule AdminAPI.V1.KeyControllerTest do
       key = insert(:key, %{secret_key: "the_secret_key"})
 
       assert user_request("/access_key.all") ==
-        %{
-          "version" => "1",
-          "success" => true,
-          "data" => %{
-            "object" => "list",
-            "data" => [%{
-              "object" => "key",
-              "id" => key.id,
-              "access_key" => key.access_key,
-              "secret_key" => nil, # Secret keys cannot be retrieved after creation
-              "account_id" => Assoc.get(key, [:account, :id]),
-              "created_at" => Date.to_iso8601(key.inserted_at),
-              "updated_at" => Date.to_iso8601(key.updated_at),
-              "deleted_at" => Date.to_iso8601(key.deleted_at)
-            }],
-            "pagination" => %{
-              "current_page" => 1,
-              "per_page" => 10,
-              "is_first_page" => true,
-              "is_last_page" => true
-            }
-          }
-        }
+               %{
+                 "version" => "1",
+                 "success" => true,
+                 "data" => %{
+                   "object" => "list",
+                   "data" => [
+                     %{
+                       "object" => "key",
+                       "id" => key.id,
+                       "access_key" => key.access_key,
+                       # Secret keys cannot be retrieved after creation
+                       "secret_key" => nil,
+                       "account_id" => Assoc.get(key, [:account, :id]),
+                       "created_at" => Date.to_iso8601(key.inserted_at),
+                       "updated_at" => Date.to_iso8601(key.updated_at),
+                       "deleted_at" => Date.to_iso8601(key.deleted_at)
+                     }
+                   ],
+                   "pagination" => %{
+                     "current_page" => 1,
+                     "per_page" => 10,
+                     "is_first_page" => true,
+                     "is_last_page" => true
+                   }
+                 }
+               }
     end
   end
 
   describe "/access_key.create" do
     test "responds with a key with the secret key" do
-      response       = user_request("/access_key.create")
-      key            = get_last_inserted(Key)
+      response = user_request("/access_key.create")
+      key = get_last_inserted(Key)
 
       # Cannot do `assert response == %{...}` because we don't know the value of `secret_key`.
       # So we assert by pattern matching to validate the response structure, then directly
       # compare each data field for its values.
       assert %{
-        "version" => "1",
-        "success" => true,
-        "data" => %{
-          "object"     => "key",
-          "id"         => _,
-          "access_key" => _,
-          "secret_key" => _,
-          "account_id" => _,
-          "created_at" => _,
-          "updated_at" => _,
-          "deleted_at" => _
-        }
-      } = response
+               "version" => "1",
+               "success" => true,
+               "data" => %{
+                 "object" => "key",
+                 "id" => _,
+                 "access_key" => _,
+                 "secret_key" => _,
+                 "account_id" => _,
+                 "created_at" => _,
+                 "updated_at" => _,
+                 "deleted_at" => _
+               }
+             } = response
 
       assert response["data"]["id"] == key.id
       assert response["data"]["access_key"] == key.access_key
@@ -73,14 +76,14 @@ defmodule AdminAPI.V1.KeyControllerTest do
 
   describe "/access_key.delete" do
     test "responds with an empty success if provided a key id" do
-      key      = insert(:key)
+      key = insert(:key)
       response = user_request("/access_key.delete", %{id: key.id})
 
       assert response == %{"version" => "1", "success" => true, "data" => %{}}
     end
 
     test "responds with an empty success if provided an access_key" do
-      key      = insert(:key)
+      key = insert(:key)
       response = user_request("/access_key.delete", %{access_key: key.access_key})
 
       assert response == %{"version" => "1", "success" => true, "data" => %{}}
@@ -90,15 +93,15 @@ defmodule AdminAPI.V1.KeyControllerTest do
       response = user_request("/access_key.delete", %{id: "wrong_id"})
 
       assert response == %{
-        "version" => "1",
-        "success" => false,
-        "data" => %{
-          "code" => "key:not_found",
-          "description" => "The key could not be found",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "version" => "1",
+               "success" => false,
+               "data" => %{
+                 "code" => "key:not_found",
+                 "description" => "The key could not be found",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/minted_token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/minted_token_controller_test.exs
@@ -13,10 +13,10 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
 
       # Asserts pagination data
       pagination = response["data"]["pagination"]
-      assert is_integer pagination["per_page"]
-      assert is_integer pagination["current_page"]
-      assert is_boolean pagination["is_last_page"]
-      assert is_boolean pagination["is_first_page"]
+      assert is_integer(pagination["per_page"])
+      assert is_integer(pagination["current_page"])
+      assert is_boolean(pagination["is_last_page"])
+      assert is_boolean(pagination["is_first_page"])
     end
 
     test "returns a list of minted tokens according to search_term, sort_by and sort_direction" do
@@ -26,9 +26,10 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
       insert(:minted_token, %{symbol: "ZZZ1"})
 
       attrs = %{
-        "search_term" => "xYz", # Search is case-insensitive
-        "sort_by"     => "symbol",
-        "sort_dir"    => "desc"
+        # Search is case-insensitive
+        "search_term" => "xYz",
+        "sort_by" => "symbol",
+        "sort_dir" => "desc"
       }
 
       response = user_request("/minted_token.all", attrs)
@@ -45,8 +46,9 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
   describe "/minted_token.get" do
     test "returns a minted token by the given ID" do
       minted_tokens = insert_list(3, :minted_token)
-      target        = Enum.at(minted_tokens, 1) # Pick the 2nd inserted minted token
-      response      = user_request("/minted_token.get", %{"id" => target.id})
+      # Pick the 2nd inserted minted token
+      target = Enum.at(minted_tokens, 1)
+      response = user_request("/minted_token.get", %{"id" => target.id})
 
       assert response["success"]
       assert response["data"]["object"] == "minted_token"
@@ -54,17 +56,18 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     end
 
     test "returns 'minted_token:id_not_found' if the given ID was not found" do
-      response  = user_request("/minted_token.get", %{"id" => "wrong_id"})
+      response = user_request("/minted_token.get", %{"id" => "wrong_id"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "minted_token:id_not_found"
+
       assert response["data"]["description"] ==
-        "There is no minted token corresponding to the provided id"
+               "There is no minted token corresponding to the provided id"
     end
 
     test "returns 'client:invalid_parameter' if id was not provided" do
-      response  = user_request("/minted_token.get", %{"not_id" => "minted_token_id"})
+      response = user_request("/minted_token.get", %{"not_id" => "minted_token_id"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
@@ -75,14 +78,16 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
 
   describe "/minted_token.create" do
     test "inserts a new minted token" do
-      response = user_request("/minted_token.create", %{
-        symbol: "BTC",
-        name: "Bitcoin",
-        description: "desc",
-        subunit_to_unit: 100,
-        metadata: %{something: "interesting"},
-        encrypted_metadata: %{something: "secret"}
-      })
+      response =
+        user_request("/minted_token.create", %{
+          symbol: "BTC",
+          name: "Bitcoin",
+          description: "desc",
+          subunit_to_unit: 100,
+          metadata: %{something: "interesting"},
+          encrypted_metadata: %{something: "secret"}
+        })
+
       mint = Mint |> Repo.all() |> Enum.at(0)
 
       assert response["success"]
@@ -94,13 +99,15 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     end
 
     test "inserts a new minted token with no minting if amount is nil" do
-      response = user_request("/minted_token.create", %{
-        symbol: "BTC",
-        name: "Bitcoin",
-        description: "desc",
-        subunit_to_unit: 100,
-        amount: nil
-      })
+      response =
+        user_request("/minted_token.create", %{
+          symbol: "BTC",
+          name: "Bitcoin",
+          description: "desc",
+          subunit_to_unit: 100,
+          amount: nil
+        })
+
       mint = Mint |> Repo.all() |> Enum.at(0)
 
       assert response["success"]
@@ -110,13 +117,15 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     end
 
     test "inserts a new minted token with no minting if amount is a string" do
-      response = user_request("/minted_token.create", %{
-        symbol: "BTC",
-        name: "Bitcoin",
-        description: "desc",
-        subunit_to_unit: 100,
-        amount: "100"
-      })
+      response =
+        user_request("/minted_token.create", %{
+          symbol: "BTC",
+          name: "Bitcoin",
+          description: "desc",
+          subunit_to_unit: 100,
+          amount: "100"
+        })
+
       mint = Mint |> Repo.all() |> Enum.at(0)
 
       assert response["success"]
@@ -126,13 +135,15 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     end
 
     test "fails a new minted token with no minting if amount is 0" do
-      response = user_request("/minted_token.create", %{
-        symbol: "BTC",
-        name: "Bitcoin",
-        description: "desc",
-        subunit_to_unit: 100,
-        amount: 0
-      })
+      response =
+        user_request("/minted_token.create", %{
+          symbol: "BTC",
+          name: "Bitcoin",
+          description: "desc",
+          subunit_to_unit: 100,
+          amount: 0
+        })
+
       mint = Mint |> Repo.all() |> Enum.at(0)
 
       assert response["success"]
@@ -142,13 +153,15 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     end
 
     test "mints the given amount of tokens" do
-      response = user_request("/minted_token.create", %{
-        symbol: "BTC",
-        name: "Bitcoin",
-        description: "desc",
-        subunit_to_unit: 100,
-        amount: 1_000 * 100
-      })
+      response =
+        user_request("/minted_token.create", %{
+          symbol: "BTC",
+          name: "Bitcoin",
+          description: "desc",
+          subunit_to_unit: 100,
+          amount: 1_000 * 100
+        })
+
       mint = Mint |> Repo.all() |> Enum.at(0)
 
       assert response["success"]
@@ -159,17 +172,20 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     end
 
     test "returns insert error when attrs are invalid" do
-      response = user_request("/minted_token.create", %{
-        name: "Bitcoin",
-        description: "desc",
-        subunit_to_unit: 100
-      })
+      response =
+        user_request("/minted_token.create", %{
+          name: "Bitcoin",
+          description: "desc",
+          subunit_to_unit: 100
+        })
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
+
       assert response["data"]["description"] ==
-             "Invalid parameter provided `symbol` can't be blank."
+               "Invalid parameter provided `symbol` can't be blank."
+
       inserted = MintedToken |> Repo.all() |> Enum.at(0)
       assert inserted == nil
     end
@@ -178,10 +194,13 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
   describe "/minted_token.mint" do
     test "mints an existing minted token" do
       minted_token = insert(:minted_token)
-      response = user_request("/minted_token.mint", %{
-        id: minted_token.id,
-        amount: 1_000_000 * minted_token.subunit_to_unit
-      })
+
+      response =
+        user_request("/minted_token.mint", %{
+          id: minted_token.id,
+          amount: 1_000_000 * minted_token.subunit_to_unit
+        })
+
       mint = Mint |> Repo.all() |> Enum.at(0)
 
       assert response["success"]
@@ -193,10 +212,11 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     end
 
     test "fails to mint a non existing token" do
-      response = user_request("/minted_token.mint", %{
-        id: "123",
-        amount: 1_000_000
-      })
+      response =
+        user_request("/minted_token.mint", %{
+          id: "123",
+          amount: 1_000_000
+        })
 
       refute response["success"]
       assert response["data"]["object"] == "error"
@@ -206,10 +226,11 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     test "fails to mint with mint amount sent as string" do
       minted_token = insert(:minted_token)
 
-      response = user_request("/minted_token.mint", %{
-        id: minted_token.id,
-        amount: "abc"
-      })
+      response =
+        user_request("/minted_token.mint", %{
+          id: minted_token.id,
+          amount: "abc"
+        })
 
       refute response["success"]
       assert response["data"]["object"] == "error"
@@ -220,30 +241,38 @@ defmodule AdminAPI.V1.MintedTokenControllerTest do
     test "fails to mint with mint amount == 0" do
       minted_token = insert(:minted_token)
 
-      response = user_request("/minted_token.mint", %{
-        id: minted_token.id,
-        amount: 0
-      })
+      response =
+        user_request("/minted_token.mint", %{
+          id: minted_token.id,
+          amount: 0
+        })
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided `amount` must be greater than %{number}."
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided `amount` must be greater than %{number}."
+
       assert response["data"]["messages"] == %{"amount" => ["number"]}
     end
 
     test "fails to mint with mint amount < 0" do
       minted_token = insert(:minted_token)
 
-      response = user_request("/minted_token.mint", %{
-        id: minted_token.id,
-        amount: -1
-      })
+      response =
+        user_request("/minted_token.mint", %{
+          id: minted_token.id,
+          amount: -1
+        })
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided `amount` must be greater than %{number}."
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided `amount` must be greater than %{number}."
+
       assert response["data"]["messages"] == %{"amount" => ["number"]}
     end
   end

--- a/apps/admin_api/test/admin_api/v1/controllers/reset_password_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/reset_password_controller_test.exs
@@ -8,10 +8,11 @@ defmodule AdminAPI.V1.ResetPasswordControllerTest do
     test "returns success if the request was generated successfully" do
       user = insert(:admin)
 
-      response = client_request("/password.reset", %{
-        "email"        => user.email,
-        "redirect_url" => "http://example.com"
-      })
+      response =
+        client_request("/password.reset", %{
+          "email" => user.email,
+          "redirect_url" => "http://example.com"
+        })
 
       request =
         ForgetPasswordRequest
@@ -19,16 +20,17 @@ defmodule AdminAPI.V1.ResetPasswordControllerTest do
         |> Repo.preload(:user)
 
       assert response["success"]
-      assert_delivered_email ForgetPasswordEmail.create(request, "http://example.com")
+      assert_delivered_email(ForgetPasswordEmail.create(request, "http://example.com"))
       assert request != nil
       assert request.token != nil
     end
 
     test "returns an error if no user is found with the associated email" do
-      response = client_request("/password.reset", %{
-        "email"        => "example@mail.com",
-        "redirect_url" => "http://example.com"
-      })
+      response =
+        client_request("/password.reset", %{
+          "email" => "example@mail.com",
+          "redirect_url" => "http://example.com"
+        })
 
       assert response["success"] == false
       assert response["data"]["code"] == "user:email_not_found"
@@ -37,9 +39,10 @@ defmodule AdminAPI.V1.ResetPasswordControllerTest do
     test "returns an error if the email is not supplied" do
       user = insert(:admin)
 
-      response = client_request("/password.reset", %{
-        "redirect_url" => "http://example.com"
-      })
+      response =
+        client_request("/password.reset", %{
+          "redirect_url" => "http://example.com"
+        })
 
       request =
         ForgetPasswordRequest
@@ -54,9 +57,10 @@ defmodule AdminAPI.V1.ResetPasswordControllerTest do
     test "returns an error if the redirect_url is not supplied" do
       user = insert(:admin)
 
-      response = client_request("/password.reset", %{
-        "email" => user.email,
-      })
+      response =
+        client_request("/password.reset", %{
+          "email" => user.email
+        })
 
       request =
         ForgetPasswordRequest
@@ -71,17 +75,18 @@ defmodule AdminAPI.V1.ResetPasswordControllerTest do
 
   describe "ResetPasswordController.update/2" do
     test "returns success and updates the password if the password has been reset succesfully" do
-      user    = insert(:admin)
+      user = insert(:admin)
       request = ForgetPasswordRequest.generate(user)
 
       assert user.password_hash != Crypto.hash_password("password")
 
-      response = client_request("/password.update", %{
-        email: user.email,
-        token: request.token,
-        password: "password",
-        password_confirmation: "password"
-      })
+      response =
+        client_request("/password.update", %{
+          email: user.email,
+          token: request.token,
+          password: "password",
+          password_confirmation: "password"
+        })
 
       assert response["success"]
       user = User.get(user.id)
@@ -90,15 +95,16 @@ defmodule AdminAPI.V1.ResetPasswordControllerTest do
     end
 
     test "returns an email_not_found error when the user is not found" do
-      user    = insert(:admin)
+      user = insert(:admin)
       request = ForgetPasswordRequest.generate(user)
 
-      response = client_request("/password.update", %{
-        email: "example@mail.com",
-        token: request.token,
-        password: "password",
-        password_confirmation: "password"
-      })
+      response =
+        client_request("/password.update", %{
+          email: "example@mail.com",
+          token: request.token,
+          password: "password",
+          password_confirmation: "password"
+        })
 
       assert response["success"] == false
       assert response["data"]["code"] == "user:email_not_found"
@@ -106,17 +112,18 @@ defmodule AdminAPI.V1.ResetPasswordControllerTest do
     end
 
     test "returns a token_not_found error when the request is not found" do
-      user      = insert(:admin)
-      _request  = ForgetPasswordRequest.generate(user)
+      user = insert(:admin)
+      _request = ForgetPasswordRequest.generate(user)
 
       assert user.password_hash != Crypto.hash_password("password")
 
-      response = client_request("/password.update", %{
-        email: user.email,
-        token: "123",
-        password: "password",
-        password_confirmation: "password"
-      })
+      response =
+        client_request("/password.update", %{
+          email: user.email,
+          token: "123",
+          password: "password",
+          password_confirmation: "password"
+        })
 
       assert response["success"] == false
       assert response["data"]["code"] == "forget_password:token_not_found"
@@ -124,16 +131,17 @@ defmodule AdminAPI.V1.ResetPasswordControllerTest do
     end
 
     test "returns an invalid parameter error when the email is not sent" do
-      user    = insert(:admin)
+      user = insert(:admin)
       request = ForgetPasswordRequest.generate(user)
 
       assert user.password_hash != Crypto.hash_password("password")
 
-      response = client_request("/password.update", %{
-        token: request.token,
-        password: "password",
-        password_confirmation: "password"
-      })
+      response =
+        client_request("/password.update", %{
+          token: request.token,
+          password: "password",
+          password_confirmation: "password"
+        })
 
       assert response["success"] == false
       assert response["data"]["code"] == "client:invalid_parameter"

--- a/apps/admin_api/test/admin_api/v1/controllers/self_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/self_controller_test.exs
@@ -19,46 +19,46 @@ defmodule AdminAPI.V1.SelfControllerTest do
       account = User.get_account(get_test_user())
 
       assert user_request("/me.get_account") ==
-        %{
-          "version" => "1",
-          "success" => true,
-          "data" => %{
-            "object" => "account",
-            "id" => account.id,
-            "socket_topic" => "account:#{account.id}",
-            "parent_id" => Assoc.get(account, [:parent, :id]),
-            "name" => account.name,
-            "description" => account.description,
-            "master" => Account.master?(account),
-            "metadata" => %{},
-            "encrypted_metadata" => %{},
-            "avatar" => %{
-              "original" => nil,
-              "large" => nil,
-              "small" => nil,
-              "thumb" => nil
-            },
-            "created_at" => Date.to_iso8601(account.inserted_at),
-            "updated_at" => Date.to_iso8601(account.updated_at)
-          }
-        }
+               %{
+                 "version" => "1",
+                 "success" => true,
+                 "data" => %{
+                   "object" => "account",
+                   "id" => account.id,
+                   "socket_topic" => "account:#{account.id}",
+                   "parent_id" => Assoc.get(account, [:parent, :id]),
+                   "name" => account.name,
+                   "description" => account.description,
+                   "master" => Account.master?(account),
+                   "metadata" => %{},
+                   "encrypted_metadata" => %{},
+                   "avatar" => %{
+                     "original" => nil,
+                     "large" => nil,
+                     "small" => nil,
+                     "thumb" => nil
+                   },
+                   "created_at" => Date.to_iso8601(account.inserted_at),
+                   "updated_at" => Date.to_iso8601(account.updated_at)
+                 }
+               }
     end
 
     test "responds with error if the user does not have an account" do
       user = get_test_user()
-      Repo.delete_all(from m in Membership, where: m.user_uuid == ^user.uuid)
+      Repo.delete_all(from(m in Membership, where: m.user_uuid == ^user.uuid))
 
       assert user_request("/me.get_account") ==
-        %{
-          "version" => "1",
-          "success" => false,
-          "data"    => %{
-            "object"      => "error",
-            "code"        => "user:account_not_found",
-            "description" => "There is no account assigned to the provided user",
-            "messages"    => nil
-          }
-        }
+               %{
+                 "version" => "1",
+                 "success" => false,
+                 "data" => %{
+                   "object" => "error",
+                   "code" => "user:account_not_found",
+                   "description" => "There is no account assigned to the provided user",
+                   "messages" => nil
+                 }
+               }
     end
   end
 
@@ -69,44 +69,44 @@ defmodule AdminAPI.V1.SelfControllerTest do
       account = insert(:account, %{parent: parent})
 
       # Clear all memberships for this user then add just one for precision
-      Repo.delete_all(from m in Membership, where: m.user_uuid == ^user.uuid)
+      Repo.delete_all(from(m in Membership, where: m.user_uuid == ^user.uuid))
       Membership.assign(user, account, "admin")
 
       assert user_request("/me.get_accounts") ==
-        %{
-          "version" => "1",
-          "success" => true,
-          "data" => %{
-            "object" => "list",
-            "data" => [
-              %{
-                "object" => "account",
-                "id" => account.id,
-                "socket_topic" => "account:#{account.id}",
-                "parent_id" => Assoc.get(account, [:parent, :id]),
-                "name" => account.name,
-                "description" => account.description,
-                "master" => Account.master?(account),
-                "metadata" => %{},
-                "encrypted_metadata" => %{},
-                "avatar" => %{
-                  "original" => nil,
-                  "large" => nil,
-                  "small" => nil,
-                  "thumb" => nil
-                },
-                "created_at" => Date.to_iso8601(account.inserted_at),
-                "updated_at" => Date.to_iso8601(account.updated_at)
-              }
-            ],
-            "pagination" => %{
-              "current_page" => 1,
-              "per_page" => 10,
-              "is_first_page" => true,
-              "is_last_page" => true
-            }
-          }
-        }
+               %{
+                 "version" => "1",
+                 "success" => true,
+                 "data" => %{
+                   "object" => "list",
+                   "data" => [
+                     %{
+                       "object" => "account",
+                       "id" => account.id,
+                       "socket_topic" => "account:#{account.id}",
+                       "parent_id" => Assoc.get(account, [:parent, :id]),
+                       "name" => account.name,
+                       "description" => account.description,
+                       "master" => Account.master?(account),
+                       "metadata" => %{},
+                       "encrypted_metadata" => %{},
+                       "avatar" => %{
+                         "original" => nil,
+                         "large" => nil,
+                         "small" => nil,
+                         "thumb" => nil
+                       },
+                       "created_at" => Date.to_iso8601(account.inserted_at),
+                       "updated_at" => Date.to_iso8601(account.updated_at)
+                     }
+                   ],
+                   "pagination" => %{
+                     "current_page" => 1,
+                     "per_page" => 10,
+                     "is_first_page" => true,
+                     "is_last_page" => true
+                   }
+                 }
+               }
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/status_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/status_controller_test.exs
@@ -27,9 +27,9 @@ defmodule AdminAPI.V1.StatusControllerTest do
       #
       # See example: /phoenix/test/phoenix/endpoint/render_errors_test.exs
       {status, _headers, response} =
-        assert_error_sent 500, fn ->
+        assert_error_sent(500, fn ->
           client_request("/status.server_error")
-        end
+        end)
 
       assert status == 500
       assert Parser.parse!(response) == expected

--- a/apps/admin_api/test/admin_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/transaction_controller_test.exs
@@ -12,10 +12,10 @@ defmodule AdminAPI.V1.TransactionControllerTest do
 
       # Asserts pagination data
       pagination = response["data"]["pagination"]
-      assert is_integer pagination["per_page"]
-      assert is_integer pagination["current_page"]
-      assert is_boolean pagination["is_last_page"]
-      assert is_boolean pagination["is_first_page"]
+      assert is_integer(pagination["per_page"])
+      assert is_integer(pagination["current_page"])
+      assert is_boolean(pagination["is_last_page"])
+      assert is_boolean(pagination["is_first_page"])
     end
 
     test "returns a list of transactions according to search_term, sort_by and sort_direction" do
@@ -30,9 +30,10 @@ defmodule AdminAPI.V1.TransactionControllerTest do
       insert(:transfer, %{from_balance: balance4})
 
       attrs = %{
-        "search_term" => "aBc", # Search is case-insensitive
-        "sort_by"     => "from",
-        "sort_dir"    => "desc"
+        # Search is case-insensitive
+        "search_term" => "aBc",
+        "sort_by" => "from",
+        "sort_dir" => "desc"
       }
 
       response = user_request("/transaction.all", attrs)
@@ -48,8 +49,9 @@ defmodule AdminAPI.V1.TransactionControllerTest do
 
   describe "/transaction.get" do
     test "returns an transaction by the given transaction's ID" do
-      transactions    = insert_list(3, :transfer)
-      target   = Enum.at(transactions, 1) # Pick the 2nd inserted transaction
+      transactions = insert_list(3, :transfer)
+      # Pick the 2nd inserted transaction
+      target = Enum.at(transactions, 1)
       response = user_request("/transaction.get", %{"id" => target.id})
 
       assert response["success"]
@@ -58,23 +60,25 @@ defmodule AdminAPI.V1.TransactionControllerTest do
     end
 
     test "returns 'transaction:id_not_found' if the given ID was not found" do
-      response  = user_request("/transaction.get", %{"id" => "tfr_12345678901234567890123456"})
+      response = user_request("/transaction.get", %{"id" => "tfr_12345678901234567890123456"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "transaction:id_not_found"
+
       assert response["data"]["description"] ==
-        "There is no transaction corresponding to the provided id"
+               "There is no transaction corresponding to the provided id"
     end
 
     test "returns 'transaction:id_not_found' if the given ID format is invalid" do
-      response  = user_request("/transaction.get", %{"id" => "not_valid_id"})
+      response = user_request("/transaction.get", %{"id" => "not_valid_id"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "transaction:id_not_found"
+
       assert response["data"]["description"] ==
-        "There is no transaction corresponding to the provided id"
+               "There is no transaction corresponding to the provided id"
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
@@ -12,10 +12,10 @@ defmodule AdminAPI.V1.UserControllerTest do
 
       # Asserts pagination data
       pagination = response["data"]["pagination"]
-      assert is_integer pagination["per_page"]
-      assert is_integer pagination["current_page"]
-      assert is_boolean pagination["is_last_page"]
-      assert is_boolean pagination["is_first_page"]
+      assert is_integer(pagination["per_page"])
+      assert is_integer(pagination["current_page"])
+      assert is_boolean(pagination["is_last_page"])
+      assert is_boolean(pagination["is_first_page"])
     end
 
     test "returns a list of users according to search_term, sort_by and sort_direction" do
@@ -25,9 +25,10 @@ defmodule AdminAPI.V1.UserControllerTest do
       insert(:user, %{username: "missed_user1"})
 
       attrs = %{
-        "search_term" => "MaTcH", # Search is case-insensitive
-        "sort_by"     => "username",
-        "sort_dir"    => "desc"
+        # Search is case-insensitive
+        "search_term" => "MaTcH",
+        "sort_by" => "username",
+        "sort_dir" => "desc"
       }
 
       response = user_request("/user.all", attrs)
@@ -43,8 +44,9 @@ defmodule AdminAPI.V1.UserControllerTest do
 
   describe "/user.get" do
     test "returns an user by the given user's ID" do
-      users    = insert_list(3, :user)
-      target   = Enum.at(users, 1) # Pick the 2nd inserted user
+      users = insert_list(3, :user)
+      # Pick the 2nd inserted user
+      target = Enum.at(users, 1)
       response = user_request("/user.get", %{"id" => target.id})
 
       assert response["success"]
@@ -53,21 +55,25 @@ defmodule AdminAPI.V1.UserControllerTest do
     end
 
     test "returns 'user:id_not_found' if the given ID was not found" do
-      response  = user_request("/user.get", %{"id" => "usr_12345678901234567890123456"})
+      response = user_request("/user.get", %{"id" => "usr_12345678901234567890123456"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
 
     test "returns 'user:id_not_found' if the given ID format is invalid" do
-      response  = user_request("/user.get", %{"id" => "not_uuid"})
+      response = user_request("/user.get", %{"id" => "not_uuid"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided id"
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/error_handler_test.exs
+++ b/apps/admin_api/test/admin_api/v1/error_handler_test.exs
@@ -8,9 +8,9 @@ defmodule AdminAPI.V1.ErrorHandlerTest do
     use Ecto.Schema
 
     schema "test_schema" do
-      field :field1, :string
-      field :field2, :string
-      field :field3, :string
+      field(:field1, :string)
+      field(:field2, :string)
+      field(:field3, :string)
     end
   end
 
@@ -47,9 +47,9 @@ defmodule AdminAPI.V1.ErrorHandlerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided"
-            <> " `field2` can't be blank."
-            <> " `field3` can't be blank.",
+          "description" =>
+            "Invalid parameter provided" <>
+              " `field2` can't be blank." <> " `field3` can't be blank.",
           "messages" => %{
             "field2" => ["required"],
             "field3" => ["required"]

--- a/apps/admin_api/test/admin_api/v1/plugs/account_scope_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/account_scope_plug_test.exs
@@ -11,7 +11,7 @@ defmodule AdminAPI.V1.AccountScopePlugTest do
   describe "AccountScopePlug.call/2" do
     test "assigns scoped_account_id to the connection if the header value is a UUID" do
       account_id = UUID.generate()
-      conn       = test_with(account_id)
+      conn = test_with(account_id)
 
       refute conn.halted
       assert conn.assigns.scoped_account_id == account_id

--- a/apps/admin_api/test/admin_api/v1/plugs/client_auth_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/client_auth_plug_test.exs
@@ -16,7 +16,7 @@ defmodule AdminAPI.V1.ClientAuthPlugTest do
     end
 
     test "assigns unauthenticated conn info if the api_key_id is not found" do
-      conn = test_with("OMGAdmin", UUID.generate, @api_key)
+      conn = test_with("OMGAdmin", UUID.generate(), @api_key)
       assert_error(conn)
     end
 
@@ -51,6 +51,7 @@ defmodule AdminAPI.V1.ClientAuthPlugTest do
   end
 
   defp test_with(type, api_key_id, api_key), do: test_with(type, [api_key_id, api_key])
+
   defp test_with(type, data) when is_list(data) do
     build_conn()
     |> put_auth_header(type, data)
@@ -59,7 +60,7 @@ defmodule AdminAPI.V1.ClientAuthPlugTest do
 
   defp test_with_no_auth do
     build_conn()
-    |> ClientAuthPlug.call([enable_client_auth: false])
+    |> ClientAuthPlug.call(enable_client_auth: false)
   end
 
   defp assert_success(conn) do

--- a/apps/admin_api/test/admin_api/v1/plugs/user_auth_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/user_auth_plug_test.exs
@@ -26,7 +26,7 @@ defmodule AdminAPI.V1.UserAuthPlugTest do
     end
 
     test "assigns unauthenticated conn info if the token doesn't belong to the user_id" do
-      conn = test_with("OMGAdmin", @api_key_id, @api_key, UUID.generate, @auth_token)
+      conn = test_with("OMGAdmin", @api_key_id, @api_key, UUID.generate(), @auth_token)
 
       assert conn.halted
       assert_error(conn)
@@ -79,7 +79,7 @@ defmodule AdminAPI.V1.UserAuthPlugTest do
   defp test_with(type, user_id, auth_token) do
     build_conn()
     |> put_auth_header(type, [user_id, auth_token])
-    |> UserAuthPlug.call([enable_client_auth: false])
+    |> UserAuthPlug.call(enable_client_auth: false)
   end
 
   defp assert_success(conn) do

--- a/apps/admin_api/test/admin_api/v1/serializers/membership_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/membership_serializer_test.exs
@@ -7,9 +7,9 @@ defmodule AdminAPI.V1.MembershipSerializerTest do
 
   describe "serialize/1" do
     test "serializes a membership into user json" do
-      account    = insert(:account)
-      user       = insert(:user)
-      role       = insert(:role)
+      account = insert(:account)
+      user = insert(:user)
+      role = insert(:role)
       membership = insert(:membership, %{account: account, user: user, role: role})
 
       expected = %{
@@ -48,9 +48,9 @@ defmodule AdminAPI.V1.MembershipSerializerTest do
     end
 
     test "serializes a list of memberships into a list of users json" do
-      account    = insert(:account)
-      user       = insert(:user)
-      role       = insert(:role)
+      account = insert(:account)
+      user = insert(:user)
+      role = insert(:role)
       membership = insert(:membership, %{account: account, user: user, role: role})
 
       expected = %{

--- a/apps/admin_api/test/admin_api/v1/views/account_membership_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/account_membership_view_test.exs
@@ -21,16 +21,17 @@ defmodule AdminAPI.V1.AccountMembershipViewTest do
         }
       }
 
-      assert AccountMembershipView.render("memberships.json", %{memberships: memberships}) == expected
+      assert AccountMembershipView.render("memberships.json", %{memberships: memberships}) ==
+               expected
     end
 
     test "renders empty.json correctly" do
       assert AccountMembershipView.render("empty.json", %{success: true}) ==
-        %{
-          version: @expected_version,
-          success: true,
-          data: %{}
-        }
+               %{
+                 version: @expected_version,
+                 success: true,
+                 data: %{}
+               }
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/views/account_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/account_view_test.exs
@@ -27,8 +27,8 @@ defmodule AdminAPI.V1.AccountViewTest do
           per_page: 10,
           current_page: 1,
           is_first_page: true,
-          is_last_page: false,
-        },
+          is_last_page: false
+        }
       }
 
       expected = %{

--- a/apps/admin_api/test/admin_api/v1/views/minted_token_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/minted_token_view_test.exs
@@ -23,7 +23,8 @@ defmodule AdminAPI.V1.MintedTokenViewTest do
         }
       }
 
-      assert MintedTokenView.render("minted_token.json", %{minted_token: minted_token}) == expected
+      assert MintedTokenView.render("minted_token.json", %{minted_token: minted_token}) ==
+               expected
     end
 
     test "renders minted_tokens.json with correct response structure" do
@@ -36,8 +37,8 @@ defmodule AdminAPI.V1.MintedTokenViewTest do
           per_page: 10,
           current_page: 1,
           is_first_page: true,
-          is_last_page: false,
-        },
+          is_last_page: false
+        }
       }
 
       expected = %{
@@ -73,8 +74,8 @@ defmodule AdminAPI.V1.MintedTokenViewTest do
             per_page: 10,
             current_page: 1,
             is_first_page: true,
-            is_last_page: false,
-          },
+            is_last_page: false
+          }
         }
       }
 

--- a/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
@@ -29,7 +29,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
               subunit_to_unit: minted_token.subunit_to_unit,
               created_at: Date.to_iso8601(minted_token.inserted_at),
               updated_at: Date.to_iso8601(minted_token.updated_at)
-            },
+            }
           },
           to: %{
             object: "transaction_source",
@@ -45,11 +45,11 @@ defmodule AdminAPI.V1.TransactionViewTest do
               subunit_to_unit: minted_token.subunit_to_unit,
               created_at: Date.to_iso8601(minted_token.inserted_at),
               updated_at: Date.to_iso8601(minted_token.updated_at)
-            },
+            }
           },
           exchange: %{
             object: "exchange",
-            rate: 1,
+            rate: 1
           },
           metadata: %{some: "metadata"},
           encrypted_metadata: %{},
@@ -63,9 +63,9 @@ defmodule AdminAPI.V1.TransactionViewTest do
     end
 
     test "renders transactions.json with correct response structure" do
-      transaction1  = insert(:transfer)
+      transaction1 = insert(:transfer)
       minted_token1 = transaction1.minted_token
-      transaction2  = insert(:transfer)
+      transaction2 = insert(:transfer)
       minted_token2 = transaction2.minted_token
 
       paginator = %Paginator{
@@ -74,8 +74,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
           per_page: 10,
           current_page: 1,
           is_first_page: true,
-          is_last_page: false,
-        },
+          is_last_page: false
+        }
       }
 
       expected = %{
@@ -102,7 +102,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                   subunit_to_unit: minted_token1.subunit_to_unit,
                   created_at: Date.to_iso8601(minted_token1.inserted_at),
                   updated_at: Date.to_iso8601(minted_token1.updated_at)
-                },
+                }
               },
               to: %{
                 object: "transaction_source",
@@ -118,11 +118,11 @@ defmodule AdminAPI.V1.TransactionViewTest do
                   subunit_to_unit: minted_token1.subunit_to_unit,
                   created_at: Date.to_iso8601(minted_token1.inserted_at),
                   updated_at: Date.to_iso8601(minted_token1.updated_at)
-                },
+                }
               },
               exchange: %{
                 object: "exchange",
-                rate: 1,
+                rate: 1
               },
               metadata: %{some: "metadata"},
               encrypted_metadata: %{},
@@ -148,7 +148,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                   subunit_to_unit: minted_token2.subunit_to_unit,
                   created_at: Date.to_iso8601(minted_token2.inserted_at),
                   updated_at: Date.to_iso8601(minted_token2.updated_at)
-                },
+                }
               },
               to: %{
                 object: "transaction_source",
@@ -164,11 +164,11 @@ defmodule AdminAPI.V1.TransactionViewTest do
                   subunit_to_unit: minted_token2.subunit_to_unit,
                   created_at: Date.to_iso8601(minted_token2.inserted_at),
                   updated_at: Date.to_iso8601(minted_token2.updated_at)
-                },
+                }
               },
               exchange: %{
                 object: "exchange",
-                rate: 1,
+                rate: 1
               },
               metadata: %{some: "metadata"},
               encrypted_metadata: %{},
@@ -181,8 +181,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
             per_page: 10,
             current_page: 1,
             is_first_page: true,
-            is_last_page: false,
-          },
+            is_last_page: false
+          }
         }
       }
 

--- a/apps/admin_api/test/admin_api/v1/views/user_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/user_view_test.exs
@@ -49,8 +49,8 @@ defmodule AdminAPI.V1.UserViewTest do
           per_page: 10,
           current_page: 1,
           is_first_page: true,
-          is_last_page: false,
-        },
+          is_last_page: false
+        }
       }
 
       expected = %{
@@ -106,8 +106,8 @@ defmodule AdminAPI.V1.UserViewTest do
             per_page: 10,
             current_page: 1,
             is_first_page: true,
-            is_last_page: false,
-          },
+            is_last_page: false
+          }
         }
       }
 

--- a/apps/admin_api/test/admin_api/versioned_router_test.exs
+++ b/apps/admin_api/test/admin_api/versioned_router_test.exs
@@ -5,13 +5,14 @@ defmodule AdminAPI.VersionedRouterTest do
   # credo:disable-for-next-line Credo.Check.Design.DuplicatedCode
   describe "versioned router" do
     test "accepts v1+json requests" do
-      response = build_conn()
-      |> put_req_header("accept", "application/vnd.omisego.v1+json")
-      |> put_auth_header("OMGAdmin", [@api_key_id, @api_key])
-      |> post(@base_dir <> "/status")
-      |> json_response(:ok)
+      response =
+        build_conn()
+        |> put_req_header("accept", "application/vnd.omisego.v1+json")
+        |> put_auth_header("OMGAdmin", [@api_key_id, @api_key])
+        |> post(@base_dir <> "/status")
+        |> json_response(:ok)
 
-      assert response == %{"success" => :true}
+      assert response == %{"success" => true}
     end
 
     test "rejects unrecognized version requests" do
@@ -21,15 +22,17 @@ defmodule AdminAPI.VersionedRouterTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_version",
-          "description" => "Invalid API version Given: 'application/vnd.omisego.invalid_ver+json'.",
+          "description" =>
+            "Invalid API version Given: 'application/vnd.omisego.invalid_ver+json'.",
           "messages" => nil
         }
       }
 
-      response = build_conn()
-      |> put_req_header("accept", "application/vnd.omisego.invalid_ver+json")
-      |> post(@base_dir <> "/status")
-      |> json_response(:ok)
+      response =
+        build_conn()
+        |> put_req_header("accept", "application/vnd.omisego.invalid_ver+json")
+        |> post(@base_dir <> "/status")
+        |> json_response(:ok)
 
       assert response == expected
     end

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -26,8 +26,10 @@ defmodule AdminAPI.ConnCase do
   @endpoint AdminAPI.Endpoint
 
   # Attributes for all calls
-  @expected_version "1" # The expected response version
-  @header_accept "application/vnd.omisego.v1+json" # The expected response version
+  # The expected response version
+  @expected_version "1"
+  # The expected response version
+  @header_accept "application/vnd.omisego.v1+json"
 
   # Attributes for client calls
   @api_key_id UUID.generate()
@@ -76,18 +78,20 @@ defmodule AdminAPI.ConnCase do
     :ok = Sandbox.checkout(LocalLedgerDB.Repo)
 
     # Insert necessary records for making authenticated calls.
-    user = insert(:user, %{
-      id: @user_id,
-      username: @username,
-      password_hash: Crypto.hash_password(@password),
-      email: @user_email,
-      provider_user_id: @provider_user_id
-    })
+    user =
+      insert(:user, %{
+        id: @user_id,
+        username: @username,
+        password_hash: Crypto.hash_password(@password),
+        email: @user_email,
+        provider_user_id: @provider_user_id
+      })
+
     {:ok, account} = :account |> params_for(parent: nil) |> Account.insert()
-    role           = insert(:role, %{name: "admin"})
-    _api_key       = insert(:api_key, %{id: @api_key_id, key: @api_key, owner_app: "admin_api"})
-    _auth_token    = insert(:auth_token, %{user: user, token: @auth_token, owner_app: "admin_api"})
-    _membership    = insert(:membership, %{user: user, role: role, account: account})
+    role = insert(:role, %{name: "admin"})
+    _api_key = insert(:api_key, %{id: @api_key_id, key: @api_key, owner_app: "admin_api"})
+    _auth_token = insert(:auth_token, %{user: user, token: @auth_token, owner_app: "admin_api"})
+    _membership = insert(:membership, %{user: user, role: role, account: account})
 
     # Setup could return all the inserted credentials using ExUnit context
     # by returning {:ok, context_map}. But it would make the code
@@ -107,14 +111,15 @@ defmodule AdminAPI.ConnCase do
   def get_last_inserted(schema) do
     schema
     |> last(:inserted_at)
-    |> Repo.one
+    |> Repo.one()
   end
 
   @doc """
   A helper function that generates a valid client request (client-authenticated)
   with given path and data, and return the parsed JSON response.
   """
-  def client_request(path, data \\ %{}, status \\ :ok) when is_binary(path) and byte_size(path) > 0 do
+  def client_request(path, data \\ %{}, status \\ :ok)
+      when is_binary(path) and byte_size(path) > 0 do
     build_conn()
     |> put_req_header("accept", @header_accept)
     |> put_auth_header("OMGAdmin", [@api_key_id, @api_key])
@@ -126,7 +131,8 @@ defmodule AdminAPI.ConnCase do
   A helper function that generates a valid user request (user-authenticated)
   with given path and data, and return the parsed JSON response.
   """
-  def user_request(path, data \\ %{}, status \\ :ok) when is_binary(path) and byte_size(path) > 0 do
+  def user_request(path, data \\ %{}, status \\ :ok)
+      when is_binary(path) and byte_size(path) > 0 do
     # Make the authenticated request after login
     build_conn()
     |> put_req_header("accept", @header_accept)
@@ -141,9 +147,10 @@ defmodule AdminAPI.ConnCase do
   followed by a space, then the base64 pair of credentials.
   """
   def put_auth_header(conn, type, content) when is_list(content) do
-    serialized = content |> Enum.join(":") |> Base.encode64
+    serialized = content |> Enum.join(":") |> Base.encode64()
     put_auth_header(conn, type, serialized)
   end
+
   def put_auth_header(conn, type, content) when is_binary(content) do
     put_req_header(conn, "authorization", type <> " " <> content)
   end
@@ -154,7 +161,7 @@ defmodule AdminAPI.ConnCase do
   """
   def ensure_num_records(schema, num_required, attrs \\ %{}, count_field \\ :id) do
     num_remaining = num_required - Repo.aggregate(schema, :count, count_field)
-    factory_name  = get_factory(schema)
+    factory_name = get_factory(schema)
 
     insert_list(num_remaining, factory_name, attrs)
     Repo.all(schema)

--- a/apps/admin_api/test/support/view_case.ex
+++ b/apps/admin_api/test/support/view_case.ex
@@ -16,7 +16,8 @@ defmodule AdminAPI.ViewCase do
         :ok = Sandbox.checkout(Repo)
       end
 
-      @expected_version "1" # The expected response version
+      # The expected response version
+      @expected_version "1"
     end
   end
 

--- a/apps/admin_panel/config/config.exs
+++ b/apps/admin_panel/config/config.exs
@@ -19,4 +19,4 @@ config :admin_panel, AdminPanel.Endpoint,
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/apps/admin_panel/config/dev.exs
+++ b/apps/admin_panel/config/dev.exs
@@ -1,8 +1,7 @@
 use Mix.Config
 
 # General application configuration
-config :admin_panel,
-  webpack_watch: true
+config :admin_panel, webpack_watch: true
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/apps/admin_panel/config/test.exs
+++ b/apps/admin_panel/config/test.exs
@@ -2,5 +2,4 @@ use Mix.Config
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
-config :admin_panel, AdminPanel.Endpoint,
-  server: false
+config :admin_panel, AdminPanel.Endpoint, server: false

--- a/apps/admin_panel/lib/admin_panel.ex
+++ b/apps/admin_panel/lib/admin_panel.ex
@@ -27,8 +27,9 @@ defmodule AdminPanel do
 
   def view do
     quote do
-      use Phoenix.View, root: "lib/admin_panel/templates",
-                        namespace: AdminPanel
+      use Phoenix.View,
+        root: "lib/admin_panel/templates",
+        namespace: AdminPanel
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 2, view_module: 1]

--- a/apps/admin_panel/lib/admin_panel/application.ex
+++ b/apps/admin_panel/lib/admin_panel/application.ex
@@ -52,18 +52,22 @@ defmodule AdminPanel.Application do
   defp webpack_watch do
     import Supervisor.Spec
 
-    worker(Watcher, [
-      :yarn,
+    worker(
+      Watcher,
       [
-        "webpack",
-        "--watch-stdin",
-        "--color",
-        "--progress",
-        "--config", "config/webpack.dev.js"
+        :yarn,
+        [
+          "webpack",
+          "--watch-stdin",
+          "--color",
+          "--progress",
+          "--config",
+          "config/webpack.dev.js"
+        ],
+        [cd: Path.expand("../../assets/", __DIR__)]
       ],
-      [cd: Path.expand("../../assets/", __DIR__)]
-    ],
-    restart: :transient)
+      restart: :transient
+    )
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
+++ b/apps/admin_panel/lib/admin_panel/controllers/page_controller.ex
@@ -6,9 +6,9 @@ defmodule AdminPanel.PageController do
   alias Plug.Conn
 
   @not_found_message """
-    The assets are not available. If you think this is incorrect,
-    please make sure that the front-end assets have been built.
-    """
+  The assets are not available. If you think this is incorrect,
+  please make sure that the front-end assets have been built.
+  """
 
   def index(conn, _params) do
     content =
@@ -30,6 +30,7 @@ defmodule AdminPanel.PageController do
   defp index_file_path(%{private: %{override_dist_path: dist_path}}) do
     Path.join(dist_path, "index.html")
   end
+
   defp index_file_path(_conn) do
     :admin_panel
     |> Application.get_env(:dist_path)
@@ -60,5 +61,7 @@ defmodule AdminPanel.PageController do
     </script>
     """
   end
-  defp api_key_script(_), do: "<!-- No API key found -->" # For troubleshooting purposes
+
+  # For troubleshooting purposes
+  defp api_key_script(_), do: "<!-- No API key found -->"
 end

--- a/apps/admin_panel/lib/admin_panel/endpoint.ex
+++ b/apps/admin_panel/lib/admin_panel/endpoint.ex
@@ -5,27 +5,31 @@ defmodule AdminPanel.Endpoint do
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
-  plug Plug.Static,
+  plug(
+    Plug.Static,
     at: "/admin",
     from: {:admin_panel, "priv/dist"},
     gzip: false
+  )
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    plug Phoenix.CodeReloader
+    plug(Phoenix.CodeReloader)
   end
 
-  plug Plug.RequestId
-  plug Plug.Logger
+  plug(Plug.RequestId)
+  plug(Plug.Logger)
 
-  plug Plug.Parsers,
+  plug(
+    Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Poison
+  )
 
-  plug Plug.MethodOverride
-  plug Plug.Head
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
 
-  plug AdminPanel.Router
+  plug(AdminPanel.Router)
 end

--- a/apps/admin_panel/lib/admin_panel/router.ex
+++ b/apps/admin_panel/lib/admin_panel/router.ex
@@ -2,12 +2,13 @@ defmodule AdminPanel.Router do
   use AdminPanel, :router
 
   pipeline :browser do
-    plug :accepts, ["html"]
-    plug :put_secure_browser_headers
+    plug(:accepts, ["html"])
+    plug(:put_secure_browser_headers)
   end
 
   scope "/admin", AdminPanel do
-    pipe_through :browser
-    match :*, "/*path", PageController, :index # All requests serve from the same index page
+    pipe_through(:browser)
+    # All requests serve from the same index page
+    match(:*, "/*path", PageController, :index)
   end
 end

--- a/apps/admin_panel/lib/admin_panel/views/error_view.ex
+++ b/apps/admin_panel/lib/admin_panel/views/error_view.ex
@@ -12,6 +12,6 @@ defmodule AdminPanel.ErrorView do
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
-    render "500.html", assigns
+    render("500.html", assigns)
   end
 end

--- a/apps/admin_panel/test/admin_panel/controllers/page_controller_test.exs
+++ b/apps/admin_panel/test/admin_panel/controllers/page_controller_test.exs
@@ -24,7 +24,7 @@ defmodule AdminPanel.PageControllerTest do
     end
 
     test "returns the main front-end app with the API key" do
-      _account       = insert(:account)
+      _account = insert(:account)
       {:ok, api_key} = APIKey.insert(%{owner_app: "admin_api"})
 
       response =

--- a/apps/ewallet/config/config.exs
+++ b/apps/ewallet/config/config.exs
@@ -6,4 +6,4 @@ config :ewallet,
   ecto_repos: [],
   max_per_page: System.get_env("REQUEST_MAX_PER_PAGE") || 100
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/apps/ewallet/lib/ewallet/cli.ex
+++ b/apps/ewallet/lib/ewallet/cli.ex
@@ -19,9 +19,9 @@ defmodule EWallet.CLI do
 
   def color(messages), do: messages |> format |> puts
 
-  def heading(message), do: Docs.print_heading(message, [width: 100])
+  def heading(message), do: Docs.print_heading(message, width: 100)
 
-  def print(message), do: Docs.print(message, [width: 100])
+  def print(message), do: Docs.print(message, width: 100)
 
   def halt(message) do
     error(message)
@@ -35,12 +35,12 @@ defmodule EWallet.CLI do
     thanks to `Mix.Hex.Utils` for the workaround below.
   """
   def gets_sensitive(prompt) do
-    pid   = spawn_link(fn -> loop_gets_sensitive(prompt) end)
-    ref   = make_ref()
+    pid = spawn_link(fn -> loop_gets_sensitive(prompt) end)
+    ref = make_ref()
     value = IO.gets(prompt <> " ")
 
-    send pid, {:done, self(), ref}
-    receive do: ({:done, ^pid, ^ref}  -> :ok)
+    send(pid, {:done, self(), ref})
+    receive do: ({:done, ^pid, ^ref} -> :ok)
 
     value
   end
@@ -48,11 +48,11 @@ defmodule EWallet.CLI do
   defp loop_gets_sensitive(prompt) do
     receive do
       {:done, parent, ref} ->
-        send parent, {:done, self(), ref}
-        IO.write :standard_error, "\e[2K\r"
+        send(parent, {:done, self(), ref})
+        IO.write(:standard_error, "\e[2K\r")
     after
       1 ->
-        IO.write :standard_error, "\e[2K\r#{prompt} "
+        IO.write(:standard_error, "\e[2K\r#{prompt} ")
         loop_gets_sensitive(prompt)
     end
   end

--- a/apps/ewallet/lib/ewallet/fetchers/address_record_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/address_record_fetcher.ex
@@ -5,10 +5,10 @@ defmodule EWallet.AddressRecordFetcher do
   alias EWalletDB.{MintedToken, Balance}
 
   def fetch(%{
-    "from_address" => from_address,
-    "to_address" => to_address,
-    "token_id" => token_id
-  }) do
+        "from_address" => from_address,
+        "to_address" => to_address,
+        "token_id" => token_id
+      }) do
     from_balance = Balance.get(from_address)
     to_balance = Balance.get(to_address)
     minted_token = MintedToken.get(token_id)
@@ -19,6 +19,7 @@ defmodule EWallet.AddressRecordFetcher do
   defp handle_result(nil, _, _), do: {:error, :from_address_not_found}
   defp handle_result(_, nil, _), do: {:error, :to_address_not_found}
   defp handle_result(_, _, nil), do: {:error, :minted_token_not_found}
+
   defp handle_result(from_balance, to_balance, minted_token) do
     {:ok, from_balance, to_balance, minted_token}
   end

--- a/apps/ewallet/lib/ewallet/fetchers/balance_assigner.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/balance_assigner.ex
@@ -6,11 +6,11 @@ defmodule EWallet.BalanceAssigner do
   alias EWallet.TransactionGate
 
   def assign(%{
-    account: account,
-    user: user,
-    type: type,
-    burn_balance_identifier: burn_balance_identifier
-  }) do
+        account: account,
+        user: user,
+        type: type,
+        burn_balance_identifier: burn_balance_identifier
+      }) do
     credit = TransactionGate.credit_type()
     debit = TransactionGate.debit_type()
     user_balance = User.get_preloaded_primary_balance(user)
@@ -19,6 +19,7 @@ defmodule EWallet.BalanceAssigner do
       ^credit ->
         account_balance = Account.get_preloaded_primary_balance(account)
         {:ok, account_balance, user_balance}
+
       ^debit ->
         case get_account_balance(burn_balance_identifier, account) do
           nil -> {:error, :burn_balance_not_found}
@@ -30,6 +31,7 @@ defmodule EWallet.BalanceAssigner do
   defp get_account_balance(nil, account) do
     Account.get_preloaded_primary_balance(account)
   end
+
   defp get_account_balance(identifier, account) do
     Account.get_balance_by_identifier(account, identifier)
   end

--- a/apps/ewallet/lib/ewallet/fetchers/balance_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/balance_fetcher.ex
@@ -4,7 +4,7 @@ defmodule EWallet.BalanceFetcher do
   """
   alias EWalletDB.{User, Balance, Account}
 
-  @spec get(User.t, String.t) :: {:ok, Balance.t} | {:error, Atom.t}
+  @spec get(User.t(), String.t()) :: {:ok, Balance.t()} | {:error, Atom.t()}
   def get(%User{} = user, nil) do
     {:ok, User.get_primary_balance(user)}
   end
@@ -14,8 +14,7 @@ defmodule EWallet.BalanceFetcher do
   end
 
   def get(nil, address) do
-    with %Balance{} = balance <- Balance.get(address) || :balance_not_found
-    do
+    with %Balance{} = balance <- Balance.get(address) || :balance_not_found do
       {:ok, balance}
     else
       error -> {:error, error}
@@ -24,8 +23,7 @@ defmodule EWallet.BalanceFetcher do
 
   def get(%User{} = user, address) do
     with %Balance{} = balance <- Balance.get(address) || :balance_not_found,
-         true <- balance.user_uuid == user.uuid || :user_balance_mismatch
-    do
+         true <- balance.user_uuid == user.uuid || :user_balance_mismatch do
       {:ok, balance}
     else
       error -> {:error, error}
@@ -34,8 +32,7 @@ defmodule EWallet.BalanceFetcher do
 
   def get(%Account{} = account, address) do
     with %Balance{} = balance <- Balance.get(address) || :balance_not_found,
-         true <- balance.account_uuid == account.uuid || :account_balance_mismatch
-    do
+         true <- balance.account_uuid == account.uuid || :account_balance_mismatch do
       {:ok, balance}
     else
       error -> {:error, error}

--- a/apps/ewallet/lib/ewallet/fetchers/computed_balance_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/computed_balance_fetcher.ex
@@ -30,6 +30,7 @@ defmodule EWallet.ComputedBalanceFetcher do
     case user do
       nil ->
         {:error, :provider_user_id_not_found}
+
       user ->
         balance = User.get_primary_balance(user)
         format_all(balance.address)
@@ -119,12 +120,14 @@ defmodule EWallet.ComputedBalanceFetcher do
           |> map_minted_tokens(data)
 
         {:ok, %{address: address, balances: balances}}
+
       balances ->
         balances
     end
   end
 
   defp load_minted_tokens(:all, _), do: MintedToken.all()
+
   defp load_minted_tokens(:one, amounts) do
     amounts |> Map.keys() |> MintedToken.get_all()
   end

--- a/apps/ewallet/lib/ewallet/fetchers/credit_debit_record_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/credit_debit_record_fetcher.ex
@@ -4,10 +4,12 @@ defmodule EWallet.CreditDebitRecordFetcher do
   """
   alias EWalletDB.{User, MintedToken, Account}
 
-  def fetch(%{
-    "provider_user_id" => provider_user_id,
-    "token_id" => token_id
-  } = attrs) do
+  def fetch(
+        %{
+          "provider_user_id" => provider_user_id,
+          "token_id" => token_id
+        } = attrs
+      ) do
     user = User.get_by_provider_user_id(provider_user_id)
     minted_token = MintedToken.get(token_id)
     account = load_account(attrs["account_id"], minted_token)
@@ -15,7 +17,10 @@ defmodule EWallet.CreditDebitRecordFetcher do
   end
 
   defp load_account(nil, nil), do: nil
-  defp load_account(nil, minted_token), do: Account.get_by([uuid: minted_token.account_uuid], preload: :balances)
+
+  defp load_account(nil, minted_token),
+    do: Account.get_by([uuid: minted_token.account_uuid], preload: :balances)
+
   defp load_account(account_id, _minted_token), do: Account.get(account_id, preload: :balances)
 
   defp handle_result(_, _, nil), do: {:error, :minted_token_not_found}

--- a/apps/ewallet/lib/ewallet/formatters/transfer.ex
+++ b/apps/ewallet/lib/ewallet/formatters/transfer.ex
@@ -10,16 +10,20 @@ defmodule EWallet.TransferFormatter do
         "id" => transfer.minted_token.id,
         "metadata" => transfer.minted_token.metadata
       },
-      "debits" => [%{
-        "address" => transfer.from_balance.address,
-        "amount" => transfer.amount,
-        "metadata" => transfer.from_balance.metadata
-      }],
-      "credits" => [%{
-        "address" => transfer.to_balance.address,
-        "amount" => transfer.amount,
-        "metadata" => transfer.to_balance.metadata
-      }]
+      "debits" => [
+        %{
+          "address" => transfer.from_balance.address,
+          "amount" => transfer.amount,
+          "metadata" => transfer.from_balance.metadata
+        }
+      ],
+      "credits" => [
+        %{
+          "address" => transfer.to_balance.address,
+          "amount" => transfer.amount,
+          "metadata" => transfer.to_balance.metadata
+        }
+      ]
     }
   end
 end

--- a/apps/ewallet/lib/ewallet/gates/transaction_request_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_request_gate.ex
@@ -9,153 +9,169 @@ defmodule EWallet.TransactionRequestGate do
   alias EWallet.BalanceFetcher
   alias EWalletDB.{TransactionRequest, User, Balance, MintedToken, Account}
 
-  @spec create(Map.t) :: {:ok, TransactionRequest.t} | {:error, Atom.t}
+  @spec create(Map.t()) :: {:ok, TransactionRequest.t()} | {:error, Atom.t()}
 
-  def create(%{
-    "account_id" => account_id,
-    "provider_user_id" => provider_user_id,
-    "address" => address
-  } = attrs) do
+  def create(
+        %{
+          "account_id" => account_id,
+          "provider_user_id" => provider_user_id,
+          "address" => address
+        } = attrs
+      ) do
     with %Account{} = account <- Account.get(account_id) || :account_id_not_found,
-         %User{} = user <- User.get_by_provider_user_id(provider_user_id) ||
-                           :provider_user_id_not_found,
+         %User{} = user <-
+           User.get_by_provider_user_id(provider_user_id) || :provider_user_id_not_found,
          {:ok, balance} <- BalanceFetcher.get(user, address),
          balance <- Map.put(balance, :account_uuid, account.uuid),
-         {:ok, transaction_request} <- create(balance, attrs)
-    do
+         {:ok, transaction_request} <- create(balance, attrs) do
       get(transaction_request.id)
     else
       error when is_atom(error) -> {:error, error}
-      error                     -> error
+      error -> error
     end
   end
 
-  def create(%{
-    "account_id" => account_id,
-    "address" => address
-  } = attrs) do
+  def create(
+        %{
+          "account_id" => account_id,
+          "address" => address
+        } = attrs
+      ) do
     with %Account{} = account <- Account.get(account_id) || :account_id_not_found,
          {:ok, balance} <- BalanceFetcher.get(account, address),
-         {:ok, transaction_request} <- create(balance, attrs)
-    do
+         {:ok, transaction_request} <- create(balance, attrs) do
       get(transaction_request.id)
     else
       error when is_atom(error) -> {:error, error}
-      error                     -> error
+      error -> error
     end
   end
+
   def create(%{"account_id" => _} = attrs) do
     attrs
     |> Map.put("address", nil)
     |> create()
   end
 
-  def create(%{
-    "provider_user_id" => provider_user_id,
-    "address" => address
-  } = attrs) do
-    with %User{} = user <- User.get_by_provider_user_id(provider_user_id) ||
-                           :provider_user_id_not_found,
+  def create(
+        %{
+          "provider_user_id" => provider_user_id,
+          "address" => address
+        } = attrs
+      ) do
+    with %User{} = user <-
+           User.get_by_provider_user_id(provider_user_id) || :provider_user_id_not_found,
          {:ok, balance} <- BalanceFetcher.get(user, address),
-         {:ok, transaction_request} <- create(balance, attrs)
-    do
+         {:ok, transaction_request} <- create(balance, attrs) do
       get(transaction_request.id)
     else
       error when is_atom(error) -> {:error, error}
-      error                     -> error
+      error -> error
     end
   end
+
   def create(%{"provider_user_id" => _} = attrs) do
     attrs
     |> Map.put("address", nil)
     |> create()
   end
 
-  def create(%{
-    "address" => address
-  } = attrs) do
+  def create(
+        %{
+          "address" => address
+        } = attrs
+      ) do
     with {:ok, balance} <- BalanceFetcher.get(nil, address),
-         {:ok, transaction_request} <- create(balance, attrs)
-    do
+         {:ok, transaction_request} <- create(balance, attrs) do
       get(transaction_request.id)
     else
       error when is_atom(error) -> {:error, error}
-      error                     -> error
+      error -> error
     end
   end
 
   def create(_), do: {:error, :invalid_parameter}
 
-  @spec create(User.t, Map.t) :: {:ok, TransactionRequest.t} | {:error, Atom.t}
-  def create(%User{} = user, %{
-    "address" => address
-  } = attrs) do
-    with {:ok, balance} <- BalanceFetcher.get(user, address)
-    do create(balance, attrs)
-    else error -> error
+  @spec create(User.t(), Map.t()) :: {:ok, TransactionRequest.t()} | {:error, Atom.t()}
+  def create(
+        %User{} = user,
+        %{
+          "address" => address
+        } = attrs
+      ) do
+    with {:ok, balance} <- BalanceFetcher.get(user, address) do
+      create(balance, attrs)
+    else
+      error -> error
     end
   end
 
-  @spec create(Balance.t, Map.t) :: {:ok, TransactionRequest.t} | {:error, Atom.t}
-  def create(%Balance{} = balance, %{
-    "type" => _,
-    "correlation_id" => _,
-    "amount" => _,
-    "token_id" => token_id
-  } = attrs) do
+  @spec create(Balance.t(), Map.t()) :: {:ok, TransactionRequest.t()} | {:error, Atom.t()}
+  def create(
+        %Balance{} = balance,
+        %{
+          "type" => _,
+          "correlation_id" => _,
+          "amount" => _,
+          "token_id" => token_id
+        } = attrs
+      ) do
     with %MintedToken{} = minted_token <- MintedToken.get(token_id) || :minted_token_not_found,
-         {:ok, transaction_request} <- insert(minted_token, balance, attrs)
-    do
+         {:ok, transaction_request} <- insert(minted_token, balance, attrs) do
       get(transaction_request.id)
     else
       error when is_atom(error) -> {:error, error}
-      error                     -> error
+      error -> error
     end
   end
-  def create(_, _attrs),   do: {:error, :invalid_parameter}
 
-  @spec get(UUID.t) :: {:ok, TransactionRequest.t} | {:error, :transaction_request_not_found}
+  def create(_, _attrs), do: {:error, :invalid_parameter}
+
+  @spec get(UUID.t()) :: {:ok, TransactionRequest.t()} | {:error, :transaction_request_not_found}
   def get(id) do
     request = TransactionRequest.get(id, preload: [:minted_token, :user, :balance])
 
     case request do
-      nil     -> {:error, :transaction_request_not_found}
+      nil -> {:error, :transaction_request_not_found}
       request -> {:ok, request}
     end
   end
 
-  @spec get_with_lock(UUID.t) :: {:ok, TransactionRequest.t} |
-                                 {:error, :transaction_request_not_found}
+  @spec get_with_lock(UUID.t()) ::
+          {:ok, TransactionRequest.t()}
+          | {:error, :transaction_request_not_found}
   def get_with_lock(id) do
     request = TransactionRequest.get_with_lock(id)
 
     case request do
-      nil     -> {:error, :transaction_request_not_found}
+      nil -> {:error, :transaction_request_not_found}
       request -> {:ok, request}
     end
   end
 
-  @spec validate_amount(TransactionRequest.t, Integer.t) ::
-        {:ok, TransactionRequest.t} | {:error, :unauthorized_amount_override}
+  @spec validate_amount(TransactionRequest.t(), Integer.t()) ::
+          {:ok, TransactionRequest.t()} | {:error, :unauthorized_amount_override}
   def validate_amount(request, amount) do
     case request.allow_amount_override do
-      true  ->
+      true ->
         {:ok, amount || request.amount}
+
       false ->
         case amount do
-          nil     -> {:ok, request.amount}
+          nil -> {:ok, request.amount}
           _amount -> {:error, :unauthorized_amount_override}
         end
     end
   end
 
-  @spec validate_request(TransactionRequest.t) :: {:ok, TransactionRequest.t} |
-                                                  {:error, Atom.t}
+  @spec validate_request(TransactionRequest.t()) ::
+          {:ok, TransactionRequest.t()}
+          | {:error, Atom.t()}
   def validate_request(request) do
     {:ok, request} = TransactionRequest.expire_if_past_expiration_date(request)
 
     case TransactionRequest.valid?(request) do
-      true  -> {:ok, request}
+      true -> {:ok, request}
       false -> {:error, String.to_existing_atom(request.expiration_reason)}
     end
   end
@@ -168,40 +184,52 @@ defmodule EWallet.TransactionRequestGate do
     request.user_uuid == user.uuid
   end
 
-  @spec expiration_from_lifetime(TransactionRequest.t) :: NaiveDateTime.t | nil
+  @spec expiration_from_lifetime(TransactionRequest.t()) :: NaiveDateTime.t() | nil
   def expiration_from_lifetime(request) do
     TransactionRequest.expiration_from_lifetime(request)
   end
 
-  @spec expire_if_past_expiration_date(TransactionRequest.t) :: {:ok, TransactionRequest.t} |
-                                                          {:error, Atom.t} |
-                                                          {:error, Map.t}
+  @spec expire_if_past_expiration_date(TransactionRequest.t()) ::
+          {:ok, TransactionRequest.t()}
+          | {:error, Atom.t()}
+          | {:error, Map.t()}
   def expire_if_past_expiration_date(request) do
     res = TransactionRequest.expire_if_past_expiration_date(request)
 
     case res do
       {:ok, %TransactionRequest{status: "expired"} = request} ->
         {:error, String.to_existing_atom(request.expiration_reason)}
+
       {:ok, request} ->
         {:ok, request}
+
       {:error, error} ->
         {:error, error}
     end
   end
 
-  @spec expire_if_max_consumption(TransactionRequest.t) :: {:ok, TransactionRequest.t} |
-                                                          {:error, Map.t}
+  @spec expire_if_max_consumption(TransactionRequest.t()) ::
+          {:ok, TransactionRequest.t()}
+          | {:error, Map.t()}
   def expire_if_max_consumption(request) do
     TransactionRequest.expire_if_max_consumption(request)
   end
 
   defp insert(minted_token, balance, attrs) do
-    require_confirmation  = if(is_nil(attrs["require_confirmation"]),
-                               do: false,
-                               else: attrs["require_confirmation"])
-    allow_amount_override = if(is_nil(attrs["allow_amount_override"]),
-                               do: true,
-                               else: attrs["allow_amount_override"])
+    require_confirmation =
+      if(
+        is_nil(attrs["require_confirmation"]),
+        do: false,
+        else: attrs["require_confirmation"]
+      )
+
+    allow_amount_override =
+      if(
+        is_nil(attrs["allow_amount_override"]),
+        do: true,
+        else: attrs["allow_amount_override"]
+      )
+
     TransactionRequest.insert(%{
       type: attrs["type"],
       correlation_id: attrs["correlation_id"],

--- a/apps/ewallet/lib/ewallet/gates/transfer_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transfer_gate.ex
@@ -30,17 +30,19 @@ defmodule EWallet.TransferGate do
     end
 
   """
-  def get_or_insert(%{
-    idempotency_token: _,
-    from: _,
-    to: _,
-    minted_token_id: _,
-    amount: _,
-    payload: _
-  } = attrs) do
+  def get_or_insert(
+        %{
+          idempotency_token: _,
+          from: _,
+          to: _,
+          minted_token_id: _,
+          amount: _,
+          payload: _
+        } = attrs
+      ) do
     attrs
-    |> Map.put(:type, Transfer.internal)
-    |> Map.put(:minted_token_uuid, MintedToken.get_by([id: attrs.minted_token_id]).uuid)
+    |> Map.put(:type, Transfer.internal())
+    |> Map.put(:minted_token_uuid, MintedToken.get_by(id: attrs.minted_token_id).uuid)
     |> Transfer.get_or_insert()
   end
 
@@ -93,6 +95,7 @@ defmodule EWallet.TransferGate do
       entry_uuid: entry.uuid
     })
   end
+
   defp update_transfer({:error, code, description}, transfer) do
     Transfer.fail(transfer, %{
       code: code,

--- a/apps/ewallet/lib/ewallet/helper.ex
+++ b/apps/ewallet/lib/ewallet/helper.ex
@@ -13,6 +13,7 @@ defmodule EWallet.Helper do
     |> Enum.reduce([], &to_existing_atoms/2)
     |> Enum.reverse()
   end
+
   def to_existing_atoms(string, atom_list) do
     atom = String.to_existing_atom(string)
     [atom | atom_list]
@@ -26,7 +27,7 @@ defmodule EWallet.Helper do
   Membership is tested with the match (`===`) operator.
   """
   def members?(enumerable, elements) do
-    Enum.all?(elements, fn(element) ->
+    Enum.all?(elements, fn element ->
       Enum.member?(enumerable, element)
     end)
   end

--- a/apps/ewallet/lib/ewallet/web/api_docs.ex
+++ b/apps/ewallet/lib/ewallet/web/api_docs.ex
@@ -42,14 +42,14 @@ defmodule EWallet.Web.APIDocs do
   defmacro __using__(scope: api_scope) do
     quote bind_quoted: binding() do
       scope api_scope do
-        get "/docs", Controller, :forward, private: %{redirect_to: api_scope <> "/docs.ui"}
-        get "/docs.ui", Controller, :ui
-        get "/docs.yaml", Controller, :yaml
+        get("/docs", Controller, :forward, private: %{redirect_to: api_scope <> "/docs.ui"})
+        get("/docs.ui", Controller, :ui)
+        get("/docs.yaml", Controller, :yaml)
 
-        get "/errors", Controller, :forward, private: %{redirect_to: api_scope <> "/errors.ui"}
-        get "/errors.ui", Controller, :errors_ui
-        get "/errors.yaml", Controller, :errors_yaml
-        get "/errors.json", Controller, :errors_json
+        get("/errors", Controller, :forward, private: %{redirect_to: api_scope <> "/errors.ui"})
+        get("/errors.ui", Controller, :errors_ui)
+        get("/errors.yaml", Controller, :errors_yaml)
+        get("/errors.json", Controller, :errors_json)
       end
     end
   end

--- a/apps/ewallet/lib/ewallet/web/api_docs/controller.ex
+++ b/apps/ewallet/lib/ewallet/web/api_docs/controller.ex
@@ -2,16 +2,16 @@ defmodule EWallet.Web.APIDocs.Controller do
   @moduledoc false
   use EWallet, :controller
 
-  plug :put_layout, false
+  plug(:put_layout, false)
 
   @doc false
-  @spec forward(Plug.Conn.t, map) :: Plug.Conn.t
+  @spec forward(Plug.Conn.t(), map) :: Plug.Conn.t()
   def forward(%{private: %{redirect_to: destination}} = conn, _attrs) do
-    redirect conn, to: destination
+    redirect(conn, to: destination)
   end
 
   @doc false
-  @spec ui(Plug.Conn.t, map) :: Plug.Conn.t
+  @spec ui(Plug.Conn.t(), map) :: Plug.Conn.t()
   def ui(conn, _attrs) do
     ui_path =
       :ewallet
@@ -22,7 +22,7 @@ defmodule EWallet.Web.APIDocs.Controller do
   end
 
   @doc false
-  @spec yaml(Plug.Conn.t, map) :: Plug.Conn.t
+  @spec yaml(Plug.Conn.t(), map) :: Plug.Conn.t()
   def yaml(conn, _attrs) do
     spec_path =
       conn
@@ -34,14 +34,19 @@ defmodule EWallet.Web.APIDocs.Controller do
   end
 
   @doc false
-  @spec errors_ui(Plug.Conn.t, map) :: Plug.Conn.t
+  @spec errors_ui(Plug.Conn.t(), map) :: Plug.Conn.t()
   def errors_ui(conn, _attrs) do
-    render(conn, EWallet.Web.ApiDocsView, "errors.html", app_name: get_app_name(conn),
-                                                         errors: get_errors(conn))
+    render(
+      conn,
+      EWallet.Web.ApiDocsView,
+      "errors.html",
+      app_name: get_app_name(conn),
+      errors: get_errors(conn)
+    )
   end
 
   @doc false
-  @spec errors_yaml(Plug.Conn.t, map) :: Plug.Conn.t
+  @spec errors_yaml(Plug.Conn.t(), map) :: Plug.Conn.t()
   def errors_yaml(conn, _attrs) do
     conn
     |> put_resp_content_type("text/x-yaml")
@@ -49,7 +54,7 @@ defmodule EWallet.Web.APIDocs.Controller do
   end
 
   @doc false
-  @spec errors_json(Plug.Conn.t, map) :: Plug.Conn.t
+  @spec errors_json(Plug.Conn.t(), map) :: Plug.Conn.t()
   def errors_json(conn, _attrs) do
     json(conn, get_errors(conn))
   end
@@ -58,14 +63,14 @@ defmodule EWallet.Web.APIDocs.Controller do
 
   defp get_app_name(conn) do
     case get_otp_app(conn) do
-      :admin_api   -> "Admin API"
+      :admin_api -> "Admin API"
       :ewallet_api -> "eWallet API"
     end
   end
 
   defp get_errors(conn) do
     case endpoint_module(conn).config(:error_handler) do
-      nil           -> %{}
+      nil -> %{}
       error_handler -> error_handler.errors()
     end
   end

--- a/apps/ewallet/lib/ewallet/web/api_docs/errors_view.ex
+++ b/apps/ewallet/lib/ewallet/web/api_docs/errors_view.ex
@@ -1,4 +1,5 @@
 defmodule EWallet.Web.ApiDocsView do
-  use Phoenix.View, root: "lib/ewallet/web/api_docs",
-                    namespace: EWallet.Web.ApiDocs
+  use Phoenix.View,
+    root: "lib/ewallet/web/api_docs",
+    namespace: EWallet.Web.ApiDocs
 end

--- a/apps/ewallet/lib/ewallet/web/email_validator.ex
+++ b/apps/ewallet/lib/ewallet/web/email_validator.ex
@@ -7,7 +7,7 @@ defmodule EWallet.EmailValidator do
   @doc """
   Checks whether the email address looks correct.
   """
-  @spec valid?(String.t) :: boolean()
+  @spec valid?(String.t()) :: boolean()
   def valid?(email) do
     Regex.match?(@email_regex, email)
   end
@@ -16,7 +16,7 @@ defmodule EWallet.EmailValidator do
   Checks whether the email address looks correct.
   Returns the email string if valid, returns false if invalid.
   """
-  @spec valid?(String.t) :: String.t | false
+  @spec valid?(String.t()) :: String.t() | false
   def validate(email) do
     if Regex.match?(@email_regex, email), do: email, else: false
   end

--- a/apps/ewallet/lib/ewallet/web/embedder.ex
+++ b/apps/ewallet/lib/ewallet/web/embedder.ex
@@ -30,10 +30,12 @@ defmodule EWallet.Web.Embedder do
   @doc """
   Embed association data.
   """
-  def embed(record, nil, embeddable, always_embed), do: embed(record, [], embeddable, always_embed)
+  def embed(record, nil, embeddable, always_embed),
+    do: embed(record, [], embeddable, always_embed)
+
   def embed(record, requested, embeddable, always_embed) do
     requested = Helper.to_existing_atoms(requested) ++ always_embed
-    allowed   = embeddable -- (embeddable -- requested)
+    allowed = embeddable -- embeddable -- requested
 
     Repo.preload(record, allowed)
   end

--- a/apps/ewallet/lib/ewallet/web/paginator.ex
+++ b/apps/ewallet/lib/ewallet/web/paginator.ex
@@ -9,15 +9,13 @@ defmodule EWallet.Web.Paginator do
   @default_per_page 10
   @default_max_per_page 100
 
-  defstruct [
-    data: [],
-    pagination: %{
-      per_page: nil,
-      current_page: nil,
-      is_first_page: nil,
-      is_last_page: nil,
-    },
-  ]
+  defstruct data: [],
+            pagination: %{
+              per_page: nil,
+              current_page: nil,
+              is_first_page: nil,
+              is_last_page: nil
+            }
 
   @doc """
   Paginate a query by attempting to extract `page` and `per_page`
@@ -31,17 +29,22 @@ defmodule EWallet.Web.Paginator do
   def paginate_attrs(queryable, %{"page" => page} = attrs) when not is_integer(page) do
     parse_string_param(queryable, attrs, "page", page)
   end
+
   def paginate_attrs(_, %{"page" => page}) when is_integer(page) and page < 0 do
     {:error, :invalid_parameter, "`page` must be non-negative integer"}
   end
-  def paginate_attrs(queryable, %{"per_page" => per_page} = attrs) when not is_integer(per_page) do
+
+  def paginate_attrs(queryable, %{"per_page" => per_page} = attrs)
+      when not is_integer(per_page) do
     parse_string_param(queryable, attrs, "per_page", per_page)
   end
+
   def paginate_attrs(_, %{"per_page" => per_page}) when is_integer(per_page) and per_page < 1 do
     {:error, :invalid_parameter, "`per_page` must be non-negative, non-zero integer"}
   end
+
   def paginate_attrs(queryable, attrs) do
-    page     = Map.get(attrs, "page", 1)
+    page = Map.get(attrs, "page", 1)
     per_page = get_per_page(attrs)
 
     paginate(queryable, page, per_page)
@@ -53,6 +56,7 @@ defmodule EWallet.Web.Paginator do
       {page, ""} ->
         attrs = Map.put(attrs, name, page)
         paginate_attrs(queryable, attrs)
+
       :error ->
         {:error, :invalid_parameter, "`#{name}` must be non-negative integer"}
     end
@@ -60,12 +64,12 @@ defmodule EWallet.Web.Paginator do
 
   # Returns the per_page number or default, but never greater than the system's defined limit
   defp get_per_page(attrs) do
-    per_page     = Map.get(attrs, "per_page", @default_per_page)
+    per_page = Map.get(attrs, "per_page", @default_per_page)
     max_per_page = Application.get_env(:ewallet, :max_per_page, @default_max_per_page)
 
     case per_page do
       n when n > max_per_page -> max_per_page
-      _                       -> per_page
+      _ -> per_page
     end
   end
 
@@ -79,7 +83,8 @@ defmodule EWallet.Web.Paginator do
       per_page: per_page,
       current_page: page,
       is_first_page: page <= 1,
-      is_last_page: !more_page, # It's the last page if there are no more records
+      # It's the last page if there are no more records
+      is_last_page: !more_page
     }
 
     %__MODULE__{data: records, pagination: pagination}
@@ -96,18 +101,20 @@ defmodule EWallet.Web.Paginator do
         _ -> 0
       end
 
-    limit = per_page + 1 # + 1 to see if it is the last page yet
+    # + 1 to see if it is the last page yet
+    limit = per_page + 1
 
     records =
       queryable
       |> offset(^offset)
       |> limit(^limit)
-      |> Repo.all
+      |> Repo.all()
 
     # If an extra record is found, remove last one and inform there is more.
     case Enum.count(records) do
       n when n > per_page ->
         {List.delete_at(records, -1), true}
+
       _ ->
         {records, false}
     end

--- a/apps/ewallet/lib/ewallet/web/preloader.ex
+++ b/apps/ewallet/lib/ewallet/web/preloader.ex
@@ -8,17 +8,19 @@ defmodule EWallet.Web.Preloader do
   @doc """
   Preload the given list of associations.
   """
-  @spec to_query(Ecto.Query.t, List.t) :: {Ecto.Query.t}
+  @spec to_query(Ecto.Query.t(), List.t()) :: {Ecto.Query.t()}
   def to_query(queryable, preload_fields) when is_list(preload_fields) do
     import Ecto.Query
-    from q in queryable, preload: ^preload_fields
+    from(q in queryable, preload: ^preload_fields)
   end
+
   def to_query(queryable, _), do: queryable
 
   @doc """
   Preloads associations into the given record(s).
   """
-  @spec preload(Ecto.Schema.t | Ecto.Schema.t, list(atom)) :: Ecto.Schema.t | [Ecto.Schema.t]
+  @spec preload(Ecto.Schema.t() | Ecto.Schema.t(), list(atom)) ::
+          Ecto.Schema.t() | [Ecto.Schema.t()]
   def preload(record, preloads) do
     Repo.preload(record, preloads)
   end

--- a/apps/ewallet/lib/ewallet/web/sort_parser.ex
+++ b/apps/ewallet/lib/ewallet/web/sort_parser.ex
@@ -9,7 +9,7 @@ defmodule EWallet.Web.SortParser do
   @doc """
   Parses sorting attributes and appends the resulting queries into the given queryable.
   """
-  @spec to_query(Ecto.Query.t, map, list) :: {Ecto.Query.t}
+  @spec to_query(Ecto.Query.t(), map, list) :: {Ecto.Query.t()}
   def to_query(queryable, attrs, fields, mapped_fields \\ %{}) do
     field = get_sort_field(attrs, fields, mapped_fields)
     direction = get_sort_direction(attrs)
@@ -18,17 +18,17 @@ defmodule EWallet.Web.SortParser do
   end
 
   defp get_sort_field(%{"sort_by" => field}, allowed_fields, mapped_fields)
-    when is_binary(field) and byte_size(field) > 0
-    and is_list(allowed_fields)
-    and is_map(mapped_fields)
-  do
+       when is_binary(field) and byte_size(field) > 0 and is_list(allowed_fields) and
+              is_map(mapped_fields) do
     field =
       mapped_fields
-      |> Map.get(field, field) # Defaults back to the original field name
+      # Defaults back to the original field name
+      |> Map.get(field, field)
       |> String.to_atom()
 
     if Enum.member?(allowed_fields, field), do: field, else: nil
   end
+
   defp get_sort_field(_, _, _), do: nil
 
   defp get_sort_direction(%{"sort_dir" => "asc"}), do: :asc
@@ -36,10 +36,9 @@ defmodule EWallet.Web.SortParser do
   defp get_sort_direction(_attrs), do: nil
 
   def build_sort_query(queryable, field, direction)
-    when is_atom(field) and not is_nil(field)
-    and is_atom(direction) and not is_nil(direction)
-  do
+      when is_atom(field) and not is_nil(field) and is_atom(direction) and not is_nil(direction) do
     order_by(queryable, {^direction, ^field})
   end
+
   def build_sort_query(queryable, _, _), do: queryable
 end

--- a/apps/ewallet/lib/ewallet/web/v1/auth/client_auth.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/auth/client_auth.ex
@@ -6,11 +6,10 @@ defmodule EWallet.Web.V1.ClientAuth do
 
   def parse_header(header) do
     with header when not is_nil(header) <- header,
-        [scheme, content] <- String.split(header, " ", parts: 2),
-        true <- scheme in ["Basic", "OMGClient"],
-        {:ok, decoded} <- Base.decode64(content),
-        [key, token] <- String.split(decoded, ":", parts: 2)
-    do
+         [scheme, content] <- String.split(header, " ", parts: 2),
+         true <- scheme in ["Basic", "OMGClient"],
+         {:ok, decoded} <- Base.decode64(content),
+         [key, token] <- String.split(decoded, ":", parts: 2) do
       {:ok, key, token}
     else
       _ ->
@@ -22,6 +21,7 @@ defmodule EWallet.Web.V1.ClientAuth do
     case APIKey.authenticate(api_key, owner_app) do
       false ->
         {:error, :invalid_api_key}
+
       account ->
         {:ok, account}
     end

--- a/apps/ewallet/lib/ewallet/web/v1/auth/provider_auth.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/auth/provider_auth.ex
@@ -9,8 +9,7 @@ defmodule EWallet.Web.V1.ProviderAuth do
          [scheme, content] <- String.split(header, " ", parts: 2),
          true <- scheme in ["Basic", "OMGServer"],
          {:ok, decoded} <- Base.decode64(content),
-         [access, secret] <- String.split(decoded, ":", parts: 2)
-    do
+         [access, secret] <- String.split(decoded, ":", parts: 2) do
       {:ok, access, secret}
     else
       _ -> {:error, :invalid_auth_scheme}
@@ -19,7 +18,7 @@ defmodule EWallet.Web.V1.ProviderAuth do
 
   def authenticate(access_key, secret_key) do
     case Key.authenticate(access_key, secret_key) do
-      false   -> {:error, :invalid_access_secret_key}
+      false -> {:error, :invalid_access_secret_key}
       account -> {:ok, account}
     end
   end

--- a/apps/ewallet/lib/ewallet/web/v1/auth/socket_client_auth.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/auth/socket_client_auth.ex
@@ -20,6 +20,7 @@ defmodule EWallet.Web.V1.SocketClientAuth do
         auth
         |> Map.put(:auth_api_key, key)
         |> Map.put(:auth_auth_token, token)
+
       {:error, :invalid_auth_scheme} ->
         auth
         |> Map.put(:authenticated, false)
@@ -28,13 +29,15 @@ defmodule EWallet.Web.V1.SocketClientAuth do
   end
 
   # Skip client auth if it already failed since header parsing
-  defp authenticate_client(%{authenticated: :false} = auth), do: auth
+  defp authenticate_client(%{authenticated: false} = auth), do: auth
+
   defp authenticate_client(auth) do
     api_key = auth[:auth_api_key]
 
     case ClientAuth.authenticate_client(api_key, :ewallet_api) do
       {:ok, account} ->
         Map.put(auth, :account, account)
+
       {:error, :invalid_api_key} ->
         auth
         |> Map.put(:authenticated, false)
@@ -43,7 +46,8 @@ defmodule EWallet.Web.V1.SocketClientAuth do
   end
 
   # Skip token auth if it already failed since API key validation
-  defp authenticate_token(%{authenticated: :false} = auth), do: auth
+  defp authenticate_token(%{authenticated: false} = auth), do: auth
+
   defp authenticate_token(auth) do
     auth_token = auth[:auth_auth_token]
 
@@ -52,6 +56,7 @@ defmodule EWallet.Web.V1.SocketClientAuth do
         auth
         |> Map.put(:authenticated, :client)
         |> Map.put(:user, user)
+
       {:error, code} ->
         auth
         |> Map.put(:authenticated, false)

--- a/apps/ewallet/lib/ewallet/web/v1/auth/socket_provider_auth.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/auth/socket_provider_auth.ex
@@ -19,6 +19,7 @@ defmodule EWallet.Web.V1.SocketProviderAuth do
         auth
         |> Map.put(:auth_access_key, access)
         |> Map.put(:auth_secret_key, secret)
+
       {:error, :invalid_auth_scheme} ->
         auth
         |> Map.put(:authenticated, false)
@@ -27,7 +28,8 @@ defmodule EWallet.Web.V1.SocketProviderAuth do
   end
 
   # Skip auth if it already failed since header parsing
-  defp authenticate_access(%{authenticated: :false} = auth), do: auth
+  defp authenticate_access(%{authenticated: false} = auth), do: auth
+
   defp authenticate_access(auth) do
     access_key = auth[:auth_access_key]
     secret_key = auth[:auth_secret_key]
@@ -37,8 +39,9 @@ defmodule EWallet.Web.V1.SocketProviderAuth do
         auth
         |> Map.put(:authenticated, :provider)
         |> Map.put(:account, account)
+
       {:error, :invalid_access_secret_key} ->
-                auth
+        auth
         |> Map.put(:authenticated, false)
         |> Map.put(:auth_error, :invalid_access_secret_key)
     end

--- a/apps/ewallet/lib/ewallet/web/v1/event_handlers/event.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/event_handlers/event.ex
@@ -6,17 +6,17 @@ defmodule EWallet.Web.V1.Event do
   alias EWallet.Web.V1.TransactionConsumptionEventHandler
   alias EWalletDB.{User, Account}
 
-  @spec dispatch(Atom.t, Map.t) :: :ok
+  @spec dispatch(Atom.t(), Map.t()) :: :ok
   def dispatch(event, attrs) do
     TransactionConsumptionEventHandler.broadcast(event, attrs)
   end
 
-  @spec broadcast(Keyword.t) :: :ok
+  @spec broadcast(Keyword.t()) :: :ok
   def broadcast(
-    event: event,
-    topics: topics,
-    payload: payload
-  ) do
+        event: event,
+        topics: topics,
+        payload: payload
+      ) do
     log(event, topics)
 
     Enum.each(topics, fn topic ->
@@ -31,34 +31,44 @@ defmodule EWallet.Web.V1.Event do
   end
 
   defp log(event, topics) do
-    Logger.info ""
-    Logger.info "WEBSOCKET EVENT: Dispatching event '#{event}' to:"
+    Logger.info("")
+    Logger.info("WEBSOCKET EVENT: Dispatching event '#{event}' to:")
     Logger.info("-- Endpoints:")
+
     Enum.each(endpoints(), fn endpoint ->
       Logger.info("---- #{endpoint}")
     end)
+
     Logger.info("-- Channels:")
+
     Enum.each(topics, fn topic ->
       Logger.info("---- #{topic}")
     end)
+
     Logger.info("Ending event dispatch...")
-    Logger.info ""
+    Logger.info("")
   end
 
   def address_topic(topics, address), do: topics ++ ["address:#{address}"]
   def transaction_request_topic(topics, id), do: topics ++ ["transaction_request:#{id}"]
   def transaction_consumption_topic(topics, id), do: topics ++ ["transaction_consumption:#{id}"]
+
   def user_topic(topics, user_id) do
     case user_id do
-      nil -> topics
+      nil ->
+        topics
+
       user_id ->
         user = User.get(user_id)
         topics ++ ["user:#{user.provider_user_id}", "user:#{user.id}"]
     end
   end
+
   def account_topic(topics, account_id) do
     case account_id do
-      nil -> topics
+      nil ->
+        topics
+
       id ->
         account = Account.get(id)
         topics ++ ["account:#{account.id}"]

--- a/apps/ewallet/lib/ewallet/web/v1/event_handlers/transaction_consumption_event_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/event_handlers/transaction_consumption_event_handler.ex
@@ -6,7 +6,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandler do
   alias EWalletDB.Helpers.{Assoc, Preloader}
   alias EWalletDB.TransactionConsumption
 
-  @spec broadcast(Atom.t, TransactionConsumption.t) :: :ok | {:error, :unhandled_event}
+  @spec broadcast(Atom.t(), TransactionConsumption.t()) :: :ok | {:error, :unhandled_event}
   def broadcast(:transaction_consumption_request, %{consumption: consumption}) do
     consumption = Preloader.preload(consumption, transaction_request: [:account, :user])
 
@@ -58,6 +58,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandler do
           status: :ok,
           data: TransactionConsumptionSerializer.serialize(consumption)
         }
+
       false ->
         %{
           status: :error,
@@ -71,7 +72,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandler do
     consumption = Preloader.preload(consumption, :transfer)
 
     case consumption.status do
-      "failed"  -> consumption.transfer.ledger_response["code"]
+      "failed" -> consumption.transfer.ledger_response["code"]
       "expired" -> :expired_transaction_consumption
       "pending" -> :unfinalized_transaction_consumption
     end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/account_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/account_serializer.ex
@@ -12,12 +12,14 @@ defmodule EWallet.Web.V1.AccountSerializer do
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+
   def serialize(accounts) when is_list(accounts) do
     %{
       object: "list",
       data: Enum.map(accounts, &serialize/1)
     }
   end
+
   def serialize(%Account{} = account) do
     account = Preloader.preload(account, :parent)
 
@@ -36,6 +38,7 @@ defmodule EWallet.Web.V1.AccountSerializer do
       updated_at: Date.to_iso8601(account.updated_at)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/address_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/address_serializer.ex
@@ -7,12 +7,13 @@ defmodule EWallet.Web.V1.AddressSerializer do
 
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
+
   def serialize(address) do
     %{
       object: "address",
       socket_topic: "address:#{address.address}",
       balances: serialize_balances(address.balances),
-      address: address.address,
+      address: address.address
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/api_key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/api_key_serializer.ex
@@ -11,6 +11,7 @@ defmodule EWallet.Web.V1.APIKeySerializer do
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+
   def serialize(%APIKey{} = api_key) do
     api_key = Preloader.preload(api_key, :account)
 
@@ -25,6 +26,7 @@ defmodule EWallet.Web.V1.APIKeySerializer do
       deleted_at: Date.to_iso8601(api_key.deleted_at)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/balance_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/balance_serializer.ex
@@ -8,6 +8,7 @@ defmodule EWallet.Web.V1.BalanceSerializer do
   # Both the given balance and `%NotLoaded{}` are maps
   # so we need to pattern-match `%NotLoaded{}` first.
   def serialize(%NotLoaded{}), do: nil
+
   def serialize(balance) when is_map(balance) do
     %{
       object: "balance",
@@ -15,5 +16,6 @@ defmodule EWallet.Web.V1.BalanceSerializer do
       amount: balance.amount
     }
   end
+
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
@@ -10,6 +10,7 @@ defmodule EWallet.Web.V1.KeySerializer do
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+
   def serialize(%Key{} = key) do
     key = Preloader.preload(key, :account)
 
@@ -24,6 +25,7 @@ defmodule EWallet.Web.V1.KeySerializer do
       deleted_at: Date.to_iso8601(key.deleted_at)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/minted_token_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/minted_token_serializer.ex
@@ -10,9 +10,11 @@ defmodule EWallet.Web.V1.MintedTokenSerializer do
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+
   def serialize(minted_tokens) when is_list(minted_tokens) do
     Enum.map(minted_tokens, &serialize/1)
   end
+
   def serialize(%MintedToken{} = minted_token) do
     %{
       object: "minted_token",
@@ -26,6 +28,7 @@ defmodule EWallet.Web.V1.MintedTokenSerializer do
       updated_at: Date.to_iso8601(minted_token.updated_at)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/paginator_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/paginator_serializer.ex
@@ -10,9 +10,10 @@ defmodule EWallet.Web.V1.PaginatorSerializer do
   """
   def serialize(%Paginator{} = paginator, mapper) when is_function(mapper) do
     paginator
-    |> Map.update!(:data, fn(data) -> Enum.map(data, mapper) end)
+    |> Map.update!(:data, fn data -> Enum.map(data, mapper) end)
     |> serialize()
   end
+
   def serialize(%Paginator{} = paginator) do
     %{
       object: "list",

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
@@ -4,6 +4,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
   """
   alias Ecto.Association.NotLoaded
   alias EWallet.Web.Date
+
   alias EWallet.Web.V1.{
     AccountSerializer,
     MintedTokenSerializer,
@@ -11,15 +12,19 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
     TransactionRequestSerializer,
     UserSerializer
   }
+
   alias EWalletDB.TransactionConsumption
   alias EWalletDB.Helpers.{Assoc, Preloader}
 
   def serialize(%TransactionConsumption{} = consumption) do
-    consumption = Preloader.preload(consumption, [:account,
-                                                  :minted_token,
-                                                  :transaction_request,
-                                                  :transfer,
-                                                  :user])
+    consumption =
+      Preloader.preload(consumption, [
+        :account,
+        :minted_token,
+        :transaction_request,
+        :transfer,
+        :user
+      ])
 
     %{
       object: "transaction_consumption",
@@ -37,7 +42,8 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
       account_id: Assoc.get(consumption, [:account, :id]),
       account: AccountSerializer.serialize(consumption.account),
       transaction_request_id: consumption.transaction_request.id,
-      transaction_request: TransactionRequestSerializer.serialize(consumption.transaction_request),
+      transaction_request:
+        TransactionRequestSerializer.serialize(consumption.transaction_request),
       address: consumption.balance_address,
       metadata: consumption.metadata,
       encrypted_metadata: consumption.encrypted_metadata,
@@ -51,6 +57,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
       created_at: Date.to_iso8601(consumption.inserted_at)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
@@ -3,20 +3,20 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
   Serializes transaction request data into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
+
   alias EWallet.Web.V1.{
     AccountSerializer,
     MintedTokenSerializer,
     UserSerializer
   }
+
   alias EWallet.Web.Date
   alias EWalletDB.Helpers.{Assoc, Preloader}
   alias EWalletDB.TransactionRequest
 
   def serialize(%TransactionRequest{} = transaction_request) do
-    transaction_request = Preloader.preload(transaction_request, [:account,
-                                                                  :consumptions,
-                                                                  :minted_token,
-                                                                  :user])
+    transaction_request =
+      Preloader.preload(transaction_request, [:account, :consumptions, :minted_token, :user])
 
     %{
       object: "transaction_request",
@@ -47,6 +47,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
       updated_at: Date.to_iso8601(transaction_request.updated_at)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_serializer.ex
@@ -10,6 +10,7 @@ defmodule EWallet.Web.V1.TransactionSerializer do
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+
   def serialize(%Transfer{} = transaction) do
     serialized_minted_token = MintedTokenSerializer.serialize(transaction.minted_token)
 
@@ -22,17 +23,17 @@ defmodule EWallet.Web.V1.TransactionSerializer do
         object: "transaction_source",
         address: transaction.from,
         amount: transaction.amount,
-        minted_token: serialized_minted_token,
+        minted_token: serialized_minted_token
       },
       to: %{
         object: "transaction_source",
         address: transaction.to,
         amount: transaction.amount,
-        minted_token: serialized_minted_token,
+        minted_token: serialized_minted_token
       },
       exchange: %{
         object: "exchange",
-        rate: 1,
+        rate: 1
       },
       metadata: transaction.metadata,
       encrypted_metadata: transaction.encrypted_metadata,
@@ -41,6 +42,7 @@ defmodule EWallet.Web.V1.TransactionSerializer do
       updated_at: Date.to_iso8601(transaction.updated_at)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/user_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/user_serializer.ex
@@ -10,6 +10,7 @@ defmodule EWallet.Web.V1.UserSerializer do
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
   end
+
   def serialize(%User{} = user) do
     %{
       object: "user",
@@ -25,6 +26,7 @@ defmodule EWallet.Web.V1.UserSerializer do
       updated_at: Date.to_iso8601(user.updated_at)
     }
   end
+
   def serialize(%NotLoaded{}), do: nil
   def serialize(nil), do: nil
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/websocket_response_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/websocket_response_serializer.ex
@@ -13,11 +13,11 @@ defmodule EWallet.Web.V1.WebsocketResponseSerializer do
   Renders the given `data` into a V1 response format as JSON.
   """
   def serialize(%{
-     data: data,
-     error: error,
-     msg: msg,
-     success: success
-  }) do
+        data: data,
+        error: error,
+        msg: msg,
+        success: success
+      }) do
     %{
       success: success,
       version: "1",
@@ -66,24 +66,26 @@ defmodule EWallet.Web.V1.WebsocketResponseSerializer do
           reason: nil
         })
         |> format()
+
       false ->
         format(reply)
     end
   end
+
   defp build_message(msg), do: format(msg)
 
   defp format(data) do
     data = Map.from_struct(data)
 
     %{
-       topic: data[:topic],
-       event: data[:event] || "phx_reply",
-       ref: data[:ref] || nil,
-       status: data[:status] || data[:payload][:status],
-       data: data[:payload][:data],
-       error: data[:payload][:error],
-       reason: data[:payload][:reason]
-     }
+      topic: data[:topic],
+      event: data[:event] || "phx_reply",
+      ref: data[:ref] || nil,
+      status: data[:status] || data[:payload][:status],
+      data: data[:payload][:data],
+      error: data[:payload][:error],
+      reason: data[:payload][:reason]
+    }
   end
 
   defp encode_fields(msg) do
@@ -98,9 +100,11 @@ defmodule EWallet.Web.V1.WebsocketResponseSerializer do
   end
 
   defp build_error(nil, nil), do: nil
+
   defp build_error(nil, reason) do
     ErrorHandler.build_error(:websocket_connect_error, reason, nil)
   end
+
   defp build_error(code, nil) when is_atom(code) when is_binary(code) do
     ErrorHandler.build_error(code, nil)
   end

--- a/apps/ewallet/test/ewallet/fetchers/balance_assigner_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/balance_assigner_test.exs
@@ -15,48 +15,52 @@ defmodule EWallet.BalanceAssignerTest do
 
   describe "load/1" do
     test "loads the correct balances when credit", meta do
-      {:ok, from, to} = BalanceAssigner.assign(%{
-        account: meta.account,
-        user: meta.user,
-        type: TransactionGate.credit_type,
-        burn_balance_identifier: nil
-      })
+      {:ok, from, to} =
+        BalanceAssigner.assign(%{
+          account: meta.account,
+          user: meta.user,
+          type: TransactionGate.credit_type(),
+          burn_balance_identifier: nil
+        })
 
       assert from == Account.get_primary_balance(meta.account)
       assert to == User.get_primary_balance(meta.user)
     end
 
     test "loads the correct balances when debit", meta do
-      {:ok, from, to} = BalanceAssigner.assign(%{
-        account: meta.account,
-        user: meta.user,
-        type: TransactionGate.debit_type,
-        burn_balance_identifier: nil
-      })
+      {:ok, from, to} =
+        BalanceAssigner.assign(%{
+          account: meta.account,
+          user: meta.user,
+          type: TransactionGate.debit_type(),
+          burn_balance_identifier: nil
+        })
 
       assert from == User.get_primary_balance(meta.user)
       assert to == Account.get_primary_balance(meta.account)
     end
 
     test "loads the correct balances when debit and burn balance is specified", meta do
-      {:ok, from, to} = BalanceAssigner.assign(%{
-        account: meta.account,
-        user: meta.user,
-        type: TransactionGate.debit_type,
-        burn_balance_identifier: "burn"
-      })
+      {:ok, from, to} =
+        BalanceAssigner.assign(%{
+          account: meta.account,
+          user: meta.user,
+          type: TransactionGate.debit_type(),
+          burn_balance_identifier: "burn"
+        })
 
       assert from == User.get_primary_balance(meta.user)
       assert to == Account.get_default_burn_balance(meta.account)
     end
 
     test "returns an error if the given burn address is not found", meta do
-      {res, code} = BalanceAssigner.assign(%{
-        account: meta.account,
-        user: meta.user,
-        type: TransactionGate.debit_type,
-        burn_balance_identifier: "burnz"
-      })
+      {res, code} =
+        BalanceAssigner.assign(%{
+          account: meta.account,
+          user: meta.user,
+          type: TransactionGate.debit_type(),
+          burn_balance_identifier: "burnz"
+        })
 
       assert res == :error
       assert code == :burn_balance_not_found

--- a/apps/ewallet/test/ewallet/fetchers/balance_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/balance_fetcher_test.exs
@@ -1,12 +1,12 @@
 defmodule EWallet.BalanceFetcherTest do
- use EWallet.LocalLedgerCase, async: true
- alias EWallet.BalanceFetcher
- alias EWalletDB.{User, Balance}
+  use EWallet.LocalLedgerCase, async: true
+  alias EWallet.BalanceFetcher
+  alias EWalletDB.{User, Balance}
 
   setup do
-    {:ok, user}  = :user |> params_for() |> User.insert()
+    {:ok, user} = :user |> params_for() |> User.insert()
     minted_token = insert(:minted_token)
-    balance      = User.get_primary_balance(user)
+    balance = User.get_primary_balance(user)
 
     %{user: user, minted_token: minted_token, balance: balance}
   end
@@ -18,7 +18,7 @@ defmodule EWallet.BalanceFetcherTest do
     end
 
     test "retrieves the balance if address is given and belonds to the user", meta do
-      inserted_balance = insert(:balance, identifier: Balance.secondary, user: meta.user)
+      inserted_balance = insert(:balance, identifier: Balance.secondary(), user: meta.user)
       {:ok, balance} = BalanceFetcher.get(meta.user, inserted_balance.address)
       assert balance.uuid == inserted_balance.uuid
     end
@@ -29,7 +29,7 @@ defmodule EWallet.BalanceFetcherTest do
     end
 
     test "returns 'user_balance_mismatch' if the balance found does not belong to the user",
-    meta do
+         meta do
       balance = insert(:balance)
       {:error, error} = BalanceFetcher.get(meta.user, balance.address)
       assert error == :user_balance_mismatch

--- a/apps/ewallet/test/ewallet/fetchers/computed_balance_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/computed_balance_fetcher_test.exs
@@ -6,13 +6,13 @@ defmodule EWallet.ComputedBalanceFetcherTest do
 
   describe "all/1" do
     test "retrieve all balances from a provider_user_id" do
-      account        = Account.get_master_account()
+      account = Account.get_master_account()
       master_balance = Account.get_primary_balance(account)
-      {:ok, user}    = :user |> params_for() |> User.insert()
-      user_balance   = User.get_primary_balance(user)
-      {:ok, btc}     = :minted_token |> params_for(symbol: "BTC") |> MintedToken.insert()
-      {:ok, omg}     = :minted_token |> params_for(symbol: "OMG") |> MintedToken.insert()
-      {:ok, knc}     = :minted_token |> params_for(symbol: "KNC") |> MintedToken.insert()
+      {:ok, user} = :user |> params_for() |> User.insert()
+      user_balance = User.get_primary_balance(user)
+      {:ok, btc} = :minted_token |> params_for(symbol: "BTC") |> MintedToken.insert()
+      {:ok, omg} = :minted_token |> params_for(symbol: "OMG") |> MintedToken.insert()
+      {:ok, knc} = :minted_token |> params_for(symbol: "KNC") |> MintedToken.insert()
 
       mint!(btc)
       mint!(omg)
@@ -21,27 +21,29 @@ defmodule EWallet.ComputedBalanceFetcherTest do
       transfer!(master_balance.address, user_balance.address, btc, 150_000 * btc.subunit_to_unit)
       transfer!(master_balance.address, user_balance.address, omg, 12_000 * omg.subunit_to_unit)
 
-      {status, address} = ComputedBalanceFetcher.all(%{"provider_user_id" => user.provider_user_id})
+      {status, address} =
+        ComputedBalanceFetcher.all(%{"provider_user_id" => user.provider_user_id})
 
       assert status == :ok
       assert address.address == User.get_primary_balance(user).address
+
       assert address.balances == [
-        %{minted_token: btc, amount: 150_000 * btc.subunit_to_unit},
-        %{minted_token: omg, amount: 12_000 * omg.subunit_to_unit},
-        %{minted_token: knc, amount: 0}
-      ]
+               %{minted_token: btc, amount: 150_000 * btc.subunit_to_unit},
+               %{minted_token: omg, amount: 12_000 * omg.subunit_to_unit},
+               %{minted_token: knc, amount: 0}
+             ]
     end
   end
 
   describe "get/2" do
     test "retrieve the specific balance from a minted_token and an address" do
-      account        = Account.get_master_account()
+      account = Account.get_master_account()
       master_balance = Account.get_primary_balance(account)
-      {:ok, user}    = :user |> params_for() |> User.insert()
-      user_balance   = User.get_primary_balance(user)
-      {:ok, omg}     = :minted_token |> params_for(symbol: "OMG") |> MintedToken.insert()
-      {:ok, btc}     = :minted_token |> params_for(symbol: "BTC") |> MintedToken.insert()
-      {:ok, knc}     = :minted_token |> params_for(symbol: "KNC") |> MintedToken.insert()
+      {:ok, user} = :user |> params_for() |> User.insert()
+      user_balance = User.get_primary_balance(user)
+      {:ok, omg} = :minted_token |> params_for(symbol: "OMG") |> MintedToken.insert()
+      {:ok, btc} = :minted_token |> params_for(symbol: "BTC") |> MintedToken.insert()
+      {:ok, knc} = :minted_token |> params_for(symbol: "KNC") |> MintedToken.insert()
 
       mint!(btc)
       mint!(omg)
@@ -52,11 +54,11 @@ defmodule EWallet.ComputedBalanceFetcherTest do
 
       {status, address} = ComputedBalanceFetcher.get(omg.id, user_balance.address)
       assert status == :ok
-      assert address.address ==
-        User.get_primary_balance(user).address
+      assert address.address == User.get_primary_balance(user).address
+
       assert address.balances == [
-        %{minted_token: omg, amount: 12_000 * omg.subunit_to_unit},
-      ]
+               %{minted_token: omg, amount: 12_000 * omg.subunit_to_unit}
+             ]
     end
   end
 end

--- a/apps/ewallet/test/ewallet/fetchers/credit_debit_record_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/credit_debit_record_fetcher_test.exs
@@ -48,10 +48,11 @@ defmodule EWallet.CreditDebitRecordFetcherTest do
       {:ok, inserted_token} = MintedToken.insert(params_for(:minted_token))
       provider_user_id = "invalid_provider_user_id"
 
-      res = CreditDebitRecordFetcher.fetch(%{
-        "provider_user_id" => provider_user_id,
-        "token_id" => inserted_token.id
-      })
+      res =
+        CreditDebitRecordFetcher.fetch(%{
+          "provider_user_id" => provider_user_id,
+          "token_id" => inserted_token.id
+        })
 
       assert res == {:error, :provider_user_id_not_found}
     end
@@ -60,11 +61,12 @@ defmodule EWallet.CreditDebitRecordFetcherTest do
       {:ok, inserted_token} = MintedToken.insert(params_for(:minted_token))
       {:ok, inserted_user} = User.insert(params_for(:user))
 
-      res = CreditDebitRecordFetcher.fetch(%{
-        "provider_user_id" => inserted_user.provider_user_id,
-        "token_id" =>  inserted_token.id,
-        "account_id" => "acc_12345678901234567890123456"
-      })
+      res =
+        CreditDebitRecordFetcher.fetch(%{
+          "provider_user_id" => inserted_user.provider_user_id,
+          "token_id" => inserted_token.id,
+          "account_id" => "acc_12345678901234567890123456"
+        })
 
       assert res == {:error, :account_id_not_found}
     end
@@ -73,11 +75,12 @@ defmodule EWallet.CreditDebitRecordFetcherTest do
       {:ok, inserted_account} = Account.insert(params_for(:account))
       {:ok, inserted_user} = User.insert(params_for(:user))
 
-      res = CreditDebitRecordFetcher.fetch(%{
-        "provider_user_id" => inserted_user.provider_user_id,
-        "token_id" =>  "invalid_id",
-        "account_id" => inserted_account.id
-      })
+      res =
+        CreditDebitRecordFetcher.fetch(%{
+          "provider_user_id" => inserted_user.provider_user_id,
+          "token_id" => "invalid_id",
+          "account_id" => inserted_account.id
+        })
 
       assert res == {:error, :minted_token_not_found}
     end

--- a/apps/ewallet/test/ewallet/gates/mint_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/mint_gate_test.exs
@@ -9,13 +9,14 @@ defmodule EWallet.MintGateTest do
     test "inserts a new confirmed mint" do
       {:ok, btc} = :minted_token |> params_for(symbol: "BTC") |> MintedToken.insert()
 
-      {res, mint, transfer} = MintGate.insert(%{
-        "idempotency_token" => UUID.generate(),
-        "token_id" => btc.id,
-        "amount" => 10_000 * btc.subunit_to_unit,
-        "description" => "Minting 10_000 #{btc.symbol}",
-        "metadata" => %{}
-      })
+      {res, mint, transfer} =
+        MintGate.insert(%{
+          "idempotency_token" => UUID.generate(),
+          "token_id" => btc.id,
+          "amount" => 10_000 * btc.subunit_to_unit,
+          "description" => "Minting 10_000 #{btc.symbol}",
+          "metadata" => %{}
+        })
 
       assert res == :ok
       assert mint != nil
@@ -26,17 +27,20 @@ defmodule EWallet.MintGateTest do
     test "fails to insert a new mint when the data is invalid" do
       {:ok, minted_token} = MintedToken.insert(params_for(:minted_token))
 
-      {res, changeset} = MintGate.insert(%{
-        "idempotency_token" => UUID.generate(),
-        "token_id" => minted_token.id,
-        "amount" => nil,
-        "description" => "description",
-        "metadata" => %{},
-      })
+      {res, changeset} =
+        MintGate.insert(%{
+          "idempotency_token" => UUID.generate(),
+          "token_id" => minted_token.id,
+          "amount" => nil,
+          "description" => "description",
+          "metadata" => %{}
+        })
+
       assert res == :error
+
       assert changeset.errors == [
-        amount: {"can't be blank", [validation: :required]}
-      ]
+               amount: {"can't be blank", [validation: :required]}
+             ]
     end
   end
 end

--- a/apps/ewallet/test/ewallet/gates/transaction_request_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_request_gate_test.exs
@@ -1,13 +1,13 @@
 defmodule EWallet.TransactionRequestTest do
- use EWallet.LocalLedgerCase, async: true
- alias EWallet.TransactionRequestGate
- alias EWalletDB.{User, TransactionRequest}
+  use EWallet.LocalLedgerCase, async: true
+  alias EWallet.TransactionRequestGate
+  alias EWalletDB.{User, TransactionRequest}
 
   setup do
-    {:ok, user}     = :user |> params_for() |> User.insert()
-    {:ok, account}  = :account |> params_for() |> Account.insert()
-    minted_token    = insert(:minted_token)
-    user_balance    = User.get_primary_balance(user)
+    {:ok, user} = :user |> params_for() |> User.insert()
+    {:ok, account} = :account |> params_for() |> Account.insert()
+    minted_token = insert(:minted_token)
+    user_balance = User.get_primary_balance(user)
     account_balance = Account.get_primary_balance(account)
 
     %{
@@ -21,64 +21,69 @@ defmodule EWallet.TransactionRequestTest do
 
   describe "create/1 with account_id" do
     test "with nil account_id and no address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "account_id" => nil
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => nil
+        })
 
       assert res == {:error, :account_id_not_found}
     end
 
     test "with invalid account_id and no address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "account_id" => "fake"
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => "fake"
+        })
 
       assert res == {:error, :account_id_not_found}
     end
 
     test "with valid account_id and nil address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "account_id" => "fake",
-        "address" => nil
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => "fake",
+          "address" => nil
+        })
 
       assert res == {:error, :account_id_not_found}
     end
 
     test "with valid account_id and no address", meta do
-      {res, request} = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "account_id" => meta.account.id
-      })
+      {res, request} =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => meta.account.id
+        })
 
       assert res == :ok
       assert %TransactionRequest{} = request
     end
 
     test "with valid account_id and a valid address", meta do
-      {res, request} = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "account_id" => meta.account.id,
-        "address" => meta.account_balance.address
-      })
+      {res, request} =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => meta.account.id,
+          "address" => meta.account_balance.address
+        })
 
       assert res == :ok
       assert %TransactionRequest{} = request
@@ -86,28 +91,30 @@ defmodule EWallet.TransactionRequestTest do
     end
 
     test "with valid account_id and an invalid address", meta do
-      res = TransactionRequestGate.create(%{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => "123",
-       "amount" => 1_000,
-       "account_id" => meta.account.id,
-       "address" => "fake"
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => meta.account.id,
+          "address" => "fake"
+        })
 
       assert res == {:error, :balance_not_found}
     end
 
     test "with valid account_id, valid user and a valid address", meta do
-      {res, request} = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "account_id" => meta.account.id,
-        "provider_user_id" => meta.user.provider_user_id,
-        "address" => meta.user_balance.address
-      })
+      {res, request} =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => meta.account.id,
+          "provider_user_id" => meta.user.provider_user_id,
+          "address" => meta.user_balance.address
+        })
 
       assert res == :ok
       assert %TransactionRequest{} = request
@@ -118,28 +125,30 @@ defmodule EWallet.TransactionRequestTest do
     end
 
     test "with valid account_id, valid user and an invalid address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "account_id" => meta.account.id,
-        "provider_user_id" => meta.user.provider_user_id,
-        "address" => meta.account_balance.address
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => meta.account.id,
+          "provider_user_id" => meta.user.provider_user_id,
+          "address" => meta.account_balance.address
+        })
 
       assert res == {:error, :user_balance_mismatch}
     end
 
     test "with valid account_id and an address that does not belong to the account", meta do
-      res = TransactionRequestGate.create(%{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => "123",
-       "amount" => 1_000,
-       "account_id" => meta.account.id,
-       "address" => meta.user_balance.address
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "account_id" => meta.account.id,
+          "address" => meta.user_balance.address
+        })
 
       assert res == {:error, :account_balance_mismatch}
     end
@@ -147,78 +156,84 @@ defmodule EWallet.TransactionRequestTest do
 
   describe "create/1 with provider_user_id" do
     test "with nil provider_user_id and no address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "provider_user_id" => nil
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "provider_user_id" => nil
+        })
 
       assert res == {:error, :provider_user_id_not_found}
     end
 
     test "with invalid provider_user_id and no address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "provider_user_id" => "fake"
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "provider_user_id" => "fake"
+        })
 
       assert res == {:error, :provider_user_id_not_found}
     end
 
     test "with valid provider_user_id and no address", meta do
-      {res, request} = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "provider_user_id" => meta.user.provider_user_id
-      })
+      {res, request} =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "provider_user_id" => meta.user.provider_user_id
+        })
 
       assert res == :ok
       assert %TransactionRequest{} = request
     end
 
     test "with valid provider_user_id and a valid address", meta do
-      {res, request} = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "provider_user_id" => meta.user.provider_user_id,
-        "address" => meta.user_balance.address
-      })
+      {res, request} =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "provider_user_id" => meta.user.provider_user_id,
+          "address" => meta.user_balance.address
+        })
 
       assert res == :ok
       assert %TransactionRequest{} = request
     end
 
     test "with valid provider_user_id and an invalid address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "provider_user_id" => meta.user.provider_user_id,
-        "address" => "fake"
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "provider_user_id" => meta.user.provider_user_id,
+          "address" => "fake"
+        })
 
       assert res == {:error, :balance_not_found}
     end
 
     test "with valid provider_user_id and an address that does not belong to the user", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "provider_user_id" => meta.user.provider_user_id,
-        "address" => meta.account_balance.address
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "provider_user_id" => meta.user.provider_user_id,
+          "address" => meta.account_balance.address
+        })
 
       assert res == {:error, :user_balance_mismatch}
     end
@@ -226,52 +241,55 @@ defmodule EWallet.TransactionRequestTest do
 
   describe "create/1 with address" do
     test "with nil address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "address" => nil
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "address" => nil
+        })
 
       assert res == {:error, :balance_not_found}
     end
 
     test "with a valid address", meta do
-      {res, request} = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "address" => meta.user_balance.address
-      })
+      {res, request} =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "address" => meta.user_balance.address
+        })
 
       assert res == :ok
       assert %TransactionRequest{} = request
     end
 
     test "with an invalid address", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "address" => "fake"
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "address" => "fake"
+        })
 
       assert res == {:error, :balance_not_found}
     end
-
   end
 
   describe "create/1 with invalid parameters" do
     test "with invalid parameters", meta do
-      res = TransactionRequestGate.create(%{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-      })
+      res =
+        TransactionRequestGate.create(%{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000
+        })
 
       assert res == {:error, :invalid_parameter}
     end
@@ -279,13 +297,14 @@ defmodule EWallet.TransactionRequestTest do
 
   describe "create/2 with %User{}" do
     test "creates a transaction request with all the params", meta do
-      {:ok, request} = TransactionRequestGate.create(meta.user, %{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => "123",
-       "amount" => 1_000,
-       "address" => meta.user_balance.address,
-      })
+      {:ok, request} =
+        TransactionRequestGate.create(meta.user, %{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "address" => meta.user_balance.address
+        })
 
       assert %TransactionRequest{} = request
       assert request.id != nil
@@ -297,66 +316,71 @@ defmodule EWallet.TransactionRequestTest do
     end
 
     test "creates a transaction request with only type and token_id", meta do
-      {:ok, request} = TransactionRequestGate.create(meta.user, %{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => nil,
-       "amount" => nil,
-       "address" => nil
-      })
+      {:ok, request} =
+        TransactionRequestGate.create(meta.user, %{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => nil,
+          "amount" => nil,
+          "address" => nil
+        })
 
       assert %TransactionRequest{} = request
     end
 
     test "receives an invalid changeset error when the type is invalid", meta do
-     {:error, changeset} = TransactionRequestGate.create(meta.user, %{
-       "type" => "fake",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => nil,
-       "amount" => nil,
-       "address" => nil
-     })
+      {:error, changeset} =
+        TransactionRequestGate.create(meta.user, %{
+          "type" => "fake",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => nil,
+          "amount" => nil,
+          "address" => nil
+        })
 
-     assert changeset.errors == [type: {"is invalid", [validation: :inclusion]}]
+      assert changeset.errors == [type: {"is invalid", [validation: :inclusion]}]
     end
 
     test "receives a 'balance_not_found' error when the address is invalid", meta do
-     {:error, error} = TransactionRequestGate.create(meta.user, %{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => nil,
-       "amount" => nil,
-       "address" => "fake"
-     })
+      {:error, error} =
+        TransactionRequestGate.create(meta.user, %{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => nil,
+          "amount" => nil,
+          "address" => "fake"
+        })
 
-     assert error == :balance_not_found
+      assert error == :balance_not_found
     end
 
     test "receives an 'user_balance_mismatch' error when the address does not belong to the user",
-    meta do
-     balance = insert(:balance)
+         meta do
+      balance = insert(:balance)
 
-     {:error, error} = TransactionRequestGate.create(meta.user, %{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => nil,
-       "amount" => nil,
-       "address" => balance.address
-     })
+      {:error, error} =
+        TransactionRequestGate.create(meta.user, %{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => nil,
+          "amount" => nil,
+          "address" => balance.address
+        })
 
-     assert error == :user_balance_mismatch
+      assert error == :user_balance_mismatch
     end
 
-    test "receives an 'minted_token_not_found' error when the token ID is not found", meta  do
-     res = TransactionRequestGate.create(meta.user, %{
-       "type" => "receive",
-       "token_id" => "fake",
-       "correlation_id" => nil,
-       "amount" => nil,
-       "address" => nil
-     })
+    test "receives an 'minted_token_not_found' error when the token ID is not found", meta do
+      res =
+        TransactionRequestGate.create(meta.user, %{
+          "type" => "receive",
+          "token_id" => "fake",
+          "correlation_id" => nil,
+          "amount" => nil,
+          "address" => nil
+        })
 
-     assert res == {:error, :minted_token_not_found}
+      assert res == {:error, :minted_token_not_found}
     end
   end
 
@@ -365,21 +389,22 @@ defmodule EWallet.TransactionRequestTest do
       t0 = NaiveDateTime.utc_now()
       expiration = t0 |> NaiveDateTime.add(60_000, :millisecond)
 
-      {:ok, request} = TransactionRequestGate.create(meta.user_balance, %{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => "123",
-       "amount" => 1_000,
-       "allow_amount_override" => false,
-       "require_confirmation" => true,
-       "consumption_lifetime" => 60_000,
-       "metadata" => %{two: "two"},
-       "encrypted_metadata" => %{one: "one"},
-       "expiration_date" => expiration,
-       "expiration_reason" => "test",
-       "expired_at" => "something",
-       "max_consumptions" => 3,
-      })
+      {:ok, request} =
+        TransactionRequestGate.create(meta.user_balance, %{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "allow_amount_override" => false,
+          "require_confirmation" => true,
+          "consumption_lifetime" => 60_000,
+          "metadata" => %{two: "two"},
+          "encrypted_metadata" => %{one: "one"},
+          "expiration_date" => expiration,
+          "expiration_reason" => "test",
+          "expired_at" => "something",
+          "max_consumptions" => 3
+        })
 
       assert %TransactionRequest{} = request
       assert request.id != nil
@@ -401,59 +426,64 @@ defmodule EWallet.TransactionRequestTest do
     end
 
     test "creates a transaction request with only type and token_id", meta do
-      {:ok, request} = TransactionRequestGate.create(meta.user_balance, %{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => nil,
-       "amount" => nil
-      })
+      {:ok, request} =
+        TransactionRequestGate.create(meta.user_balance, %{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => nil,
+          "amount" => nil
+        })
 
       assert %TransactionRequest{} = request
     end
 
     test "receives an invalid changeset error when the type is invalid", meta do
-     {:error, changeset} = TransactionRequestGate.create(meta.user_balance, %{
-       "type" => "fake",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => nil,
-       "amount" => nil
-     })
+      {:error, changeset} =
+        TransactionRequestGate.create(meta.user_balance, %{
+          "type" => "fake",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => nil,
+          "amount" => nil
+        })
 
-     assert changeset.errors == [type: {"is invalid", [validation: :inclusion]}]
+      assert changeset.errors == [type: {"is invalid", [validation: :inclusion]}]
     end
 
     test "receives a 'invalid_parameter' error when the balance is nil", meta do
-     {:error, error} = TransactionRequestGate.create(nil, %{
-       "type" => "receive",
-       "token_id" => meta.minted_token.id,
-       "correlation_id" => nil,
-       "amount" => nil
-     })
+      {:error, error} =
+        TransactionRequestGate.create(nil, %{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => nil,
+          "amount" => nil
+        })
 
-     assert error == :invalid_parameter
+      assert error == :invalid_parameter
     end
 
-    test "receives an 'minted_token_not_found' error when the token ID is not found", meta  do
-     res = TransactionRequestGate.create(meta.user_balance, %{
-       "type" => "receive",
-       "token_id" => "fake",
-       "correlation_id" => nil,
-       "amount" => nil
-     })
+    test "receives an 'minted_token_not_found' error when the token ID is not found", meta do
+      res =
+        TransactionRequestGate.create(meta.user_balance, %{
+          "type" => "receive",
+          "token_id" => "fake",
+          "correlation_id" => nil,
+          "amount" => nil
+        })
 
-     assert res == {:error, :minted_token_not_found}
+      assert res == {:error, :minted_token_not_found}
     end
   end
 
   describe "get/1" do
     test "returns the request do when given valid ID", meta do
-      {:ok, request} = TransactionRequestGate.create(meta.user, %{
-        "type" => "receive",
-        "token_id" => meta.minted_token.id,
-        "correlation_id" => "123",
-        "amount" => 1_000,
-        "address" => meta.user_balance.address,
-      })
+      {:ok, request} =
+        TransactionRequestGate.create(meta.user, %{
+          "type" => "receive",
+          "token_id" => meta.minted_token.id,
+          "correlation_id" => "123",
+          "amount" => 1_000,
+          "address" => meta.user_balance.address
+        })
 
       assert {:ok, request} = TransactionRequestGate.get(request.id)
       assert %TransactionRequest{} = request
@@ -480,7 +510,8 @@ defmodule EWallet.TransactionRequestTest do
     end
 
     test "returns a 'transaction_request_not_found' error when given invalid UUID" do
-      assert TransactionRequestGate.get_with_lock("123") == {:error, :transaction_request_not_found}
+      assert TransactionRequestGate.get_with_lock("123") ==
+               {:error, :transaction_request_not_found}
     end
   end
 
@@ -518,7 +549,9 @@ defmodule EWallet.TransactionRequestTest do
     end
 
     test "returns nil if no consumption lifetime" do
-      request = insert(:transaction_request, require_confirmation: true, consumption_lifetime: nil)
+      request =
+        insert(:transaction_request, require_confirmation: true, consumption_lifetime: nil)
+
       date = TransactionRequestGate.expiration_from_lifetime(request)
       assert date == nil
     end
@@ -531,8 +564,14 @@ defmodule EWallet.TransactionRequestTest do
 
     test "returns the expiration date based on consumption_lifetime" do
       now = NaiveDateTime.utc_now()
-      request = insert(:transaction_request, require_confirmation: true,
-                                             consumption_lifetime: 1_000)
+
+      request =
+        insert(
+          :transaction_request,
+          require_confirmation: true,
+          consumption_lifetime: 1_000
+        )
+
       date = TransactionRequestGate.expiration_from_lifetime(request)
       assert date > now
     end
@@ -598,10 +637,20 @@ defmodule EWallet.TransactionRequestTest do
 
     test "expires the request if max_consumptions has been reached" do
       request = insert(:transaction_request, max_consumptions: 2)
-      _consumption = insert(:transaction_consumption, transaction_request_uuid: request.uuid,
-                                                      status: "confirmed")
-      _consumption = insert(:transaction_consumption, transaction_request_uuid: request.uuid,
-                                                      status: "confirmed")
+
+      _consumption =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "confirmed"
+        )
+
+      _consumption =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "confirmed"
+        )
 
       {res, updated_request} = TransactionRequestGate.expire_if_max_consumption(request)
       assert res == :ok

--- a/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
@@ -1,4 +1,4 @@
- defmodule EWallet.TransferTest do
+defmodule EWallet.TransferTest do
   use EWallet.LocalLedgerCase, async: true
   alias EWallet.TransferGate
   alias EWalletDB.{Repo, MintedToken, Account, Transfer}
@@ -6,13 +6,13 @@
   alias Ecto.UUID
 
   setup do
-    master_account  = Account.get_master_account()
-    master_balance  = Account.get_primary_balance(master_account)
+    master_account = Account.get_master_account()
+    master_balance = Account.get_primary_balance(master_account)
     {:ok, account1} = Account.insert(params_for(:account))
     {:ok, account2} = Account.insert(params_for(:account))
-    {:ok, token}    = MintedToken.insert(params_for(:minted_token, subunit_to_unit: 100))
-    from            = Account.get_primary_balance(account1)
-    to              = Account.get_primary_balance(account2)
+    {:ok, token} = MintedToken.insert(params_for(:minted_token, subunit_to_unit: 100))
+    from = Account.get_primary_balance(account1)
+    to = Account.get_primary_balance(account2)
 
     mint!(token)
     transfer!(master_balance.address, from.address, token, 1_000 * token.subunit_to_unit)
@@ -22,7 +22,7 @@
       from: from.address,
       to: to.address,
       minted_token_id: token.id,
-      amount: 100  * token.subunit_to_unit,
+      amount: 100 * token.subunit_to_unit,
       metadata: %{},
       payload: %{}
     }
@@ -37,7 +37,7 @@
 
       transfer = Transfer.get_by_idempotency_token(attrs.idempotency_token)
       assert transfer.id == inserted_transfer.id
-      assert transfer.type == Transfer.internal
+      assert transfer.type == Transfer.internal()
     end
 
     test "gets a transfer if already existing", attrs do
@@ -59,7 +59,7 @@
       transfer = TransferGate.process(transfer)
 
       assert %{"entry_uuid" => _} = transfer.ledger_response
-      assert transfer.status == Transfer.confirmed
+      assert transfer.status == Transfer.confirmed()
     end
 
     test "does not insert an entry and fails the transfer when transaction failed", attrs do
@@ -67,16 +67,17 @@
       {:ok, transfer} = TransferGate.get_or_insert(attrs)
       transfer = TransferGate.process(transfer)
 
-      assert transfer.status == Transfer.failed
+      assert transfer.status == Transfer.failed()
       assert transfer.ledger_response["code"] == "insufficient_funds"
-      assert transfer.ledger_response["description"] == %{
-        "address" => attrs[:from],
-        "amount_to_debit" => 1_000_000,
-        "current_amount" => 100_000,
-        "minted_token_id" => attrs[:minted_token_id]
-      }
 
-      assert transfer.status == Transfer.failed
+      assert transfer.ledger_response["description"] == %{
+               "address" => attrs[:from],
+               "amount_to_debit" => 1_000_000,
+               "current_amount" => 100_000,
+               "minted_token_id" => attrs[:minted_token_id]
+             }
+
+      assert transfer.status == Transfer.failed()
     end
   end
 
@@ -85,7 +86,7 @@
       {:ok, transfer} = TransferGate.get_or_insert(attrs)
       transfer = TransferGate.genesis(transfer)
 
-      assert transfer.status == Transfer.confirmed
+      assert transfer.status == Transfer.confirmed()
       assert %{"entry_uuid" => _} = transfer.ledger_response
     end
   end

--- a/apps/ewallet/test/ewallet/web/api_docs/controller_test.exs
+++ b/apps/ewallet/test/ewallet/web/api_docs/controller_test.exs
@@ -14,9 +14,10 @@ defmodule EWallet.Web.APIDocs.ControllerTest do
       refute conn.halted
       assert conn.status == 302
       assert conn.resp_body =~ ~s(/some_scope/docs.ui)
-      assert Enum.any?(conn.resp_headers, fn(header) ->
-        header == {"location", "/some_scope/docs.ui"}
-      end)
+
+      assert Enum.any?(conn.resp_headers, fn header ->
+               header == {"location", "/some_scope/docs.ui"}
+             end)
     end
 
     test "return the Swagger UI page when calling /docs.ui" do
@@ -32,7 +33,8 @@ defmodule EWallet.Web.APIDocs.ControllerTest do
 
       refute conn.halted
       assert conn.status == 200
-      assert conn.resp_body =~ ~r/^openapi:/ # Expects the spec to begin with "openapi:"
+      # Expects the spec to begin with "openapi:"
+      assert conn.resp_body =~ ~r/^openapi:/
     end
   end
 
@@ -43,9 +45,10 @@ defmodule EWallet.Web.APIDocs.ControllerTest do
       refute conn.halted
       assert conn.status == 302
       assert conn.resp_body =~ ~s(/some_scope/errors.ui)
-      assert Enum.any?(conn.resp_headers, fn(header) ->
-        header == {"location", "/some_scope/errors.ui"}
-      end)
+
+      assert Enum.any?(conn.resp_headers, fn header ->
+               header == {"location", "/some_scope/errors.ui"}
+             end)
     end
 
     test "returns the HTML page when calling /errors.ui" do
@@ -61,8 +64,10 @@ defmodule EWallet.Web.APIDocs.ControllerTest do
 
       refute conn.halted
       assert conn.status == 200
-      assert conn.resp_body =~ ~r/code:/ # Expects the response to have a `code` key
-      assert conn.resp_body =~ ~r/description:/ # Expects the response to have a `description` key
+      # Expects the response to have a `code` key
+      assert conn.resp_body =~ ~r/code:/
+      # Expects the response to have a `description` key
+      assert conn.resp_body =~ ~r/description:/
     end
 
     test "returns the json spec when calling /errors.json" do
@@ -70,8 +75,10 @@ defmodule EWallet.Web.APIDocs.ControllerTest do
 
       refute conn.halted
       assert conn.status == 200
-      assert conn.resp_body =~ ~r/"code":/ # Expects the response to have a `code` key
-      assert conn.resp_body =~ ~r/"description":/ # Expects the response to have a `description` key
+      # Expects the response to have a `code` key
+      assert conn.resp_body =~ ~r/"code":/
+      # Expects the response to have a `description` key
+      assert conn.resp_body =~ ~r/"description":/
     end
   end
 

--- a/apps/ewallet/test/ewallet/web/paginator_test.exs
+++ b/apps/ewallet/test/ewallet/web/paginator_test.exs
@@ -99,11 +99,13 @@ defmodule EWallet.Web.PaginatorTest do
 
       # Assertions for paginator.pagination
       assert paginator.pagination == %{
-        per_page: per_page,
-        current_page: page,
-        is_first_page: false, # 2nd page is not the first page
-        is_last_page: false, # 2nd page is not the last page
-      }
+               per_page: per_page,
+               current_page: page,
+               # 2nd page is not the first page
+               is_first_page: false,
+               # 2nd page is not the last page
+               is_last_page: false
+             }
     end
   end
 
@@ -124,30 +126,35 @@ defmodule EWallet.Web.PaginatorTest do
       ensure_num_records(Account, 10)
       per_page = 4
 
-      query   = from(a in Account, select: a.id, order_by: a.id)
+      query = from(a in Account, select: a.id, order_by: a.id)
       all_ids = Repo.all(query)
 
-      {records, _} = Paginator.fetch(query, 1, per_page) # Page 1
+      # Page 1
+      {records, _} = Paginator.fetch(query, 1, per_page)
       assert records == Enum.slice(all_ids, 0..3)
 
-      {records, _} = Paginator.fetch(query, 2, per_page) # Page 2
+      # Page 2
+      {records, _} = Paginator.fetch(query, 2, per_page)
       assert records == Enum.slice(all_ids, 4..7)
 
-      {records, _} = Paginator.fetch(query, 3, per_page) # Page 3
+      # Page 3
+      {records, _} = Paginator.fetch(query, 3, per_page)
       assert records == Enum.slice(all_ids, 8..9)
     end
 
     test "returns {_, true} if there are more records to fetch" do
       ensure_num_records(Account, 10)
 
-      result = Paginator.fetch(Account, 2, 4) # Request page 2 out of div(10, 4) = 3
+      # Request page 2 out of div(10, 4) = 3
+      result = Paginator.fetch(Account, 2, 4)
       assert {_, true} = result
     end
 
     test "returns {_, false} if there are no more records to fetch" do
       ensure_num_records(Account, 9)
 
-      result = Paginator.fetch(Account, 3, 3) # Request page 2 out of div(10, 4) = 3
+      # Request page 2 out of div(10, 4) = 3
+      result = Paginator.fetch(Account, 3, 3)
       assert {_, false} = result
     end
   end

--- a/apps/ewallet/test/ewallet/web/search_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/search_parser_test.exs
@@ -18,6 +18,7 @@ defmodule EWallet.Web.SearchParserTest do
       account = prepare_test_accounts() |> Enum.at(0)
 
       attrs = %{"search_term" => account.id}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:id, :name])
@@ -31,6 +32,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_term" => "Name Match 1"}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name])
@@ -44,6 +46,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_term" => "me Matc"}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name])
@@ -58,6 +61,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_term" => "NAME MATCH"}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name])
@@ -72,6 +76,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_term" => "match"}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name, :description])
@@ -84,6 +89,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_term" => "Description match 1"}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name])
@@ -94,8 +100,8 @@ defmodule EWallet.Web.SearchParserTest do
 
     test "returns original query if search_term is missing" do
       original = Account
-      attrs    = %{"wrong_attr" => "Name Match 1"}
-      result   = SearchParser.to_query(original, attrs, [:name])
+      attrs = %{"wrong_attr" => "Name Match 1"}
+      result = SearchParser.to_query(original, attrs, [:name])
 
       assert result == original
     end
@@ -106,6 +112,7 @@ defmodule EWallet.Web.SearchParserTest do
       account = prepare_test_accounts() |> Enum.at(0)
 
       attrs = %{"search_terms" => %{"id" => account.id}}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:id, :name])
@@ -119,6 +126,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_terms" => %{"name" => "Name Match 1"}}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name])
@@ -132,6 +140,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_terms" => %{"name" => "me Matc"}}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name])
@@ -146,6 +155,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_terms" => %{"name" => "NAME MATCH"}}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name])
@@ -160,6 +170,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_terms" => %{"name" => "match"}}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name, :description])
@@ -172,6 +183,7 @@ defmodule EWallet.Web.SearchParserTest do
       prepare_test_accounts()
 
       attrs = %{"search_terms" => %{"name" => "Description match 1"}}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:name])
@@ -184,6 +196,7 @@ defmodule EWallet.Web.SearchParserTest do
       account = prepare_test_accounts() |> Enum.at(0)
 
       attrs = %{"search_terms" => %{"mapped_id" => account.id}}
+
       result =
         Account
         |> SearchParser.to_query(attrs, [:id], %{"mapped_id" => "id"})
@@ -195,8 +208,8 @@ defmodule EWallet.Web.SearchParserTest do
 
     test "returns original query if search_terms is missing" do
       original = Account
-      attrs    = %{"search_terms" => %{"wrong_attr" => "Name Match 1"}}
-      result   = SearchParser.to_query(original, attrs, [:name])
+      attrs = %{"search_terms" => %{"wrong_attr" => "Name Match 1"}}
+      result = SearchParser.to_query(original, attrs, [:name])
 
       assert result == original
     end

--- a/apps/ewallet/test/ewallet/web/sort_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/sort_parser_test.exs
@@ -15,6 +15,7 @@ defmodule EWallet.Web.SortParserTest do
       prepare_test_accounts()
 
       attrs = %{"sort_by" => "name", "sort_dir" => "asc"}
+
       sorted =
         Account
         |> SortParser.to_query(attrs, [:name])
@@ -29,6 +30,7 @@ defmodule EWallet.Web.SortParserTest do
       prepare_test_accounts()
 
       attrs = %{"sort_by" => "description", "sort_dir" => "desc"}
+
       sorted =
         Account
         |> SortParser.to_query(attrs, [:description])
@@ -44,6 +46,7 @@ defmodule EWallet.Web.SortParserTest do
 
       mapped_fields = %{"some_description_field" => "description"}
       attrs = %{"sort_by" => "some_description_field", "sort_dir" => "desc"}
+
       sorted =
         Account
         |> SortParser.to_query(attrs, [:description], mapped_fields)
@@ -56,32 +59,32 @@ defmodule EWallet.Web.SortParserTest do
 
     test "returns original query if sort_by is missing" do
       original = Account
-      attrs    = %{"sort_dir" => "asc"}
-      result   = SortParser.to_query(original, attrs, [:name])
+      attrs = %{"sort_dir" => "asc"}
+      result = SortParser.to_query(original, attrs, [:name])
 
       assert result == original
     end
 
     test "returns original query if sort_by is not an allowed field" do
       original = Account
-      attrs    = %{"sort_by" => "name", "sort_dir" => "asc"}
-      result   = SortParser.to_query(original, attrs, [:not_name])
+      attrs = %{"sort_by" => "name", "sort_dir" => "asc"}
+      result = SortParser.to_query(original, attrs, [:not_name])
 
       assert result == original
     end
 
     test "returns original query if sort_dir is missing" do
       original = Account
-      attrs    = %{"sort_by" => "name"}
-      result   = SortParser.to_query(original, attrs, [:name])
+      attrs = %{"sort_by" => "name"}
+      result = SortParser.to_query(original, attrs, [:name])
 
       assert result == original
     end
 
     test "returns original query if sort_dir is invalid" do
       original = Account
-      attrs    = %{"sort_by" => "name", "sort_dir" => "not a direction"}
-      result   = SortParser.to_query(original, attrs, [:name])
+      attrs = %{"sort_by" => "name", "sort_dir" => "not a direction"}
+      result = SortParser.to_query(original, attrs, [:name])
 
       assert result == original
     end

--- a/apps/ewallet/test/ewallet/web/v1/auth/socket_client_auth_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/auth/socket_client_auth_test.exs
@@ -80,9 +80,10 @@ defmodule EWallet.Web.V1.SocketClientAuthTest do
     end
 
     test "halts with :invalid_auth_scheme if auth header is not provided" do
-      auth = SocketClientAuth.authenticate(%{
-        http_headers: %{}
-      })
+      auth =
+        SocketClientAuth.authenticate(%{
+          http_headers: %{}
+        })
 
       assert auth.authenticated == false
       assert auth[:auth_error] == :invalid_auth_scheme
@@ -91,11 +92,12 @@ defmodule EWallet.Web.V1.SocketClientAuthTest do
     end
 
     test "halts with :invalid_auth_scheme if auth header is not a valid auth scheme" do
-      auth = SocketClientAuth.authenticate(%{
-        http_headers: %{
-          "authorization" => "InvalidScheme abc"
-        }
-      })
+      auth =
+        SocketClientAuth.authenticate(%{
+          http_headers: %{
+            "authorization" => "InvalidScheme abc"
+          }
+        })
 
       assert auth.authenticated == false
       assert auth[:auth_error] == :invalid_auth_scheme
@@ -104,11 +106,12 @@ defmodule EWallet.Web.V1.SocketClientAuthTest do
     end
 
     test "halts with :invalid_auth_scheme if auth header is invalid" do
-      auth = SocketClientAuth.authenticate(%{
-        http_headers: %{
-          "authorization" => "OMGClient not_colon_separated_base64"
-        }
-      })
+      auth =
+        SocketClientAuth.authenticate(%{
+          http_headers: %{
+            "authorization" => "OMGClient not_colon_separated_base64"
+          }
+        })
 
       assert auth.authenticated == false
       assert auth[:auth_error] == :invalid_auth_scheme

--- a/apps/ewallet/test/ewallet/web/v1/auth/socket_provider_auth_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/auth/socket_provider_auth_test.exs
@@ -57,11 +57,13 @@ defmodule EWallet.Web.V1.SocketProviderAuthTest do
     end
 
     test "halts with :invalid_auth_scheme if auth header is not provided" do
-      auth = SocketProviderAuth.authenticate(%{
-        http_headers: %{
-          "authorization" => "FAKE test"
-        }
-      })
+      auth =
+        SocketProviderAuth.authenticate(%{
+          http_headers: %{
+            "authorization" => "FAKE test"
+          }
+        })
+
       refute auth.authenticated
       assert auth[:auth_error] == :invalid_auth_scheme
       assert auth[:account] == nil

--- a/apps/ewallet/test/ewallet/web/v1/event_handlers/transaction_consumption_confirmation_event_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/event_handlers/transaction_consumption_confirmation_event_test.exs
@@ -13,14 +13,18 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandlerTest do
         |> insert()
         |> Repo.preload([:user, :transaction_request, :minted_token])
 
-      res = TransactionConsumptionEventHandler.broadcast(:transaction_consumption_finalized,
-                                                         %{consumption: consumption})
+      res =
+        TransactionConsumptionEventHandler.broadcast(:transaction_consumption_finalized, %{
+          consumption: consumption
+        })
+
       events = TestEndpoint.get_events()
 
       assert res == :ok
       assert length(events) == 5
 
       mapped = Enum.map(events, fn event -> {event.event, event.topic} end)
+
       [
         "transaction_request:#{consumption.transaction_request.id}",
         "address:#{consumption.balance_address}",
@@ -43,8 +47,11 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandlerTest do
         |> insert()
         |> Repo.preload([:user, :transaction_request, :minted_token])
 
-      res = TransactionConsumptionEventHandler.broadcast(:transaction_consumption_request,
-                                                         %{consumption: consumption})
+      res =
+        TransactionConsumptionEventHandler.broadcast(:transaction_consumption_request, %{
+          consumption: consumption
+        })
+
       events = TestEndpoint.get_events()
 
       assert res == :ok
@@ -52,6 +59,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandlerTest do
 
       request = consumption.transaction_request |> Repo.preload(:user)
       mapped = Enum.map(events, fn event -> {event.event, event.topic} end)
+
       [
         "transaction_request:#{request.id}",
         "address:#{request.balance_address}",

--- a/apps/ewallet/test/ewallet/web/v1/serializers/account_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/account_serializer_test.exs
@@ -7,7 +7,7 @@ defmodule EWallet.Web.V1.AccountSerializerTest do
 
   describe "AccountSerializer.serialize/1" do
     test "serializes an account into V1 response format" do
-      master  = :account |> insert()
+      master = :account |> insert()
       account = :account |> insert() |> Repo.preload(:parent)
 
       expected = %{

--- a/apps/ewallet/test/ewallet/web/v1/serializers/error_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/error_serializer_test.exs
@@ -4,10 +4,10 @@ defmodule EWallet.Web.V1.ErrorSerializerTest do
 
   describe "V1.ErrorSerializer.serialize" do
     test "data contains the code, description and messages" do
-      code        = "error_code"
+      code = "error_code"
       description = "This is the description"
-      messages    = %{field: "required"}
-      serialized  = ErrorSerializer.serialize(code, description, messages)
+      messages = %{field: "required"}
+      serialized = ErrorSerializer.serialize(code, description, messages)
 
       assert serialized.object == "error"
       assert serialized.code == "error_code"

--- a/apps/ewallet/test/ewallet/web/v1/serializers/key_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/key_serializer_test.exs
@@ -6,7 +6,7 @@ defmodule EWallet.Web.V1.KeySerializerTest do
 
   describe "serialize/1" do
     test "serializes a key into the correct response format" do
-      key     = :key |> insert() |> Repo.preload(:account)
+      key = :key |> insert() |> Repo.preload(:account)
 
       expected = %{
         object: "key",

--- a/apps/ewallet/test/ewallet/web/v1/serializers/paginator_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/paginator_serializer_test.exs
@@ -53,7 +53,7 @@ defmodule EWallet.Web.V1.PaginatorSerializerTest do
         }
       }
 
-      result = PaginatorSerializer.serialize(paginator, fn(_) -> "replaced_data" end)
+      result = PaginatorSerializer.serialize(paginator, fn _ -> "replaced_data" end)
       assert result == expected
     end
   end

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_consumption_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_consumption_serializer_test.exs
@@ -3,6 +3,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializerTest do
   alias EWalletDB.Helpers.Assoc
   alias EWalletDB.TransactionConsumption
   alias EWallet.Web.Date
+
   alias EWallet.Web.V1.{
     AccountSerializer,
     MintedTokenSerializer,
@@ -15,10 +16,12 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializerTest do
   describe "serialize/1 for single transaction request consumption" do
     test "serializes into correct V1 transaction_request consumption format" do
       request = insert(:transaction_consumption)
-      consumption = TransactionConsumption.get(request.id, preload: [:minted_token,
-                                                                     :transfer,
-                                                                     :transaction_request,
-                                                                     :user])
+
+      consumption =
+        TransactionConsumption.get(
+          request.id,
+          preload: [:minted_token, :transfer, :transaction_request, :user]
+        )
 
       expected = %{
         object: "transaction_consumption",
@@ -48,7 +51,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializerTest do
         confirmed_at: Date.to_iso8601(consumption.confirmed_at),
         failed_at: Date.to_iso8601(consumption.failed_at),
         expired_at: Date.to_iso8601(consumption.expired_at),
-        created_at: Date.to_iso8601(consumption.inserted_at),
+        created_at: Date.to_iso8601(consumption.inserted_at)
       }
 
       assert TransactionConsumptionSerializer.serialize(consumption) == expected

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
@@ -2,20 +2,23 @@ defmodule EWallet.Web.V1.TransactionRequestSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias EWalletDB.Helpers.Assoc
   alias EWalletDB.TransactionRequest
+
   alias EWallet.Web.V1.{
     TransactionRequestSerializer,
     MintedTokenSerializer,
     UserSerializer,
     AccountSerializer
   }
+
   alias EWallet.Web.Date
 
   describe "serialize/1 for single transaction request" do
     test "serializes into correct V1 transaction_request format" do
       request = insert(:transaction_request)
-      transaction_request = TransactionRequest.get(request.id, preload: [:minted_token,
-                                                                         :account,
-                                                                         :user])
+
+      transaction_request =
+        TransactionRequest.get(request.id, preload: [:minted_token, :account, :user])
+
       insert(:transaction_consumption, transaction_request_uuid: request.uuid)
       insert(:transaction_consumption, transaction_request_uuid: request.uuid)
 

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
@@ -23,11 +23,11 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
           object: "transaction_source",
           address: transaction.to,
           amount: transaction.amount,
-          minted_token: MintedTokenSerializer.serialize(transaction.minted_token),
+          minted_token: MintedTokenSerializer.serialize(transaction.minted_token)
         },
         exchange: %{
           object: "exchange",
-          rate: 1,
+          rate: 1
         },
         metadata: %{some: "metadata"},
         encrypted_metadata: %{},

--- a/apps/ewallet/test/ewallet/web/v1/serializers/websocket_response_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/websocket_response_serializer_test.exs
@@ -6,64 +6,77 @@ defmodule EWallet.Web.V1.WebsocketResponseSerializerTest do
   describe "serialize/1" do
     test "serializes a websocket message" do
       msg = %Message{ref: 1, topic: "topic", event: "event"}
-      res = WebsocketResponseSerializer.serialize(%{
-        data: %{something: "cool"},
-        error: nil,
-        msg: msg,
-        success: true
-      })
+
+      res =
+        WebsocketResponseSerializer.serialize(%{
+          data: %{something: "cool"},
+          error: nil,
+          msg: msg,
+          success: true
+        })
 
       assert res == %{
-        event: "event",
-        ref: 1,
-        success: true,
-        topic: "topic",
-        version: "1",
-        data: %{something: "cool"},
-        error: nil
-      }
+               event: "event",
+               ref: 1,
+               success: true,
+               topic: "topic",
+               version: "1",
+               data: %{something: "cool"},
+               error: nil
+             }
     end
   end
 
   describe "encode!/1 with %Broadcast{}" do
     test "encodes fields" do
-      msg = %Broadcast{topic: "topic", event: "event", payload: %{
-        status: :ok,
-        data: %{}
-      }}
+      msg = %Broadcast{
+        topic: "topic",
+        event: "event",
+        payload: %{
+          status: :ok,
+          data: %{}
+        }
+      }
+
       {:socket_push, :text, encoded} = WebsocketResponseSerializer.encode!(msg)
       decoded = Poison.decode!(encoded)
 
       assert decoded == %{
-        "data" => %{},
-        "error" => nil,
-        "event" => "event",
-        "ref" => nil,
-        "success" => true,
-        "topic" => "topic",
-        "version" => "1"
-      }
+               "data" => %{},
+               "error" => nil,
+               "event" => "event",
+               "ref" => nil,
+               "success" => true,
+               "topic" => "topic",
+               "version" => "1"
+             }
     end
   end
 
   describe "encode!/1 with %Message{}" do
     test "encodes fields" do
-      msg = %Message{ref: 1, topic: "topic", event: "event", payload: %{
-        status: :ok,
-        data: %{}
-      }}
+      msg = %Message{
+        ref: 1,
+        topic: "topic",
+        event: "event",
+        payload: %{
+          status: :ok,
+          data: %{}
+        }
+      }
+
       {:socket_push, :text, encoded} = WebsocketResponseSerializer.encode!(msg)
       decoded = Poison.decode!(encoded)
 
       assert decoded == %{
-        "data" => %{},
-        "error" => nil,
-        "event" => "event",
-        "ref" => 1,
-        "success" => true,
-        "topic" => "topic",
-        "version" => "1"
-      }
+               "data" => %{},
+               "error" => nil,
+               "event" => "event",
+               "ref" => 1,
+               "success" => true,
+               "topic" => "topic",
+               "version" => "1"
+             }
     end
   end
 
@@ -74,14 +87,14 @@ defmodule EWallet.Web.V1.WebsocketResponseSerializerTest do
       decoded = Poison.decode!(encoded)
 
       assert decoded == %{
-        "data" => %{},
-        "error" => nil,
-        "event" => "phx_reply",
-        "ref" => 1,
-        "success" => true,
-        "topic" => "topic",
-        "version" => "1"
-      }
+               "data" => %{},
+               "error" => nil,
+               "event" => "phx_reply",
+               "ref" => 1,
+               "success" => true,
+               "topic" => "topic",
+               "version" => "1"
+             }
     end
 
     test "encodes phx_reply with reason" do
@@ -90,19 +103,19 @@ defmodule EWallet.Web.V1.WebsocketResponseSerializerTest do
       decoded = Poison.decode!(encoded)
 
       assert decoded == %{
-        "data" => nil,
-        "error" => %{
-          "code" => "websocket:connect_error",
-          "description" => "something",
-          "messages" => nil,
-          "object" => "error"
-        },
-        "event" => "phx_reply",
-        "ref" => 1,
-        "success" => false,
-        "topic" => "topic",
-        "version" => "1"
-      }
+               "data" => nil,
+               "error" => %{
+                 "code" => "websocket:connect_error",
+                 "description" => "something",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "event" => "phx_reply",
+               "ref" => 1,
+               "success" => false,
+               "topic" => "topic",
+               "version" => "1"
+             }
     end
 
     test "encodes phx_reply with code" do
@@ -112,19 +125,19 @@ defmodule EWallet.Web.V1.WebsocketResponseSerializerTest do
       decoded = Poison.decode!(encoded)
 
       assert decoded == %{
-        "data" => nil,
-        "error" => %{
-          "code" => "websocket:forbidden_channel",
-          "description" => "You don't have access to this channel.",
-          "messages" => nil,
-          "object" => "error"
-        },
-        "event" => "phx_reply",
-        "ref" => 1,
-        "success" => false,
-        "topic" => "topic",
-        "version" => "1"
-      }
+               "data" => nil,
+               "error" => %{
+                 "code" => "websocket:forbidden_channel",
+                 "description" => "You don't have access to this channel.",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "event" => "phx_reply",
+               "ref" => 1,
+               "success" => false,
+               "topic" => "topic",
+               "version" => "1"
+             }
     end
 
     test "encodes phx_reply with empty payload" do
@@ -133,14 +146,14 @@ defmodule EWallet.Web.V1.WebsocketResponseSerializerTest do
       decoded = Poison.decode!(encoded)
 
       assert decoded == %{
-        "data" => nil,
-        "error" => nil,
-        "event" => "phx_reply",
-        "ref" => 1,
-        "success" => true,
-        "topic" => "topic",
-        "version" => "1"
-      }
+               "data" => nil,
+               "error" => nil,
+               "event" => "phx_reply",
+               "ref" => 1,
+               "success" => true,
+               "topic" => "topic",
+               "version" => "1"
+             }
     end
   end
 end

--- a/apps/ewallet/test/support/db_case.ex
+++ b/apps/ewallet/test/support/db_case.ex
@@ -20,7 +20,7 @@ defmodule EWallet.DBCase do
 
   def ensure_num_records(schema, num_required, attrs \\ %{}, count_field \\ :id) do
     num_remaining = num_required - Repo.aggregate(schema, :count, count_field)
-    factory_name  = get_factory(schema)
+    factory_name = get_factory(schema)
 
     insert_list(num_remaining, factory_name, attrs)
     Repo.all(schema)

--- a/apps/ewallet/test/support/local_ledger_case.ex
+++ b/apps/ewallet/test/support/local_ledger_case.ex
@@ -27,27 +27,29 @@ defmodule EWallet.LocalLedgerCase do
   end
 
   def mint!(minted_token, amount \\ 1_000_000) do
-    {:ok, mint, _transfer} = MintGate.insert(%{
-      "idempotency_token" => UUID.generate(),
-      "token_id" => minted_token.id,
-      "amount" => amount * minted_token.subunit_to_unit,
-      "description" => "Minting #{amount} #{minted_token.symbol}",
-      "metadata" => %{}
-    })
+    {:ok, mint, _transfer} =
+      MintGate.insert(%{
+        "idempotency_token" => UUID.generate(),
+        "token_id" => minted_token.id,
+        "amount" => amount * minted_token.subunit_to_unit,
+        "description" => "Minting #{amount} #{minted_token.symbol}",
+        "metadata" => %{}
+      })
 
     assert mint.confirmed == true
     mint
   end
 
   def transfer!(from, to, minted_token, amount) do
-    {:ok, transfer, _balances, _minted_token} = TransactionGate.process_with_addresses(%{
-      "from_address" => from,
-      "to_address" => to,
-      "token_id" => minted_token.id,
-      "amount" => amount,
-      "metadata" => %{},
-      "idempotency_token" => UUID.generate()
-    })
+    {:ok, transfer, _balances, _minted_token} =
+      TransactionGate.process_with_addresses(%{
+        "from_address" => from,
+        "to_address" => to,
+        "token_id" => minted_token.id,
+        "amount" => amount,
+        "metadata" => %{},
+        "idempotency_token" => UUID.generate()
+      })
 
     transfer
   end
@@ -56,14 +58,15 @@ defmodule EWallet.LocalLedgerCase do
     master_account = Account.get_master_account()
     master_balance = Account.get_primary_balance(master_account)
 
-    {:ok, transfer, _balances, _minted_token} = TransactionGate.process_with_addresses(%{
-      "from_address" => master_balance.address,
-      "to_address" => balance.address,
-      "token_id" => minted_token.id,
-      "amount" => amount * minted_token.subunit_to_unit,
-      "metadata" => %{},
-      "idempotency_token" => UUID.generate()
-    })
+    {:ok, transfer, _balances, _minted_token} =
+      TransactionGate.process_with_addresses(%{
+        "from_address" => master_balance.address,
+        "to_address" => balance.address,
+        "token_id" => minted_token.id,
+        "amount" => amount * minted_token.subunit_to_unit,
+        "metadata" => %{},
+        "idempotency_token" => UUID.generate()
+      })
 
     transfer
   end

--- a/apps/ewallet/test/support/test_endpoint.ex
+++ b/apps/ewallet/test/support/test_endpoint.ex
@@ -18,11 +18,15 @@ defmodule EWallet.TestEndpoint do
 
   def broadcast(topic, event, payload) do
     Agent.get_and_update(__MODULE__, fn list ->
-      updated = list ++ [%{
-        topic: topic,
-        event: event,
-        payload: payload
-      }]
+      updated =
+        list ++
+          [
+            %{
+              topic: topic,
+              event: event,
+              payload: payload
+            }
+          ]
 
       {list, updated}
     end)

--- a/apps/ewallet_api/config/config.exs
+++ b/apps/ewallet_api/config/config.exs
@@ -30,8 +30,7 @@ config :ewallet_api, EWalletAPI.V1.Endpoint,
     adapter: Phoenix.PubSub.PG2
   ]
 
-config :ewallet_api, :generators,
-  context_app: false
+config :ewallet_api, :generators, context_app: false
 
 # Two configs need to be added to have a new EWallet API version:
 #
@@ -59,16 +58,16 @@ config :mime, :types, %{
 # Configs for Sentry exception reporting
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),
-  environment_name: Mix.env,
+  environment_name: Mix.env(),
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!,
+  root_source_code_path: File.cwd!(),
   tags: %{
-    env: Mix.env,
-    application: Mix.Project.config[:app]
+    env: Mix.env(),
+    application: Mix.Project.config()[:app]
   },
-  server_name: elem(:inet.gethostname, 1),
+  server_name: elem(:inet.gethostname(), 1),
   included_environments: [:prod]
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/apps/ewallet_api/config/test.exs
+++ b/apps/ewallet_api/config/test.exs
@@ -2,11 +2,9 @@ use Mix.Config
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
-config :ewallet_api, EWalletAPI.Endpoint,
-  server: false
+config :ewallet_api, EWalletAPI.Endpoint, server: false
 
-config :ewallet_api, EWalletAPI.V1.Endpoint,
-  server: false
+config :ewallet_api, EWalletAPI.V1.Endpoint, server: false
 
 # We do not do node discovery during test.
 config :peerage,

--- a/apps/ewallet_api/lib/ewallet_api.ex
+++ b/apps/ewallet_api/lib/ewallet_api.ex
@@ -41,8 +41,9 @@ defmodule EWalletAPI do
 
   def view do
     quote do
-      use Phoenix.View, root: "lib/ewallet_api/templates",
-                        namespace: EWalletAPI
+      use Phoenix.View,
+        root: "lib/ewallet_api/templates",
+        namespace: EWalletAPI
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 2, view_module: 1]

--- a/apps/ewallet_api/lib/ewallet_api/application.ex
+++ b/apps/ewallet_api/lib/ewallet_api/application.ex
@@ -12,7 +12,7 @@ defmodule EWalletAPI.Application do
     children = [
       # Start the endpoint when the application starts
       supervisor(EWalletAPI.Endpoint, []),
-      supervisor(EWalletAPI.V1.Endpoint, []),
+      supervisor(EWalletAPI.V1.Endpoint, [])
       # Start your own worker by calling:
       #   EWalletAPI.Worker.start_link(arg1, arg2, arg3)
       # worker(EWalletAPI.Worker, [arg1, arg2, arg3]),

--- a/apps/ewallet_api/lib/ewallet_api/endpoint.ex
+++ b/apps/ewallet_api/lib/ewallet_api/endpoint.ex
@@ -4,19 +4,21 @@ defmodule EWalletAPI.Endpoint do
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    plug Phoenix.CodeReloader
+    plug(Phoenix.CodeReloader)
   end
 
-  plug Plug.RequestId
-  plug Plug.Logger
+  plug(Plug.RequestId)
+  plug(Plug.Logger)
 
-  plug Plug.Parsers,
+  plug(
+    Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Poison
+  )
 
-  plug Plug.MethodOverride
-  plug Plug.Head
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
 
-  plug EWalletAPI.Router
+  plug(EWalletAPI.Router)
 end

--- a/apps/ewallet_api/lib/ewallet_api/global/controllers/status_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/global/controllers/status_controller.ex
@@ -3,20 +3,21 @@ defmodule EWalletAPI.StatusController do
   alias LocalLedger.Status
 
   def status(conn, _attrs) do
-    json conn, %{
+    json(conn, %{
       success: true,
       nodes: node_count(),
       services: %{
         ewallet: true,
         local_ledger: local_ledger()
       }
-    }
+    })
   end
 
   defp local_ledger do
     case Status.check() do
       :ok ->
         true
+
       _ ->
         false
     end

--- a/apps/ewallet_api/lib/ewallet_api/router.ex
+++ b/apps/ewallet_api/lib/ewallet_api/router.ex
@@ -4,7 +4,7 @@ defmodule EWalletAPI.Router do
   alias EWalletAPI.{StatusController, VersionedRouter}
 
   scope "/api" do
-    get "/", StatusController, :status
-    forward "/", VersionedRouter
+    get("/", StatusController, :status)
+    forward("/", VersionedRouter)
   end
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/channels/account_channel.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/channels/account_channel.ex
@@ -8,11 +8,13 @@ defmodule EWalletAPI.V1.AccountChannel do
   def join("account:" <> account_id, _params, %{assigns: %{auth: auth}} = socket) do
     join_as(account_id, auth, socket)
   end
+
   def join(_, _, _), do: {:error, :invalid_parameter}
 
   defp join_as(account_id, %{authenticated: :provider}, socket) do
     account_id |> Account.get() |> respond(socket)
   end
+
   defp join_as(_, _, _), do: {:error, :forbidden_channel}
 
   defp respond(nil, _socket), do: {:error, :channel_not_found}

--- a/apps/ewallet_api/lib/ewallet_api/v1/channels/address_channel.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/channels/address_channel.ex
@@ -10,6 +10,7 @@ defmodule EWalletAPI.V1.AddressChannel do
     |> Balance.get()
     |> join_as(auth, socket)
   end
+
   def join(_, _, _), do: {:error, :invalid_parameter}
 
   defp join_as(nil, _auth, _socket), do: {:error, :channel_not_found}
@@ -23,7 +24,7 @@ defmodule EWalletAPI.V1.AddressChannel do
     |> User.addresses()
     |> Enum.member?(balance.address)
     |> case do
-      true  -> {:ok, socket}
+      true -> {:ok, socket}
       false -> {:error, :forbidden_channel}
     end
   end

--- a/apps/ewallet_api/lib/ewallet_api/v1/channels/transaction_consumption_channel.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/channels/transaction_consumption_channel.ex
@@ -5,13 +5,18 @@ defmodule EWalletAPI.V1.TransactionConsumptionChannel do
   use Phoenix.Channel
   alias EWalletDB.{User, TransactionConsumption}
 
-  def join("transaction_consumption:" <> consumption_id, _params, %{
-    assigns: %{auth: auth}
-  } = socket) do
+  def join(
+        "transaction_consumption:" <> consumption_id,
+        _params,
+        %{
+          assigns: %{auth: auth}
+        } = socket
+      ) do
     consumption_id
     |> TransactionConsumption.get()
     |> join_as(auth, socket)
   end
+
   def join(_, _, _), do: {:error, :invalid_parameter}
 
   defp join_as(nil, _auth, _socket), do: {:error, :channel_not_found}
@@ -25,7 +30,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionChannel do
     |> User.addresses()
     |> Enum.member?(consumption.balance_address)
     |> case do
-      true  -> {:ok, socket}
+      true -> {:ok, socket}
       false -> {:error, :forbidden_channel}
     end
   end

--- a/apps/ewallet_api/lib/ewallet_api/v1/channels/transaction_request_channel.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/channels/transaction_request_channel.ex
@@ -10,6 +10,7 @@ defmodule EWalletAPI.V1.TransactionRequestChannel do
     |> TransactionRequest.get()
     |> join_as(auth, socket)
   end
+
   def join(_, _, _), do: {:error, :invalid_parameter}
 
   defp join_as(nil, _auth, _socket), do: {:error, :channel_not_found}
@@ -23,7 +24,7 @@ defmodule EWalletAPI.V1.TransactionRequestChannel do
     |> User.addresses()
     |> Enum.member?(request.balance_address)
     |> case do
-      true  -> {:ok, socket}
+      true -> {:ok, socket}
       false -> {:error, :forbidden_channel}
     end
   end

--- a/apps/ewallet_api/lib/ewallet_api/v1/channels/user_channel.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/channels/user_channel.ex
@@ -5,12 +5,17 @@ defmodule EWalletAPI.V1.UserChannel do
   use Phoenix.Channel
   alias EWalletDB.User
 
-  def join("user:" <> user_id, _params, %{
-    assigns: %{auth: auth}
-  } = socket) do
+  def join(
+        "user:" <> user_id,
+        _params,
+        %{
+          assigns: %{auth: auth}
+        } = socket
+      ) do
     user = User.get(user_id) || User.get_by_provider_user_id(user_id)
     join_as(user, auth, socket)
   end
+
   def join(_, _, _), do: {:error, :invalid_parameter}
 
   defp join_as(nil, _auth, _socket), do: {:error, :channel_not_found}
@@ -20,11 +25,10 @@ defmodule EWalletAPI.V1.UserChannel do
   end
 
   defp join_as(user, %{authenticated: :client, user: auth_user}, socket) do
-    same_user? = auth_user.id == user.id ||
-                 auth_user.provider_user_id == user.provider_user_id
+    same_user? = auth_user.id == user.id || auth_user.provider_user_id == user.provider_user_id
 
     case same_user? do
-      true  -> {:ok, socket}
+      true -> {:ok, socket}
       false -> {:error, :forbidden_channel}
     end
   end

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/auth_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/auth_controller.ex
@@ -8,12 +8,13 @@ defmodule EWalletAPI.V1.AuthController do
   Generates a new authentication token for the provider_user_id and returns it.
   """
   def login(conn, %{"provider_user_id" => id})
-  when is_binary(id) and byte_size(id) > 0  do
+      when is_binary(id) and byte_size(id) > 0 do
     id
     |> User.get_by_provider_user_id()
     |> generate_token()
     |> respond(conn)
   end
+
   def login(conn, _attrs), do: handle_error(conn, :invalid_parameter)
 
   defp generate_token(nil), do: {:error, :provider_user_id_not_found}

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/computed_balance_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/computed_balance_controller.ex
@@ -4,11 +4,13 @@ defmodule EWalletAPI.V1.ComputedBalanceController do
   alias EWallet.ComputedBalanceFetcher
 
   def all(conn, %{"provider_user_id" => provider_user_id} = attrs)
-    when provider_user_id != nil,
-  do: get_all(conn, attrs)
+      when provider_user_id != nil,
+      do: get_all(conn, attrs)
+
   def all(conn, %{"address" => address} = attrs)
-    when address != nil,
-  do: get_all(conn, attrs)
+      when address != nil,
+      do: get_all(conn, attrs)
+
   def all(conn, _params), do: handle_error(conn, :invalid_parameter)
 
   defp get_all(conn, attrs) do
@@ -20,8 +22,10 @@ defmodule EWalletAPI.V1.ComputedBalanceController do
   defp respond({:ok, addresses}, conn) do
     render(conn, :balances, %{addresses: [addresses]})
   end
+
   defp respond({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
+
   defp respond({:error, code}, conn), do: handle_error(conn, code)
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/self_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/self_controller.ex
@@ -22,8 +22,10 @@ defmodule EWalletAPI.V1.SelfController do
   defp respond({:ok, addresses}, conn) do
     render(conn, :balances, %{addresses: [addresses]})
   end
+
   defp respond({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
+
   defp respond({:error, code}, conn), do: handle_error(conn, code)
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/status_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/status_controller.ex
@@ -2,7 +2,7 @@ defmodule EWalletAPI.V1.StatusController do
   use EWalletAPI, :controller
 
   def index(conn, _attrs) do
-    json conn, %{"success" => :true}
+    json(conn, %{"success" => true})
   end
 
   def server_error(_conn, _attrs) do

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
@@ -38,21 +38,27 @@ defmodule EWalletAPI.V1.TransactionConsumptionController do
     |> TransactionConsumptionGate.confirm(approved, entity)
     |> respond(conn)
   end
+
   defp confirm(conn, _entity, _attrs, _approved), do: handle_error(conn, :invalid_parameter)
 
   defp respond({:error, error}, conn) when is_atom(error), do: handle_error(conn, error)
+
   defp respond({:error, changeset}, conn) do
     handle_error(conn, :invalid_parameter, changeset)
   end
+
   defp respond({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
+
   defp respond({:error, consumption, code, description}, conn) do
     dispatch_confirm_event(consumption)
     handle_error(conn, code, description)
   end
+
   defp respond({:ok, consumption}, conn) do
     dispatch_confirm_event(consumption)
+
     render(conn, :transaction_consumption, %{
       transaction_consumption: embed(consumption, conn.body_params["embed"])
     })

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_controller.ex
@@ -23,9 +23,11 @@ defmodule EWalletAPI.V1.TransactionRequestController do
 
   defp respond(nil, conn), do: handle_error(conn, :transaction_request_not_found)
   defp respond({:error, error}, conn) when is_atom(error), do: handle_error(conn, error)
+
   defp respond({:error, changeset}, conn) do
     handle_error(conn, :invalid_parameter, changeset)
   end
+
   defp respond({:ok, request}, conn) do
     render(conn, :transaction_request, %{
       transaction_request: request

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
@@ -3,60 +3,63 @@ defmodule EWalletAPI.V1.TransferController do
   import EWalletAPI.V1.ErrorHandler
   alias EWallet.{ComputedBalanceFetcher, TransactionGate}
 
-  plug :put_view, EWalletAPI.V1.ComputedBalanceView
+  plug(:put_view, EWalletAPI.V1.ComputedBalanceView)
 
-  def transfer(conn, %{
-    "from_address" => from_address,
-    "to_address" => to_address,
-    "token_id" => token_id,
-    "amount" => amount,
-  } = attrs)
-  when from_address != nil
-  when to_address != nil
-  and token_id != nil
-  and is_integer(amount)
-  do
+  def transfer(
+        conn,
+        %{
+          "from_address" => from_address,
+          "to_address" => to_address,
+          "token_id" => token_id,
+          "amount" => amount
+        } = attrs
+      )
+      when from_address != nil
+      when to_address != nil and token_id != nil and is_integer(amount) do
     attrs
     |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
     |> TransactionGate.process_with_addresses()
     |> respond_with_balances(conn)
   end
+
   def transfer(conn, _attrs), do: handle_error(conn, :invalid_parameter)
 
-  def credit(conn, attrs), do: credit_or_debit(conn, TransactionGate.credit_type, attrs)
-  def debit(conn, attrs), do: credit_or_debit(conn, TransactionGate.debit_type, attrs)
+  def credit(conn, attrs), do: credit_or_debit(conn, TransactionGate.credit_type(), attrs)
+  def debit(conn, attrs), do: credit_or_debit(conn, TransactionGate.debit_type(), attrs)
 
-  defp credit_or_debit(conn, type, %{
-    "provider_user_id" => provider_user_id,
-    "token_id" => token_id,
-    "amount" => amount} = attrs
-  )
-  when provider_user_id != nil
-  and token_id != nil
-  and is_integer(amount)
-  do
+  defp credit_or_debit(
+         conn,
+         type,
+         %{"provider_user_id" => provider_user_id, "token_id" => token_id, "amount" => amount} =
+           attrs
+       )
+       when provider_user_id != nil and token_id != nil and is_integer(amount) do
     attrs
     |> Map.put("type", type)
     |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
     |> TransactionGate.process_credit_or_debit()
     |> respond_with_balances(conn)
   end
+
   defp credit_or_debit(conn, _type, _attrs), do: handle_error(conn, :invalid_parameter)
 
   defp respond_with_balances({:ok, _transfer, balances, minted_token}, conn) do
-    addresses = Enum.map(balances, fn balance ->
-      case ComputedBalanceFetcher.get(minted_token.id, balance.address) do
-        {:ok, address} -> address
-        error -> error
-      end
-    end)
+    addresses =
+      Enum.map(balances, fn balance ->
+        case ComputedBalanceFetcher.get(minted_token.id, balance.address) do
+          {:ok, address} -> address
+          error -> error
+        end
+      end)
 
-    case Enum.find(addresses, fn(e) -> match?({:error, _code, _description}, e) end) do
+    case Enum.find(addresses, fn e -> match?({:error, _code, _description}, e) end) do
       nil -> respond({:ok, addresses}, conn)
       error -> error
     end
   end
+
   defp respond_with_balances({:error, code}, conn), do: handle_error(conn, code)
+
   defp respond_with_balances({:error, _transfer, code, description}, conn) do
     handle_error(conn, code, description)
   end
@@ -64,8 +67,10 @@ defmodule EWalletAPI.V1.TransferController do
   defp respond({:ok, addresses}, conn) do
     render(conn, :balances, %{addresses: addresses})
   end
+
   defp respond({:error, code, description}, conn) do
     handle_error(conn, code, description)
   end
+
   defp respond({:error, code}, conn), do: handle_error(conn, code)
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/user_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/user_controller.ex
@@ -4,7 +4,7 @@ defmodule EWalletAPI.V1.UserController do
   alias EWalletDB.User
 
   def get(conn, %{"provider_user_id" => id})
-  when is_binary(id) and byte_size(id) > 0  do
+      when is_binary(id) and byte_size(id) > 0 do
     id
     |> User.get_by_provider_user_id()
     |> respond(conn)
@@ -25,15 +25,20 @@ defmodule EWalletAPI.V1.UserController do
   """
   # Pattern matching for required params because changeset will treat
   # missing param as not need to update.
-  def update(conn, %{
-    "provider_user_id" => id,
-    "username" => _
-  } = attrs) when is_binary(id) and byte_size(id) > 0  do
+  def update(
+        conn,
+        %{
+          "provider_user_id" => id,
+          "username" => _
+        } = attrs
+      )
+      when is_binary(id) and byte_size(id) > 0 do
     id
     |> User.get_by_provider_user_id()
     |> update_user(attrs)
     |> respond(conn)
   end
+
   def update(conn, _attrs), do: handle_error(conn, :invalid_parameter)
 
   defp update_user(%User{} = user, attrs), do: User.update(user, attrs)

--- a/apps/ewallet_api/lib/ewallet_api/v1/error_handler.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/error_handler.ex
@@ -45,9 +45,9 @@ defmodule EWalletAPI.V1.ErrorHandler do
   @doc """
   Returns a map of all the error atoms along with their code and description.
   """
-  @spec errors() :: %{required(atom()) => %{code: String.t, description: String.t}}
+  @spec errors() :: %{required(atom()) => %{code: String.t(), description: String.t()}}
   def errors do
-    Map.merge(EWalletErrorHandler.errors, @errors, fn _k, _shared, current ->
+    Map.merge(EWalletErrorHandler.errors(), @errors, fn _k, _shared, current ->
       current
     end)
   end
@@ -60,6 +60,7 @@ defmodule EWalletAPI.V1.ErrorHandler do
     |> EWalletErrorHandler.build_error(attrs, errors())
     |> respond(conn)
   end
+
   def handle_error(conn, code) do
     code
     |> EWalletErrorHandler.build_error(errors())

--- a/apps/ewallet_api/lib/ewallet_api/v1/plugs/client_auth.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/plugs/client_auth.ex
@@ -30,6 +30,7 @@ defmodule EWalletAPI.V1.Plug.ClientAuth do
         conn
         |> put_private(:auth_api_key, key)
         |> put_private(:auth_auth_token, token)
+
       {:error, :invalid_auth_scheme} ->
         conn
         |> assign(:authenticated, false)
@@ -38,7 +39,8 @@ defmodule EWalletAPI.V1.Plug.ClientAuth do
   end
 
   # Skip client auth if it already failed since header parsing
-  defp authenticate_client(%{assigns: %{authenticated: :false}} = conn), do: conn
+  defp authenticate_client(%{assigns: %{authenticated: false}} = conn), do: conn
+
   defp authenticate_client(conn) do
     api_key = conn.private[:auth_api_key]
 
@@ -46,6 +48,7 @@ defmodule EWalletAPI.V1.Plug.ClientAuth do
       {:ok, account} ->
         conn
         |> assign(:account, account)
+
       {:error, :invalid_api_key} ->
         conn
         |> assign(:authenticated, false)
@@ -55,6 +58,7 @@ defmodule EWalletAPI.V1.Plug.ClientAuth do
 
   # Skip token auth if it already failed since API key validation
   defp authenticate_token(%{assigns: %{authenticated: false}} = conn), do: conn
+
   defp authenticate_token(conn) do
     auth_token = conn.private[:auth_auth_token]
 
@@ -63,6 +67,7 @@ defmodule EWalletAPI.V1.Plug.ClientAuth do
         conn
         |> assign(:authenticated, :client)
         |> assign(:user, user)
+
       {:error, code} ->
         conn
         |> assign(:authenticated, false)

--- a/apps/ewallet_api/lib/ewallet_api/v1/plugs/idempotency.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/plugs/idempotency.ex
@@ -24,6 +24,7 @@ defmodule EWalletAPI.V1.Plug.Idempotency do
     |> assign(:idempotency_token, nil)
     |> handle_error(:no_idempotency_token_provided)
   end
+
   defp assign_token(idempotency_token, conn) do
     assign(conn, :idempotency_token, idempotency_token)
   end

--- a/apps/ewallet_api/lib/ewallet_api/v1/plugs/provider_auth.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/plugs/provider_auth.ex
@@ -29,6 +29,7 @@ defmodule EWalletAPI.V1.Plug.ProviderAuth do
         conn
         |> put_private(:auth_access_key, access)
         |> put_private(:auth_secret_key, secret)
+
       {:error, :invalid_auth_scheme} ->
         conn
         |> assign(:authenticated, false)
@@ -38,15 +39,17 @@ defmodule EWalletAPI.V1.Plug.ProviderAuth do
 
   # Skip auth if it already failed since header parsing
   defp authenticate(%{assigns: %{authenticated: false}} = conn), do: conn
+
   defp authenticate(conn) do
     access_key = conn.private[:auth_access_key]
     secret_key = conn.private[:auth_secret_key]
 
     case ProviderAuth.authenticate(access_key, secret_key) do
-       {:ok, account} ->
+      {:ok, account} ->
         conn
         |> assign(:authenticated, :provider)
         |> assign(:account, account)
+
       {:error, :invalid_access_secret_key} ->
         conn
         |> assign(:authenticated, false)

--- a/apps/ewallet_api/lib/ewallet_api/v1/router.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/router.ex
@@ -3,84 +3,88 @@ defmodule EWalletAPI.V1.Router do
   alias EWalletAPI.V1.Plug.{ClientAuth, ProviderAuth, Idempotency}
 
   pipeline :provider_api do
-    plug ProviderAuth
+    plug(ProviderAuth)
   end
 
   pipeline :client_api do
-    plug ClientAuth
+    plug(ClientAuth)
   end
 
   pipeline :idempotency do
-    plug Idempotency
+    plug(Idempotency)
   end
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug(:accepts, ["json"])
   end
 
   # Provider endpoints
   scope "/", EWalletAPI.V1 do
-    pipe_through [:api, :provider_api]
+    pipe_through([:api, :provider_api])
 
-    post "/user.create", UserController, :create
-    post "/user.get", UserController, :get
-    post "/user.update", UserController, :update
+    post("/user.create", UserController, :create)
+    post("/user.get", UserController, :get)
+    post("/user.update", UserController, :update)
 
-    post "/user.list_balances", ComputedBalanceController, :all
-    post "/user.list_transactions", TransactionController, :all_for_user
+    post("/user.list_balances", ComputedBalanceController, :all)
+    post("/user.list_transactions", TransactionController, :all_for_user)
 
-    post "/transaction_request.create", TransactionRequestController, :create
-    post "/transaction_request.get", TransactionRequestController, :get
-    post "/transaction_consumption.approve", TransactionConsumptionController, :approve
-    post "/transaction_consumption.reject", TransactionConsumptionController, :reject
+    post("/transaction_request.create", TransactionRequestController, :create)
+    post("/transaction_request.get", TransactionRequestController, :get)
+    post("/transaction_consumption.approve", TransactionConsumptionController, :approve)
+    post("/transaction_consumption.reject", TransactionConsumptionController, :reject)
 
-    post "/transaction.all", TransactionController, :all
+    post("/transaction.all", TransactionController, :all)
 
     # Idempotent requests
     scope "/" do
-      pipe_through [:idempotency]
+      pipe_through([:idempotency])
 
-      post "/user.credit_balance", TransferController, :credit
-      post "/user.debit_balance", TransferController, :debit
-      post "/transfer", TransferController, :transfer
-      post "/transaction_request.consume", TransactionConsumptionController, :consume
+      post("/user.credit_balance", TransferController, :credit)
+      post("/user.debit_balance", TransferController, :debit)
+      post("/transfer", TransferController, :transfer)
+      post("/transaction_request.consume", TransactionConsumptionController, :consume)
     end
 
-    post "/login", AuthController, :login
-    post "/get_settings", SettingsController, :get_settings
+    post("/login", AuthController, :login)
+    post("/get_settings", SettingsController, :get_settings)
   end
 
   # Client endpoints
   scope "/", EWalletAPI.V1 do
-    pipe_through [:api, :client_api]
+    pipe_through([:api, :client_api])
 
-    post "/me.get", SelfController, :get
-    post "/me.get_settings", SelfController, :get_settings
-    post "/me.list_balances", SelfController, :get_balances
-    post "/me.list_transactions", TransactionController, :get_transactions
+    post("/me.get", SelfController, :get)
+    post("/me.get_settings", SelfController, :get_settings)
+    post("/me.list_balances", SelfController, :get_balances)
+    post("/me.list_transactions", TransactionController, :get_transactions)
 
-    post "/me.create_transaction_request", TransactionRequestController, :create_for_user
-    post "/me.get_transaction_request", TransactionRequestController, :get
-    post "/me.approve_transaction_consumption", TransactionConsumptionController, :approve_for_user
-    post "/me.reject_transaction_consumption", TransactionConsumptionController, :reject_for_user
+    post("/me.create_transaction_request", TransactionRequestController, :create_for_user)
+    post("/me.get_transaction_request", TransactionRequestController, :get)
+
+    post(
+      "/me.approve_transaction_consumption",
+      TransactionConsumptionController,
+      :approve_for_user
+    )
+
+    post("/me.reject_transaction_consumption", TransactionConsumptionController, :reject_for_user)
 
     scope "/" do
-      pipe_through [:idempotency]
-      post "/me.consume_transaction_request",
-           TransactionConsumptionController,
-           :consume_for_user
+      pipe_through([:idempotency])
+      post("/me.consume_transaction_request", TransactionConsumptionController, :consume_for_user)
     end
 
-    post "/logout", AuthController, :logout
+    post("/logout", AuthController, :logout)
   end
 
   # Public endpoints
   scope "/", EWalletAPI.V1 do
-    pipe_through [:api]
+    pipe_through([:api])
 
-    post "/status", StatusController, :index
-    post "/status.server_error", StatusController, :server_error
+    post("/status", StatusController, :index)
+    post("/status.server_error", StatusController, :server_error)
 
-    match :*, "/*path", FallbackController, :not_found
+    match(:*, "/*path", FallbackController, :not_found)
   end
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/sockets/endpoint.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/sockets/endpoint.ex
@@ -1,5 +1,5 @@
 defmodule EWalletAPI.V1.Endpoint do
   use Phoenix.Endpoint, otp_app: :ewallet_api
 
-  socket "/socket", EWalletAPI.V1.Socket
+  socket("/socket", EWalletAPI.V1.Socket)
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/sockets/socket.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/sockets/socket.ex
@@ -6,21 +6,23 @@ defmodule EWalletAPI.V1.Socket do
   use Phoenix.Socket
   alias EWallet.Web.V1.{SocketClientAuth, SocketProviderAuth}
 
-  channel "user:*", EWalletAPI.V1.UserChannel
-  channel "transaction_request:*", EWalletAPI.V1.TransactionRequestChannel
-  channel "transaction_consumption:*", EWalletAPI.V1.TransactionConsumptionChannel
+  channel("user:*", EWalletAPI.V1.UserChannel)
+  channel("transaction_request:*", EWalletAPI.V1.TransactionRequestChannel)
+  channel("transaction_consumption:*", EWalletAPI.V1.TransactionConsumptionChannel)
 
-  transport :websocket, Phoenix.Transports.WebSocket
+  transport(:websocket, Phoenix.Transports.WebSocket)
 
   def connect(params, socket) do
     provider_auth = SocketProviderAuth.authenticate(params)
-    client_auth   = SocketClientAuth.authenticate(params)
+    client_auth = SocketClientAuth.authenticate(params)
 
     case {provider_auth, client_auth} do
       {%{authenticated: :provider} = provider_auth, _} ->
         {:ok, assign(socket, :auth, provider_auth)}
+
       {_, %{authenticated: :client} = client_auth} ->
         {:ok, assign(socket, :auth, client_auth)}
+
       _ ->
         :error
     end

--- a/apps/ewallet_api/lib/ewallet_api/v1/views/balance_view.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/views/balance_view.ex
@@ -1,7 +1,6 @@
 defmodule EWalletAPI.V1.BalanceView do
   use EWalletAPI, :view
-  alias EWallet.Web.V1.{AddressSerializer, ListSerializer,
-                           ResponseSerializer}
+  alias EWallet.Web.V1.{AddressSerializer, ListSerializer, ResponseSerializer}
 
   def render("balances.json", %{addresses: addresses}) do
     addresses

--- a/apps/ewallet_api/lib/ewallet_api/v1/views/transaction_consumption_view.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/views/transaction_consumption_view.ex
@@ -1,13 +1,14 @@
 defmodule EWalletAPI.V1.TransactionConsumptionView do
   use EWalletAPI, :view
+
   alias EWallet.Web.V1.{
     ResponseSerializer,
     TransactionConsumptionSerializer
   }
 
   def render("transaction_consumption.json", %{
-    transaction_consumption: consumption
-  }) do
+        transaction_consumption: consumption
+      }) do
     consumption
     |> TransactionConsumptionSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)

--- a/apps/ewallet_api/lib/ewallet_api/v1/views/transaction_request_view.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/views/transaction_request_view.ex
@@ -1,13 +1,14 @@
 defmodule EWalletAPI.V1.TransactionRequestView do
   use EWalletAPI, :view
+
   alias EWallet.Web.V1.{
     ResponseSerializer,
     TransactionRequestSerializer
   }
 
   def render("transaction_request.json", %{
-    transaction_request: transaction_request
-  }) do
+        transaction_request: transaction_request
+      }) do
     transaction_request
     |> TransactionRequestSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)

--- a/apps/ewallet_api/lib/ewallet_api/v1/views/transaction_view.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/views/transaction_view.ex
@@ -1,5 +1,6 @@
 defmodule EWalletAPI.V1.TransactionView do
   use EWalletAPI, :view
+
   alias EWallet.Web.V1.{
     ResponseSerializer,
     TransactionSerializer
@@ -10,6 +11,7 @@ defmodule EWalletAPI.V1.TransactionView do
     |> TransactionSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
   def render("transactions.json", %{transactions: transactions}) do
     transactions
     |> TransactionSerializer.serialize()

--- a/apps/ewallet_api/lib/ewallet_api/versioned_router.ex
+++ b/apps/ewallet_api/lib/ewallet_api/versioned_router.ex
@@ -21,6 +21,7 @@ defmodule EWalletAPI.VersionedRouter do
     case get_accept_version(accept) do
       {:ok, router_module} ->
         dispatch_to_router(conn, opts, router_module)
+
       _ ->
         handle_invalid_version(conn, accept)
     end
@@ -32,7 +33,9 @@ defmodule EWalletAPI.VersionedRouter do
     case Map.fetch(api_version, accept) do
       {:ok, version} ->
         {:ok, version[:router]}
-      _ -> :error
+
+      _ ->
+        :error
     end
   end
 

--- a/apps/ewallet_api/lib/ewallet_api/websocket.ex
+++ b/apps/ewallet_api/lib/ewallet_api/websocket.ex
@@ -27,8 +27,7 @@ defmodule EWalletAPI.WebSocket do
   @behaviour Phoenix.Socket.Transport
 
   def default_config do
-    [timeout: 60_000,
-     transport_log: false]
+    [timeout: 60_000, transport_log: false]
   end
 
   ## Callbacks
@@ -55,9 +54,8 @@ defmodule EWalletAPI.WebSocket do
          conn <- Transport.check_origin(conn, handler, endpoint, opts),
          %{halted: false} = conn <- conn,
          params <- conn.params |> Map.put_new(:http_headers, conn.req_headers),
-         {:ok, socket} <- Transport.connect(endpoint, handler, transport, __MODULE__,
-                                            serializer, params)
-    do
+         {:ok, socket} <-
+           Transport.connect(endpoint, handler, transport, __MODULE__, serializer, params) do
       {:ok, conn, {__MODULE__, {socket, opts}}}
     else
       _error ->
@@ -74,7 +72,7 @@ defmodule EWalletAPI.WebSocket do
   defp get_endpoint(conn, accept) when is_binary(accept) do
     case get_accept_version(accept) do
       {:ok, version} -> {:ok, version[:endpoint], version[:websocket_serializer]}
-      _              -> invalid_version(conn, accept)
+      _ -> invalid_version(conn, accept)
     end
   end
 

--- a/apps/ewallet_api/test/ewallet_api/global/controllers/status_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/global/controllers/status_controller_test.exs
@@ -3,19 +3,19 @@ defmodule EWalletAPI.StatusControllerTest do
 
   describe "GET request to root url" do
     test "returns status ok" do
-
-      response = build_conn()
+      response =
+        build_conn()
         |> get(@base_dir <> "/")
         |> json_response(:ok)
 
       assert response == %{
-        "success" => true,
-        "nodes" => 1,
-        "services" => %{
-          "ewallet" => true,
-          "local_ledger" => true
-        }
-      }
+               "success" => true,
+               "nodes" => 1,
+               "services" => %{
+                 "ewallet" => true,
+                 "local_ledger" => true
+               }
+             }
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/channels/account_channel_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/channels/account_channel_test.exs
@@ -21,8 +21,8 @@ defmodule EWalletAPI.V1.AccountChannelTest do
         |> socket(%{auth: %{authenticated: :provider}})
         |> subscribe_and_join(AccountChannel, "account:123")
 
-        assert res == :error
-        assert code == :channel_not_found
+      assert res == :error
+      assert code == :channel_not_found
     end
   end
 

--- a/apps/ewallet_api/test/ewallet_api/v1/channels/address_channel_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/channels/address_channel_test.exs
@@ -24,8 +24,8 @@ defmodule EWalletAPI.V1.AddressChannelTest do
         |> socket(%{auth: %{authenticated: :provider, account: account}})
         |> subscribe_and_join(AddressChannel, "address:123")
 
-        assert res == :error
-        assert code == :channel_not_found
+      assert res == :error
+      assert code == :channel_not_found
     end
   end
 

--- a/apps/ewallet_api/test/ewallet_api/v1/channels/transaction_consumption_channel_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/channels/transaction_consumption_channel_test.exs
@@ -11,8 +11,10 @@ defmodule EWalletAPI.V1.TransactionConsumptionChannelTest do
       {res, _, socket} =
         "test"
         |> socket(%{auth: %{authenticated: :provider, account: account}})
-        |> subscribe_and_join(TransactionConsumptionChannel,
-                              "transaction_consumption:#{consumption.id}")
+        |> subscribe_and_join(
+          TransactionConsumptionChannel,
+          "transaction_consumption:#{consumption.id}"
+        )
 
       assert res == :ok
       assert socket.topic == "transaction_consumption:#{consumption.id}"
@@ -40,8 +42,10 @@ defmodule EWalletAPI.V1.TransactionConsumptionChannelTest do
       {res, _, socket} =
         "test"
         |> socket(%{auth: %{authenticated: :client, user: user}})
-        |> subscribe_and_join(TransactionConsumptionChannel,
-                              "transaction_consumption:#{consumption.id}")
+        |> subscribe_and_join(
+          TransactionConsumptionChannel,
+          "transaction_consumption:#{consumption.id}"
+        )
 
       assert res == :ok
       assert socket.topic == "transaction_consumption:#{consumption.id}"
@@ -54,8 +58,10 @@ defmodule EWalletAPI.V1.TransactionConsumptionChannelTest do
       {res, code} =
         "test"
         |> socket(%{auth: %{authenticated: :client, user: user}})
-        |> subscribe_and_join(TransactionConsumptionChannel,
-                              "transaction_consumption:#{consumption.id}")
+        |> subscribe_and_join(
+          TransactionConsumptionChannel,
+          "transaction_consumption:#{consumption.id}"
+        )
 
       assert res == :error
       assert code == :forbidden_channel

--- a/apps/ewallet_api/test/ewallet_api/v1/channels/transaction_request_channel_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/channels/transaction_request_channel_test.exs
@@ -11,8 +11,7 @@ defmodule EWalletAPI.V1.TransactionRequestChannelTest do
       {res, _, socket} =
         "test"
         |> socket(%{auth: %{authenticated: :provider, account: account}})
-        |> subscribe_and_join(TransactionRequestChannel,
-                              "transaction_request:#{request.id}")
+        |> subscribe_and_join(TransactionRequestChannel, "transaction_request:#{request.id}")
 
       assert res == :ok
       assert socket.topic == "transaction_request:#{request.id}"
@@ -40,8 +39,7 @@ defmodule EWalletAPI.V1.TransactionRequestChannelTest do
       {res, _, socket} =
         "test"
         |> socket(%{auth: %{authenticated: :client, user: user}})
-        |> subscribe_and_join(TransactionRequestChannel,
-                              "transaction_request:#{request.id}")
+        |> subscribe_and_join(TransactionRequestChannel, "transaction_request:#{request.id}")
 
       assert res == :ok
       assert socket.topic == "transaction_request:#{request.id}"
@@ -54,8 +52,7 @@ defmodule EWalletAPI.V1.TransactionRequestChannelTest do
       {res, code} =
         "test"
         |> socket(%{auth: %{authenticated: :client, user: user}})
-        |> subscribe_and_join(TransactionRequestChannel,
-                              "transaction_request:#{request.id}")
+        |> subscribe_and_join(TransactionRequestChannel, "transaction_request:#{request.id}")
 
       assert res == :error
       assert code == :forbidden_channel

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/auth_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/auth_controller_test.exs
@@ -4,8 +4,8 @@ defmodule EWalletAPI.V1.AuthControllerTest do
 
   describe "/login" do
     test "responds with a new auth token if provider_user_id is valid" do
-      _user      = insert(:user, %{provider_user_id: "1234"})
-      response   = provider_request("/login", %{provider_user_id: "1234"})
+      _user = insert(:user, %{provider_user_id: "1234"})
+      response = provider_request("/login", %{provider_user_id: "1234"})
       auth_token = get_last_inserted(AuthToken)
 
       expected = %{
@@ -77,7 +77,7 @@ defmodule EWalletAPI.V1.AuthControllerTest do
       response = client_request("/logout")
 
       assert response["version"] == @expected_version
-      assert response["success"] == :true
+      assert response["success"] == true
       assert response["data"] == %{}
     end
   end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/computed_balance_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/computed_balance_controller_test.exs
@@ -8,7 +8,7 @@ defmodule EWalletAPI.V1.ComputedBalanceControllerTest do
       account = Account.get_master_account()
       master_balance = Account.get_primary_balance(account)
       {:ok, user} = :user |> params_for() |> User.insert()
-      user_balance   = User.get_primary_balance(user)
+      user_balance = User.get_primary_balance(user)
       {:ok, btc} = :minted_token |> params_for(symbol: "BTC") |> MintedToken.insert()
       {:ok, omg} = :minted_token |> params_for(symbol: "OMG") |> MintedToken.insert()
 
@@ -18,65 +18,66 @@ defmodule EWalletAPI.V1.ComputedBalanceControllerTest do
       transfer!(master_balance.address, user_balance.address, btc, 150_000 * btc.subunit_to_unit)
       transfer!(master_balance.address, user_balance.address, omg, 12_000 * omg.subunit_to_unit)
 
-      response = provider_request("/user.list_balances", %{
-        provider_user_id: user.provider_user_id
-      })
+      response =
+        provider_request("/user.list_balances", %{
+          provider_user_id: user.provider_user_id
+        })
 
       address = User.get_primary_balance(user).address
 
       assert response == %{
-        "version" => "1",
-        "success" => true,
-        "data" => %{
-          "object" => "list",
-          "data" => [
-            %{
-              "object" => "address",
-              "socket_topic" => "address:#{address}",
-              "address" => address,
-              "balances" => [
-                %{
-                  "object" => "balance",
-                  "amount" => 150_000 * btc.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => btc.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => btc.subunit_to_unit,
-                    "symbol" => btc.symbol,
-                    "id" => btc.id,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(btc.inserted_at),
-                    "updated_at" => Date.to_iso8601(btc.updated_at)
-                  }
-                },
-                %{
-                  "object" => "balance",
-                  "amount" => 12_000 * omg.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => omg.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => omg.subunit_to_unit,
-                    "symbol" => omg.symbol,
-                    "id" => omg.id,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(omg.inserted_at),
-                    "updated_at" => Date.to_iso8601(omg.updated_at)
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
+               "version" => "1",
+               "success" => true,
+               "data" => %{
+                 "object" => "list",
+                 "data" => [
+                   %{
+                     "object" => "address",
+                     "socket_topic" => "address:#{address}",
+                     "address" => address,
+                     "balances" => [
+                       %{
+                         "object" => "balance",
+                         "amount" => 150_000 * btc.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => btc.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => btc.subunit_to_unit,
+                           "symbol" => btc.symbol,
+                           "id" => btc.id,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(btc.inserted_at),
+                           "updated_at" => Date.to_iso8601(btc.updated_at)
+                         }
+                       },
+                       %{
+                         "object" => "balance",
+                         "amount" => 12_000 * omg.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => omg.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => omg.subunit_to_unit,
+                           "symbol" => omg.symbol,
+                           "id" => omg.id,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(omg.inserted_at),
+                           "updated_at" => Date.to_iso8601(omg.updated_at)
+                         }
+                       }
+                     ]
+                   }
+                 ]
+               }
+             }
     end
 
     test "Get all user balances from an address" do
       account = Account.get_master_account()
       master_balance = Account.get_primary_balance(account)
       {:ok, user} = :user |> params_for() |> User.insert()
-      user_balance   = User.get_primary_balance(user)
+      user_balance = User.get_primary_balance(user)
       {:ok, btc} = :minted_token |> params_for(symbol: "BTC") |> MintedToken.insert()
       {:ok, omg} = :minted_token |> params_for(symbol: "OMG") |> MintedToken.insert()
 
@@ -86,104 +87,105 @@ defmodule EWalletAPI.V1.ComputedBalanceControllerTest do
       transfer!(master_balance.address, user_balance.address, btc, 150_000 * btc.subunit_to_unit)
       transfer!(master_balance.address, user_balance.address, omg, 12_000 * omg.subunit_to_unit)
 
-      response = provider_request("/user.list_balances", %{
-        address: user_balance.address
-      })
+      response =
+        provider_request("/user.list_balances", %{
+          address: user_balance.address
+        })
 
       assert response == %{
-        "version" => "1",
-        "success" => true,
-        "data" => %{
-          "object" => "list",
-          "data" => [
-            %{
-              "object" => "address",
-              "socket_topic" => "address:#{user_balance.address}",
-              "address" => user_balance.address,
-              "balances" => [
-                %{
-                  "object" => "balance",
-                  "amount" => 150_000 * btc.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => btc.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => btc.subunit_to_unit,
-                    "symbol" => btc.symbol,
-                    "id" => btc.id,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(btc.inserted_at),
-                    "updated_at" => Date.to_iso8601(btc.updated_at)
-                  }
-                },
-                %{
-                  "object" => "balance",
-                  "amount" => 12_000 * omg.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => omg.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => omg.subunit_to_unit,
-                    "symbol" => omg.symbol,
-                    "id" => omg.id,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(omg.inserted_at),
-                    "updated_at" => Date.to_iso8601(omg.updated_at)
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
+               "version" => "1",
+               "success" => true,
+               "data" => %{
+                 "object" => "list",
+                 "data" => [
+                   %{
+                     "object" => "address",
+                     "socket_topic" => "address:#{user_balance.address}",
+                     "address" => user_balance.address,
+                     "balances" => [
+                       %{
+                         "object" => "balance",
+                         "amount" => 150_000 * btc.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => btc.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => btc.subunit_to_unit,
+                           "symbol" => btc.symbol,
+                           "id" => btc.id,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(btc.inserted_at),
+                           "updated_at" => Date.to_iso8601(btc.updated_at)
+                         }
+                       },
+                       %{
+                         "object" => "balance",
+                         "amount" => 12_000 * omg.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => omg.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => omg.subunit_to_unit,
+                           "symbol" => omg.symbol,
+                           "id" => omg.id,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(omg.inserted_at),
+                           "updated_at" => Date.to_iso8601(omg.updated_at)
+                         }
+                       }
+                     ]
+                   }
+                 ]
+               }
+             }
     end
 
     test "Get all user balances with an invalid parameter should fail" do
       request_data = %{some_invalid_param: "some_invalid_value"}
-      response     = provider_request("/user.list_balances", request_data)
+      response = provider_request("/user.list_balances", request_data)
 
       assert response == %{
-        "version" => "1",
-        "success" => false,
-        "data" => %{
-          "object" => "error",
-          "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
-          "messages" => nil
-        }
-      }
+               "version" => "1",
+               "success" => false,
+               "data" => %{
+                 "object" => "error",
+                 "code" => "client:invalid_parameter",
+                 "description" => "Invalid parameter provided",
+                 "messages" => nil
+               }
+             }
     end
 
     test "Get all user balances with a nil provider_user_id should fail" do
       request_data = %{provider_user_id: nil}
-      response     = provider_request("/user.list_balances", request_data)
+      response = provider_request("/user.list_balances", request_data)
 
       assert response == %{
-        "version" => "1",
-        "success" => false,
-        "data" => %{
-          "object" => "error",
-          "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
-          "messages" => nil
-        }
-      }
+               "version" => "1",
+               "success" => false,
+               "data" => %{
+                 "object" => "error",
+                 "code" => "client:invalid_parameter",
+                 "description" => "Invalid parameter provided",
+                 "messages" => nil
+               }
+             }
     end
 
     test "Get all user balances with a nil address should fail" do
       request_data = %{address: nil}
-      response     = provider_request("/user.list_balances", request_data)
+      response = provider_request("/user.list_balances", request_data)
 
       assert response == %{
-        "version" => "1",
-        "success" => false,
-        "data" => %{
-          "object" => "error",
-          "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
-          "messages" => nil
-        }
-      }
+               "version" => "1",
+               "success" => false,
+               "data" => %{
+                 "object" => "error",
+                 "code" => "client:invalid_parameter",
+                 "description" => "Invalid parameter provided",
+                 "messages" => nil
+               }
+             }
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
@@ -24,12 +24,12 @@ defmodule EWalletAPI.V1.SelfControllerTest do
 
   describe "/me.list_balances" do
     test "responds with a list of balances" do
-      account        = Account.get_master_account()
+      account = Account.get_master_account()
       master_balance = Account.get_primary_balance(account)
-      user           = get_test_user()
-      user_balance   = User.get_primary_balance(user)
-      btc            = insert(:minted_token, %{symbol: "BTC"})
-      omg            = insert(:minted_token, %{symbol: "OMG"})
+      user = get_test_user()
+      user_balance = User.get_primary_balance(user)
+      btc = insert(:minted_token, %{symbol: "BTC"})
+      omg = insert(:minted_token, %{symbol: "OMG"})
 
       mint!(btc)
       mint!(omg)
@@ -40,51 +40,51 @@ defmodule EWalletAPI.V1.SelfControllerTest do
       response = client_request("/me.list_balances")
 
       assert response == %{
-        "version" => "1",
-        "success" => true,
-        "data" => %{
-          "object" => "list",
-          "data" => [
-            %{
-              "object" => "address",
-              "socket_topic" => "address:#{user_balance.address}",
-              "address" => user_balance.address,
-              "balances" => [
-                %{
-                  "object" => "balance",
-                  "amount" => 150_000 * btc.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => btc.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => btc.subunit_to_unit,
-                    "symbol" => btc.symbol,
-                    "id" => btc.id,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(btc.inserted_at),
-                    "updated_at" => Date.to_iso8601(btc.updated_at)
-                  }
-                },
-                %{
-                  "object" => "balance",
-                  "amount" => 12_000 * omg.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => omg.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => omg.subunit_to_unit,
-                    "symbol" => omg.symbol,
-                    "id" => omg.id,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(omg.inserted_at),
-                    "updated_at" => Date.to_iso8601(omg.updated_at)
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
+               "version" => "1",
+               "success" => true,
+               "data" => %{
+                 "object" => "list",
+                 "data" => [
+                   %{
+                     "object" => "address",
+                     "socket_topic" => "address:#{user_balance.address}",
+                     "address" => user_balance.address,
+                     "balances" => [
+                       %{
+                         "object" => "balance",
+                         "amount" => 150_000 * btc.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => btc.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => btc.subunit_to_unit,
+                           "symbol" => btc.symbol,
+                           "id" => btc.id,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(btc.inserted_at),
+                           "updated_at" => Date.to_iso8601(btc.updated_at)
+                         }
+                       },
+                       %{
+                         "object" => "balance",
+                         "amount" => 12_000 * omg.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => omg.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => omg.subunit_to_unit,
+                           "symbol" => omg.symbol,
+                           "id" => omg.id,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(omg.inserted_at),
+                           "updated_at" => Date.to_iso8601(omg.updated_at)
+                         }
+                       }
+                     ]
+                   }
+                 ]
+               }
+             }
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/status_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/status_controller_test.exs
@@ -27,9 +27,9 @@ defmodule EWalletAPI.V1.StatusControllerTest do
       #
       # See example: /phoenix/test/phoenix/endpoint/render_errors_test.exs
       {status, _headers, response} =
-        assert_error_sent 500, fn ->
+        assert_error_sent(500, fn ->
           public_request("/status.server_error")
-        end
+        end)
 
       assert status == 500
       assert Parser.parse!(response) == expected

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
@@ -9,33 +9,57 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
     balance_3 = insert(:balance)
     balance_4 = insert(:balance, user: user, identifier: "secondary")
 
-    transfer_1 = insert(:transfer, %{
-      from_balance: balance_1, to_balance: balance_2, status: "confirmed"
-    })
-    transfer_2 = insert(:transfer, %{
-      from_balance: balance_2, to_balance: balance_1, status: "confirmed"
-    })
-    transfer_3 = insert(:transfer, %{
-      from_balance: balance_1, to_balance: balance_3, status: "confirmed"
-    })
-    transfer_4 = insert(:transfer, %{
-      from_balance: balance_1, to_balance: balance_2, status: "pending"
-    })
+    transfer_1 =
+      insert(:transfer, %{
+        from_balance: balance_1,
+        to_balance: balance_2,
+        status: "confirmed"
+      })
+
+    transfer_2 =
+      insert(:transfer, %{
+        from_balance: balance_2,
+        to_balance: balance_1,
+        status: "confirmed"
+      })
+
+    transfer_3 =
+      insert(:transfer, %{
+        from_balance: balance_1,
+        to_balance: balance_3,
+        status: "confirmed"
+      })
+
+    transfer_4 =
+      insert(:transfer, %{
+        from_balance: balance_1,
+        to_balance: balance_2,
+        status: "pending"
+      })
+
     transfer_5 = insert(:transfer, %{status: "confirmed"})
     transfer_6 = insert(:transfer, %{status: "pending"})
-    transfer_7 = insert(:transfer, %{
-      from_balance: balance_4, to_balance: balance_2, status: "confirmed"
-    })
-    transfer_8 = insert(:transfer, %{
-      from_balance: balance_4, to_balance: balance_3, status: "pending"
-    })
+
+    transfer_7 =
+      insert(:transfer, %{
+        from_balance: balance_4,
+        to_balance: balance_2,
+        status: "confirmed"
+      })
+
+    transfer_8 =
+      insert(:transfer, %{
+        from_balance: balance_4,
+        to_balance: balance_3,
+        status: "pending"
+      })
 
     %{
-      user:       user,
-      balance_1:  balance_1,
-      balance_2:  balance_2,
-      balance_3:  balance_3,
-      balance_4:  balance_4,
+      user: user,
+      balance_1: balance_1,
+      balance_2: balance_2,
+      balance_3: balance_3,
+      balance_4: balance_4,
       transfer_1: transfer_1,
       transfer_2: transfer_2,
       transfer_3: transfer_3,
@@ -49,297 +73,338 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
 
   describe "/transactions.all" do
     test "returns all the transactions", meta do
-      response = provider_request("/transaction.all", %{
-        "sort_by" => "created",
-        "sort_dir" => "asc"
-      })
+      response =
+        provider_request("/transaction.all", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
 
-      transfers =
-        [
-          meta.transfer_1,
-          meta.transfer_2,
-          meta.transfer_3,
-          meta.transfer_4,
-          meta.transfer_5,
-          meta.transfer_6,
-          meta.transfer_7,
-          meta.transfer_8
-        ]
+      transfers = [
+        meta.transfer_1,
+        meta.transfer_2,
+        meta.transfer_3,
+        meta.transfer_4,
+        meta.transfer_5,
+        meta.transfer_6,
+        meta.transfer_7,
+        meta.transfer_8
+      ]
 
       assert length(response["data"]["data"]) == length(transfers)
 
       # All transfers made during setup should exist in the response
-      assert Enum.all?(transfers, fn(transfer) ->
-        Enum.any?(response["data"]["data"], fn(data) ->
-          transfer.id == data["id"]
-        end)
-      end)
+      assert Enum.all?(transfers, fn transfer ->
+               Enum.any?(response["data"]["data"], fn data ->
+                 transfer.id == data["id"]
+               end)
+             end)
     end
 
     test "returns all the transactions for a specific address", meta do
-      response = provider_request("/transaction.all", %{
-        "sort_by" => "created_at",
-        "sort_dir" => "asc",
-        "search_terms" => %{
-          "from" => meta.balance_1.address,
-          "to"   => meta.balance_2.address
-        }
-      })
+      response =
+        provider_request("/transaction.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "from" => meta.balance_1.address,
+            "to" => meta.balance_2.address
+          }
+        })
+
       assert response["data"]["data"] |> length() == 4
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_1.id,
-        meta.transfer_3.id,
-        meta.transfer_4.id,
-        meta.transfer_7.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_1.id,
+               meta.transfer_3.id,
+               meta.transfer_4.id,
+               meta.transfer_7.id
+             ]
     end
 
     test "returns all transactions filtered", meta do
-      response = provider_request("/transaction.all", %{
-        "sort_by" => "created_at",
-        "sort_dir" => "asc",
-        "search_term" => "pending"
-      })
+      response =
+        provider_request("/transaction.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
       assert response["data"]["data"] |> length() == 3
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_4.id,
-        meta.transfer_6.id,
-        meta.transfer_8.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_4.id,
+               meta.transfer_6.id,
+               meta.transfer_8.id
+             ]
     end
 
     test "returns all transactions sorted and paginated", meta do
-      response = provider_request("/transaction.all", %{
-        "sort_by" => "created_at",
-        "sort_dir" => "asc",
-        "per_page" => 2,
-        "page" => 1
-      })
+      response =
+        provider_request("/transaction.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
       assert response["data"]["data"] |> length() == 2
       transaction_1 = Enum.at(response["data"]["data"], 0)
       transaction_2 = Enum.at(response["data"]["data"], 1)
       assert transaction_2["created_at"] > transaction_1["created_at"]
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_1.id,
-        meta.transfer_2.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_1.id,
+               meta.transfer_2.id
+             ]
     end
   end
 
   describe "/user.list_transactions" do
     test "returns all the transactions for a specific provider_user_id", meta do
-      response = provider_request("/user.list_transactions", %{
-        "sort_by" => "created_at",
-        "sort_dir" => "asc",
-        "provider_user_id" => meta.user.provider_user_id
-      })
+      response =
+        provider_request("/user.list_transactions", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "provider_user_id" => meta.user.provider_user_id
+        })
+
       assert response["data"]["data"] |> length() == 4
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_1.id,
-        meta.transfer_2.id,
-        meta.transfer_3.id,
-        meta.transfer_4.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_1.id,
+               meta.transfer_2.id,
+               meta.transfer_3.id,
+               meta.transfer_4.id
+             ]
     end
 
     test "returns all the transactions for a specific provider_user_id and valid address", meta do
-      response = provider_request("/user.list_transactions", %{
-        "provider_user_id" => meta.user.provider_user_id,
-        "address" => meta.balance_4.address
-      })
+      response =
+        provider_request("/user.list_transactions", %{
+          "provider_user_id" => meta.user.provider_user_id,
+          "address" => meta.balance_4.address
+        })
+
       assert response["data"]["data"] |> length() == 2
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_7.id,
-        meta.transfer_8.id,
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_7.id,
+               meta.transfer_8.id
+             ]
     end
 
-    test "returns an 'user:user_balance_mismatch' error with provider_user_id and invalid address", meta do
+    test "returns an 'user:user_balance_mismatch' error with provider_user_id and invalid address",
+         meta do
+      response =
+        provider_request("/user.list_transactions", %{
+          "provider_user_id" => meta.user.provider_user_id,
+          "address" => meta.balance_2.address
+        })
 
-      response = provider_request("/user.list_transactions", %{
-        "provider_user_id" => meta.user.provider_user_id,
-        "address" => meta.balance_2.address
-      })
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:user_balance_mismatch"
+
       assert response["data"]["description"] ==
-             "The provided balance does not belong to the current user"
+               "The provided balance does not belong to the current user"
     end
 
     test "returns the user's transactions even when different search terms are provided", meta do
-      response = provider_request("/user.list_transactions", %{
-        "provider_user_id" => meta.user.provider_user_id,
-        "sort_by" => "created_at",
-        "sort_dir" => "desc",
-        "search_terms" => %{
-          "from" => meta.balance_2.address,
-          "to"   => meta.balance_2.address
-        }
-      })
+      response =
+        provider_request("/user.list_transactions", %{
+          "provider_user_id" => meta.user.provider_user_id,
+          "sort_by" => "created_at",
+          "sort_dir" => "desc",
+          "search_terms" => %{
+            "from" => meta.balance_2.address,
+            "to" => meta.balance_2.address
+          }
+        })
+
       assert response["data"]["data"] |> length() == 4
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_4.id,
-        meta.transfer_3.id,
-        meta.transfer_2.id,
-        meta.transfer_1.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_4.id,
+               meta.transfer_3.id,
+               meta.transfer_2.id,
+               meta.transfer_1.id
+             ]
     end
 
     test "returns all transactions filtered", meta do
-      response = provider_request("/user.list_transactions", %{
-        "provider_user_id" => meta.user.provider_user_id,
-        "search_terms" => %{"status" => "pending"}
-      })
+      response =
+        provider_request("/user.list_transactions", %{
+          "provider_user_id" => meta.user.provider_user_id,
+          "search_terms" => %{"status" => "pending"}
+        })
+
       assert response["data"]["data"] |> length() == 1
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_4.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_4.id
+             ]
     end
 
     test "returns all transactions sorted and paginated", meta do
-      response = provider_request("/user.list_transactions", %{
-        "provider_user_id" => meta.user.provider_user_id,
-        "sort_by" => "created_at",
-        "sort_dir" => "asc",
-        "per_page" => 2,
-        "page" => 1
-      })
+      response =
+        provider_request("/user.list_transactions", %{
+          "provider_user_id" => meta.user.provider_user_id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
       assert response["data"]["data"] |> length() == 2
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_1.id,
-        meta.transfer_2.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_1.id,
+               meta.transfer_2.id
+             ]
     end
   end
 
   describe "/me.list_transactions" do
     test "returns all the transactions for the current user", meta do
-      response = client_request("/me.list_transactions", %{
-        "sort_by" => "created_at"
-      })
+      response =
+        client_request("/me.list_transactions", %{
+          "sort_by" => "created_at"
+        })
+
       assert response["data"]["data"] |> length() == 4
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_1.id,
-        meta.transfer_2.id,
-        meta.transfer_3.id,
-        meta.transfer_4.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_1.id,
+               meta.transfer_2.id,
+               meta.transfer_3.id,
+               meta.transfer_4.id
+             ]
     end
 
     test "ignores search terms if both from and to are provided and
           address does not belong to user", meta do
-      response = client_request("/me.list_transactions", %{
-        "sort_by" => "created_at",
-        "sort_dir" => "asc",
-        "search_terms" => %{
-          "from" => meta.balance_2.address,
-          "to" => meta.balance_2.address
-        }
-      })
+      response =
+        client_request("/me.list_transactions", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "from" => meta.balance_2.address,
+            "to" => meta.balance_2.address
+          }
+        })
 
       assert response["data"]["data"] |> length() == 4
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_1.id,
-        meta.transfer_2.id,
-        meta.transfer_3.id,
-        meta.transfer_4.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_1.id,
+               meta.transfer_2.id,
+               meta.transfer_3.id,
+               meta.transfer_4.id
+             ]
     end
 
     test "returns only the transactions sent to a specific balance with nil from", meta do
-      response = client_request("/me.list_transactions", %{
-        "search_terms" => %{
-          "from" => nil,
-          "to" => meta.balance_3.address
-        }
-      })
+      response =
+        client_request("/me.list_transactions", %{
+          "search_terms" => %{
+            "from" => nil,
+            "to" => meta.balance_3.address
+          }
+        })
 
       assert response["data"]["data"] |> length() == 1
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_3.id,
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_3.id
+             ]
     end
 
     test "returns only the transactions sent to a specific balance", meta do
-      response = client_request("/me.list_transactions", %{
-        "search_terms" => %{
-          "to" => meta.balance_3.address
-        }
-      })
+      response =
+        client_request("/me.list_transactions", %{
+          "search_terms" => %{
+            "to" => meta.balance_3.address
+          }
+        })
 
       assert response["data"]["data"] |> length() == 1
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_3.id,
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_3.id
+             ]
     end
 
     test "returns all transactions for the current user sorted", meta do
-      response = client_request("/me.list_transactions", %{
-        "sort_by"  => "created_at",
-        "sort_dir" => "desc"
-      })
+      response =
+        client_request("/me.list_transactions", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "desc"
+        })
 
       assert response["data"]["data"] |> length() == 4
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_4.id,
-        meta.transfer_3.id,
-        meta.transfer_2.id,
-        meta.transfer_1.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_4.id,
+               meta.transfer_3.id,
+               meta.transfer_2.id,
+               meta.transfer_1.id
+             ]
     end
 
     test "returns all transactions for the current user filtered", meta do
-      response = client_request("/me.list_transactions", %{
-        "search_terms" => %{"status" => "pending"}
-      })
+      response =
+        client_request("/me.list_transactions", %{
+          "search_terms" => %{"status" => "pending"}
+        })
 
       assert response["data"]["data"] |> length() == 1
+
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_4.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_4.id
+             ]
     end
 
     test "returns all transactions for the current user paginated", meta do
-      response = client_request("/me.list_transactions", %{
-        "page"  => 2,
-        "per_page" => 1,
-        "sort_by"  => "created_at",
-        "sort_dir" => "desc"
-      })
+      response =
+        client_request("/me.list_transactions", %{
+          "page" => 2,
+          "per_page" => 1,
+          "sort_by" => "created_at",
+          "sort_dir" => "desc"
+        })
 
       assert Enum.map(response["data"]["data"], fn t ->
-        t["id"]
-      end) == [
-        meta.transfer_3.id
-      ]
+               t["id"]
+             end) == [
+               meta.transfer_3.id
+             ]
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -5,389 +5,405 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
 
   describe "/transaction_request.create" do
     test "creates a transaction request with all the params" do
-      user         = get_test_user()
+      user = get_test_user()
       minted_token = insert(:minted_token)
-      balance      = User.get_primary_balance(user)
+      balance = User.get_primary_balance(user)
 
-      response = provider_request("/transaction_request.create", %{
-        type: "send",
-        token_id: minted_token.id,
-        correlation_id: "123",
-        amount: 1_000,
-        address: balance.address,
-      })
+      response =
+        provider_request("/transaction_request.create", %{
+          type: "send",
+          token_id: minted_token.id,
+          correlation_id: "123",
+          amount: 1_000,
+          address: balance.address
+        })
 
       request = TransactionRequest |> Repo.all() |> Enum.at(0)
 
       assert response == %{
-        "success" => true,
-        "version" => "1",
-        "data" => %{
-          "object" => "transaction_request",
-          "amount" => 1_000,
-          "address" => balance.address,
-          "correlation_id" => "123",
-          "id" => request.id,
-          "socket_topic" => "transaction_request:#{request.id}",
-          "minted_token_id" => minted_token.id,
-          "minted_token" => minted_token |> MintedTokenSerializer.serialize() |> stringify_keys(),
-          "type" => "send",
-          "status" => "valid",
-          "user_id" => user.id,
-          "user" => user |> UserSerializer.serialize() |> stringify_keys(),
-          "account_id" => nil,
-          "account" => nil,
-          "allow_amount_override" => true,
-          "require_confirmation" => false,
-          "consumption_lifetime" => nil,
-          "encrypted_metadata" => %{},
-          "expiration_date" => nil,
-          "expiration_reason" => nil,
-          "expired_at" => nil,
-          "max_consumptions" => nil,
-          "current_consumptions_count" => 0,
-          "metadata" => %{},
-          "created_at" => Date.to_iso8601(request.inserted_at),
-          "updated_at" => Date.to_iso8601(request.updated_at)
-        }
-      }
+               "success" => true,
+               "version" => "1",
+               "data" => %{
+                 "object" => "transaction_request",
+                 "amount" => 1_000,
+                 "address" => balance.address,
+                 "correlation_id" => "123",
+                 "id" => request.id,
+                 "socket_topic" => "transaction_request:#{request.id}",
+                 "minted_token_id" => minted_token.id,
+                 "minted_token" =>
+                   minted_token |> MintedTokenSerializer.serialize() |> stringify_keys(),
+                 "type" => "send",
+                 "status" => "valid",
+                 "user_id" => user.id,
+                 "user" => user |> UserSerializer.serialize() |> stringify_keys(),
+                 "account_id" => nil,
+                 "account" => nil,
+                 "allow_amount_override" => true,
+                 "require_confirmation" => false,
+                 "consumption_lifetime" => nil,
+                 "encrypted_metadata" => %{},
+                 "expiration_date" => nil,
+                 "expiration_reason" => nil,
+                 "expired_at" => nil,
+                 "max_consumptions" => nil,
+                 "current_consumptions_count" => 0,
+                 "metadata" => %{},
+                 "created_at" => Date.to_iso8601(request.inserted_at),
+                 "updated_at" => Date.to_iso8601(request.updated_at)
+               }
+             }
     end
 
     test "creates a transaction request with the minimum params" do
-      user         = get_test_user()
+      user = get_test_user()
       minted_token = insert(:minted_token)
-      balance      = User.get_primary_balance(user)
+      balance = User.get_primary_balance(user)
 
-      response = provider_request("/transaction_request.create", %{
-        type: "send",
-        token_id: minted_token.id,
-        correlation_id: nil,
-        amount: nil,
-        address: balance.address,
-      })
+      response =
+        provider_request("/transaction_request.create", %{
+          type: "send",
+          token_id: minted_token.id,
+          correlation_id: nil,
+          amount: nil,
+          address: balance.address
+        })
 
       request = TransactionRequest |> Repo.all() |> Enum.at(0)
 
       assert response == %{
-        "success" => true,
-        "version" => "1",
-        "data" => %{
-          "object" => "transaction_request",
-          "amount" => nil,
-          "address" => balance.address,
-          "correlation_id" => nil,
-          "id" => request.id,
-          "socket_topic" => "transaction_request:#{request.id}",
-          "minted_token_id" => minted_token.id,
-          "minted_token" => minted_token |> MintedTokenSerializer.serialize() |> stringify_keys(),
-          "type" => "send",
-          "status" => "valid",
-          "user_id" => user.id,
-          "user" => user |> UserSerializer.serialize() |> stringify_keys(),
-          "account_id" => nil,
-          "account" => nil,
-          "allow_amount_override" => true,
-          "require_confirmation" => false,
-          "consumption_lifetime" => nil,
-          "metadata" => %{},
-          "encrypted_metadata" => %{},
-          "expiration_date" => nil,
-          "expiration_reason" => nil,
-          "expired_at" => nil,
-          "max_consumptions" => nil,
-          "current_consumptions_count" => 0,
-          "created_at" => Date.to_iso8601(request.inserted_at),
-          "updated_at" => Date.to_iso8601(request.updated_at)
-        }
-      }
+               "success" => true,
+               "version" => "1",
+               "data" => %{
+                 "object" => "transaction_request",
+                 "amount" => nil,
+                 "address" => balance.address,
+                 "correlation_id" => nil,
+                 "id" => request.id,
+                 "socket_topic" => "transaction_request:#{request.id}",
+                 "minted_token_id" => minted_token.id,
+                 "minted_token" =>
+                   minted_token |> MintedTokenSerializer.serialize() |> stringify_keys(),
+                 "type" => "send",
+                 "status" => "valid",
+                 "user_id" => user.id,
+                 "user" => user |> UserSerializer.serialize() |> stringify_keys(),
+                 "account_id" => nil,
+                 "account" => nil,
+                 "allow_amount_override" => true,
+                 "require_confirmation" => false,
+                 "consumption_lifetime" => nil,
+                 "metadata" => %{},
+                 "encrypted_metadata" => %{},
+                 "expiration_date" => nil,
+                 "expiration_reason" => nil,
+                 "expired_at" => nil,
+                 "max_consumptions" => nil,
+                 "current_consumptions_count" => 0,
+                 "created_at" => Date.to_iso8601(request.inserted_at),
+                 "updated_at" => Date.to_iso8601(request.updated_at)
+               }
+             }
     end
 
     test "receives an error when the type is invalid" do
       minted_token = insert(:minted_token)
-      user         = get_test_user()
-      balance      = User.get_primary_balance(user)
+      user = get_test_user()
+      balance = User.get_primary_balance(user)
 
-      response = provider_request("/transaction_request.create", %{
-        type: "fake",
-        token_id: minted_token.id,
-        correlation_id: nil,
-        amount: nil,
-        address: balance.address,
-      })
+      response =
+        provider_request("/transaction_request.create", %{
+          type: "fake",
+          token_id: minted_token.id,
+          correlation_id: nil,
+          amount: nil,
+          address: balance.address
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided `type` is invalid.",
-          "messages" => %{"type" => ["inclusion"]},
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Invalid parameter provided `type` is invalid.",
+                 "messages" => %{"type" => ["inclusion"]},
+                 "object" => "error"
+               }
+             }
     end
 
     test "receives an error when the address is invalid" do
       minted_token = insert(:minted_token)
 
-      response = provider_request("/transaction_request.create", %{
-        type: "send",
-        token_id: minted_token.id,
-        correlation_id: nil,
-        amount: nil,
-        address: "fake",
-      })
+      response =
+        provider_request("/transaction_request.create", %{
+          type: "send",
+          token_id: minted_token.id,
+          correlation_id: nil,
+          amount: nil,
+          address: "fake"
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "user:balance_not_found",
-          "description" => "There is no balance corresponding to the provided address",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:balance_not_found",
+                 "description" => "There is no balance corresponding to the provided address",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "receives an error when the address does not belong to the user" do
-      account      = Account.get_master_account()
+      account = Account.get_master_account()
       minted_token = insert(:minted_token)
-      balance      = insert(:balance)
+      balance = insert(:balance)
 
-      response = provider_request("/transaction_request.create", %{
-        type: "send",
-        token_id: minted_token.id,
-        correlation_id: nil,
-        amount: nil,
-        account_id: account.id,
-        address: balance.address,
-      })
+      response =
+        provider_request("/transaction_request.create", %{
+          type: "send",
+          token_id: minted_token.id,
+          correlation_id: nil,
+          amount: nil,
+          account_id: account.id,
+          address: balance.address
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "account:account_balance_mismatch",
-          "description" => "The provided balance does not belong to the given account",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "account:account_balance_mismatch",
+                 "description" => "The provided balance does not belong to the given account",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "receives an error when the token ID is not found" do
       balance = insert(:balance)
 
-      response = provider_request("/transaction_request.create", %{
-        type: "send",
-        token_id: "123",
-        correlation_id: nil,
-        amount: nil,
-        address: balance.address,
-      })
+      response =
+        provider_request("/transaction_request.create", %{
+          type: "send",
+          token_id: "123",
+          correlation_id: nil,
+          amount: nil,
+          address: balance.address
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "minted_token:minted_token_not_found",
-          "description" => "There is no minted token matching the provided token_id.",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "minted_token:minted_token_not_found",
+                 "description" => "There is no minted token matching the provided token_id.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
   end
 
   describe "/me.create_transaction_request" do
     test "creates a transaction request with all the params" do
-      user         = get_test_user()
+      user = get_test_user()
       minted_token = insert(:minted_token)
-      balance      = User.get_primary_balance(user)
+      balance = User.get_primary_balance(user)
 
-      response = client_request("/me.create_transaction_request", %{
-        type: "send",
-        token_id: minted_token.id,
-        correlation_id: "123",
-        amount: 1_000,
-        address: balance.address,
-      })
+      response =
+        client_request("/me.create_transaction_request", %{
+          type: "send",
+          token_id: minted_token.id,
+          correlation_id: "123",
+          amount: 1_000,
+          address: balance.address
+        })
 
       request = TransactionRequest |> Repo.all() |> Enum.at(0)
 
       assert response == %{
-        "success" => true,
-        "version" => "1",
-        "data" => %{
-          "object" => "transaction_request",
-          "amount" => 1_000,
-          "address" => balance.address,
-          "correlation_id" => "123",
-          "id" => request.id,
-          "socket_topic" => "transaction_request:#{request.id}",
-          "minted_token_id" => minted_token.id,
-          "minted_token" => minted_token |> MintedTokenSerializer.serialize() |> stringify_keys(),
-          "type" => "send",
-          "status" => "valid",
-          "user_id" => user.id,
-          "user" => user |> UserSerializer.serialize() |> stringify_keys(),
-          "account_id" => nil,
-          "account" => nil,
-          "allow_amount_override" => true,
-          "require_confirmation" => false,
-          "consumption_lifetime" => nil,
-          "metadata" => %{},
-          "encrypted_metadata" => %{},
-          "expiration_date" => nil,
-          "expiration_reason" => nil,
-          "expired_at" => nil,
-          "max_consumptions" => nil,
-          "current_consumptions_count" => 0,
-          "created_at" => Date.to_iso8601(request.inserted_at),
-          "updated_at" => Date.to_iso8601(request.updated_at)
-        }
-      }
+               "success" => true,
+               "version" => "1",
+               "data" => %{
+                 "object" => "transaction_request",
+                 "amount" => 1_000,
+                 "address" => balance.address,
+                 "correlation_id" => "123",
+                 "id" => request.id,
+                 "socket_topic" => "transaction_request:#{request.id}",
+                 "minted_token_id" => minted_token.id,
+                 "minted_token" =>
+                   minted_token |> MintedTokenSerializer.serialize() |> stringify_keys(),
+                 "type" => "send",
+                 "status" => "valid",
+                 "user_id" => user.id,
+                 "user" => user |> UserSerializer.serialize() |> stringify_keys(),
+                 "account_id" => nil,
+                 "account" => nil,
+                 "allow_amount_override" => true,
+                 "require_confirmation" => false,
+                 "consumption_lifetime" => nil,
+                 "metadata" => %{},
+                 "encrypted_metadata" => %{},
+                 "expiration_date" => nil,
+                 "expiration_reason" => nil,
+                 "expired_at" => nil,
+                 "max_consumptions" => nil,
+                 "current_consumptions_count" => 0,
+                 "created_at" => Date.to_iso8601(request.inserted_at),
+                 "updated_at" => Date.to_iso8601(request.updated_at)
+               }
+             }
     end
 
     test "creates a transaction request with the minimum params" do
-      user         = get_test_user()
+      user = get_test_user()
       minted_token = insert(:minted_token)
-      balance      = User.get_primary_balance(user)
+      balance = User.get_primary_balance(user)
 
-      response = client_request("/me.create_transaction_request", %{
-        type: "send",
-        token_id: minted_token.id,
-        correlation_id: nil,
-        amount: nil,
-        address: nil,
-      })
+      response =
+        client_request("/me.create_transaction_request", %{
+          type: "send",
+          token_id: minted_token.id,
+          correlation_id: nil,
+          amount: nil,
+          address: nil
+        })
 
       request = TransactionRequest |> Repo.all() |> Enum.at(0)
 
       assert response == %{
-        "success" => true,
-        "version" => "1",
-        "data" => %{
-          "object" => "transaction_request",
-          "amount" => nil,
-          "address" => balance.address,
-          "correlation_id" => nil,
-          "id" => request.id,
-          "socket_topic" => "transaction_request:#{request.id}",
-          "minted_token_id" => minted_token.id,
-          "minted_token" => minted_token |> MintedTokenSerializer.serialize() |> stringify_keys(),
-          "allow_amount_override" => true,
-          "require_confirmation" => false,
-          "consumption_lifetime" => nil,
-          "metadata" => %{},
-          "encrypted_metadata" => %{},
-          "expiration_date" => nil,
-          "expiration_reason" => nil,
-          "expired_at" => nil,
-          "max_consumptions" => nil,
-          "current_consumptions_count" => 0,
-          "type" => "send",
-          "status" => "valid",
-          "user_id" => user.id,
-          "user" => user |> UserSerializer.serialize() |> stringify_keys(),
-          "account_id" => nil,
-          "account" => nil,
-          "created_at" => Date.to_iso8601(request.inserted_at),
-          "updated_at" => Date.to_iso8601(request.updated_at)
-        }
-      }
+               "success" => true,
+               "version" => "1",
+               "data" => %{
+                 "object" => "transaction_request",
+                 "amount" => nil,
+                 "address" => balance.address,
+                 "correlation_id" => nil,
+                 "id" => request.id,
+                 "socket_topic" => "transaction_request:#{request.id}",
+                 "minted_token_id" => minted_token.id,
+                 "minted_token" =>
+                   minted_token |> MintedTokenSerializer.serialize() |> stringify_keys(),
+                 "allow_amount_override" => true,
+                 "require_confirmation" => false,
+                 "consumption_lifetime" => nil,
+                 "metadata" => %{},
+                 "encrypted_metadata" => %{},
+                 "expiration_date" => nil,
+                 "expiration_reason" => nil,
+                 "expired_at" => nil,
+                 "max_consumptions" => nil,
+                 "current_consumptions_count" => 0,
+                 "type" => "send",
+                 "status" => "valid",
+                 "user_id" => user.id,
+                 "user" => user |> UserSerializer.serialize() |> stringify_keys(),
+                 "account_id" => nil,
+                 "account" => nil,
+                 "created_at" => Date.to_iso8601(request.inserted_at),
+                 "updated_at" => Date.to_iso8601(request.updated_at)
+               }
+             }
     end
 
     test "receives an error when the type is invalid" do
       minted_token = insert(:minted_token)
 
-      response = client_request("/me.create_transaction_request", %{
-        type: "fake",
-        token_id: minted_token.id,
-        correlation_id: nil,
-        amount: nil,
-        address: nil,
-      })
+      response =
+        client_request("/me.create_transaction_request", %{
+          type: "fake",
+          token_id: minted_token.id,
+          correlation_id: nil,
+          amount: nil,
+          address: nil
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided `type` is invalid.",
-          "messages" => %{"type" => ["inclusion"]},
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Invalid parameter provided `type` is invalid.",
+                 "messages" => %{"type" => ["inclusion"]},
+                 "object" => "error"
+               }
+             }
     end
 
     test "receives an error when the address is invalid" do
       minted_token = insert(:minted_token)
 
-      response = client_request("/me.create_transaction_request", %{
-        type: "send",
-        token_id: minted_token.id,
-        correlation_id: nil,
-        amount: nil,
-        address: "fake",
-      })
+      response =
+        client_request("/me.create_transaction_request", %{
+          type: "send",
+          token_id: minted_token.id,
+          correlation_id: nil,
+          amount: nil,
+          address: "fake"
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "user:balance_not_found",
-          "description" => "There is no balance corresponding to the provided address",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:balance_not_found",
+                 "description" => "There is no balance corresponding to the provided address",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "receives an error when the address does not belong to the user" do
       minted_token = insert(:minted_token)
-      balance      = insert(:balance)
+      balance = insert(:balance)
 
-      response = client_request("/me.create_transaction_request", %{
-        type: "send",
-        token_id: minted_token.id,
-        correlation_id: nil,
-        amount: nil,
-        address: balance.address,
-      })
+      response =
+        client_request("/me.create_transaction_request", %{
+          type: "send",
+          token_id: minted_token.id,
+          correlation_id: nil,
+          amount: nil,
+          address: balance.address
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "user:user_balance_mismatch",
-          "description" => "The provided balance does not belong to the current user",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:user_balance_mismatch",
+                 "description" => "The provided balance does not belong to the current user",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "receives an error when the token ID is not found" do
-      response = client_request("/me.create_transaction_request", %{
-        type: "send",
-        token_id: "123",
-        correlation_id: nil,
-        amount: nil,
-        address: nil,
-      })
+      response =
+        client_request("/me.create_transaction_request", %{
+          type: "send",
+          token_id: "123",
+          correlation_id: nil,
+          amount: nil,
+          address: nil
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "minted_token:minted_token_not_found",
-          "description" => "There is no minted token matching the provided token_id.",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "minted_token:minted_token_not_found",
+                 "description" => "There is no minted token matching the provided token_id.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
   end
 
@@ -395,29 +411,32 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
     test "returns the transaction request" do
       transaction_request = insert(:transaction_request)
 
-      response = provider_request("/transaction_request.get", %{
-        id: transaction_request.id
-      })
+      response =
+        provider_request("/transaction_request.get", %{
+          id: transaction_request.id
+        })
 
       assert response["success"] == true
       assert response["data"]["id"] == transaction_request.id
     end
 
     test "returns an error when the request ID is not found" do
-      response = provider_request("/transaction_request.get", %{
-        id: "123"
-      })
+      response =
+        provider_request("/transaction_request.get", %{
+          id: "123"
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "transaction_request:transaction_request_not_found",
-          "description" => "There is no transaction request corresponding to the provided address",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction_request:transaction_request_not_found",
+                 "description" =>
+                   "There is no transaction request corresponding to the provided address",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
   end
 
@@ -425,29 +444,32 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
     test "returns the transaction request" do
       transaction_request = insert(:transaction_request)
 
-      response = client_request("/me.get_transaction_request", %{
-        id: transaction_request.id
-      })
+      response =
+        client_request("/me.get_transaction_request", %{
+          id: transaction_request.id
+        })
 
       assert response["success"] == true
       assert response["data"]["id"] == transaction_request.id
     end
 
     test "returns an error when the request ID is not found" do
-      response = client_request("/me.get_transaction_request", %{
-        id: "123"
-      })
+      response =
+        client_request("/me.get_transaction_request", %{
+          id: "123"
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "transaction_request:transaction_request_not_found",
-          "description" => "There is no transaction request corresponding to the provided address",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction_request:transaction_request_not_found",
+                 "description" =>
+                   "There is no transaction request corresponding to the provided address",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -21,218 +21,230 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       response = provider_request("/transfer", request_data)
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "client:no_idempotency_token_provided",
-          "description" =>
-            "The call you made requires the Idempotency-Token header to prevent duplication.",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "client:no_idempotency_token_provided",
+                 "description" =>
+                   "The call you made requires the Idempotency-Token header to prevent duplication.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "updates the user balance and returns the updated amount" do
-      account        = Account.get_master_account()
+      account = Account.get_master_account()
       master_balance = Account.get_primary_balance(account)
-      balance1      = insert(:balance)
-      balance2      = insert(:balance)
-      minted_token   = insert(:minted_token)
-      _mint          = mint!(minted_token)
+      balance1 = insert(:balance)
+      balance2 = insert(:balance)
+      minted_token = insert(:minted_token)
+      _mint = mint!(minted_token)
 
-      transfer!(master_balance.address, balance1.address,
-                minted_token, 200_000 * minted_token.subunit_to_unit)
+      transfer!(
+        master_balance.address,
+        balance1.address,
+        minted_token,
+        200_000 * minted_token.subunit_to_unit
+      )
 
-      response = provider_request_with_idempotency("/transfer", UUID.generate(), %{
-        from_address: balance1.address,
-        to_address: balance2.address,
-        token_id: minted_token.id,
-        amount: 100_000 * minted_token.subunit_to_unit,
-        metadata: %{something: "interesting"},
-        encrypted_metadata: %{something: "secret"}
-      })
+      response =
+        provider_request_with_idempotency("/transfer", UUID.generate(), %{
+          from_address: balance1.address,
+          to_address: balance2.address,
+          token_id: minted_token.id,
+          amount: 100_000 * minted_token.subunit_to_unit,
+          metadata: %{something: "interesting"},
+          encrypted_metadata: %{something: "secret"}
+        })
 
       transfer = get_last_inserted(Transfer)
       assert transfer.metadata == %{"something" => "interesting"}
       assert transfer.encrypted_metadata == %{"something" => "secret"}
 
       assert response == %{
-        "success" => true,
-        "version" => "1",
-        "data" => %{
-          "object" => "list",
-          "data" => [
-            %{
-              "object" => "address",
-              "socket_topic" => "address:#{balance1.address}",
-              "address" => balance1.address,
-              "balances" => [
-                %{
-                  "object" => "balance",
-                  "amount" => 100_000 * minted_token.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => minted_token.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => 100,
-                    "id" => minted_token.id,
-                    "symbol" => minted_token.symbol,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(minted_token.inserted_at),
-                    "updated_at" => Date.to_iso8601(minted_token.updated_at)
-                  }
-                }
-              ]
-            },
-            %{
-              "object" => "address",
-              "socket_topic" => "address:#{balance2.address}",
-              "address" => balance2.address,
-              "balances" => [
-                %{
-                  "object" => "balance",
-                  "amount" => 100_000 * minted_token.subunit_to_unit,
-                  "minted_token" => %{
-                    "id" => minted_token.id,
-                    "name" => minted_token.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => 100,
-                    "symbol" => minted_token.symbol,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(minted_token.inserted_at),
-                    "updated_at" => Date.to_iso8601(minted_token.updated_at)
-                  },
-                }
-              ]
-            }
-          ]
-        }
-      }
+               "success" => true,
+               "version" => "1",
+               "data" => %{
+                 "object" => "list",
+                 "data" => [
+                   %{
+                     "object" => "address",
+                     "socket_topic" => "address:#{balance1.address}",
+                     "address" => balance1.address,
+                     "balances" => [
+                       %{
+                         "object" => "balance",
+                         "amount" => 100_000 * minted_token.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => minted_token.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => 100,
+                           "id" => minted_token.id,
+                           "symbol" => minted_token.symbol,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(minted_token.inserted_at),
+                           "updated_at" => Date.to_iso8601(minted_token.updated_at)
+                         }
+                       }
+                     ]
+                   },
+                   %{
+                     "object" => "address",
+                     "socket_topic" => "address:#{balance2.address}",
+                     "address" => balance2.address,
+                     "balances" => [
+                       %{
+                         "object" => "balance",
+                         "amount" => 100_000 * minted_token.subunit_to_unit,
+                         "minted_token" => %{
+                           "id" => minted_token.id,
+                           "name" => minted_token.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => 100,
+                           "symbol" => minted_token.symbol,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(minted_token.inserted_at),
+                           "updated_at" => Date.to_iso8601(minted_token.updated_at)
+                         }
+                       }
+                     ]
+                   }
+                 ]
+               }
+             }
     end
 
     test "returns a 'same_address' error when the addresses are the same" do
-      balance      = insert(:balance)
-      minted_token   = insert(:minted_token)
+      balance = insert(:balance)
+      minted_token = insert(:minted_token)
 
-      response = provider_request_with_idempotency("/transfer", UUID.generate(), %{
-         from_address: balance.address,
-         to_address: balance.address,
-         token_id: minted_token.id,
-         amount: 100_000 * minted_token.subunit_to_unit,
-         metadata: %{}
-       })
+      response =
+        provider_request_with_idempotency("/transfer", UUID.generate(), %{
+          from_address: balance.address,
+          to_address: balance.address,
+          token_id: minted_token.id,
+          amount: 100_000 * minted_token.subunit_to_unit,
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "transaction:same_address",
-          "description" => "Found identical addresses in senders and receivers: #{balance.address}.",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction:same_address",
+                 "description" =>
+                   "Found identical addresses in senders and receivers: #{balance.address}.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns insufficient_funds when the user is too poor" do
-      balance1      = insert(:balance)
-      balance2      = insert(:balance)
-      minted_token   = insert(:minted_token)
+      balance1 = insert(:balance)
+      balance2 = insert(:balance)
+      minted_token = insert(:minted_token)
 
-      response = provider_request_with_idempotency("/transfer", UUID.generate(), %{
-         from_address: balance1.address,
-         to_address: balance2.address,
-         token_id: minted_token.id,
-         amount: 100_000 * minted_token.subunit_to_unit,
-         metadata: %{}
-       })
+      response =
+        provider_request_with_idempotency("/transfer", UUID.generate(), %{
+          from_address: balance1.address,
+          to_address: balance2.address,
+          token_id: minted_token.id,
+          amount: 100_000 * minted_token.subunit_to_unit,
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "transaction:insufficient_funds",
-          "description" => "The specified balance (#{balance1.address}) does not " <>
-          "contain enough funds. Available: 0.0 #{minted_token.id} - " <>
-          "Attempted debit: 100000.0 #{minted_token.id}",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction:insufficient_funds",
+                 "description" =>
+                   "The specified balance (#{balance1.address}) does not " <>
+                     "contain enough funds. Available: 0.0 #{minted_token.id} - " <>
+                     "Attempted debit: 100000.0 #{minted_token.id}",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns from_address_not_found when the from balance is not found" do
       balance = insert(:balance)
       minted_token = insert(:minted_token)
 
-      response = provider_request_with_idempotency("/transfer", UUID.generate(), %{
-        from_address: "00000000-0000-0000-0000-000000000000",
-        to_address: balance.address,
-        token_id: minted_token.id,
-        amount: 100_000,
-        metadata: %{}
-      })
+      response =
+        provider_request_with_idempotency("/transfer", UUID.generate(), %{
+          from_address: "00000000-0000-0000-0000-000000000000",
+          to_address: balance.address,
+          token_id: minted_token.id,
+          amount: 100_000,
+          metadata: %{}
+        })
 
       assert response == %{
-       "success" => false,
-       "version" => "1",
-       "data" => %{
-         "code" => "user:from_address_not_found",
-         "description" =>
-           "No balance found for the provided from_address.",
-         "messages" => nil,
-         "object" => "error"
-       }}
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:from_address_not_found",
+                 "description" => "No balance found for the provided from_address.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns to_address_not_found when the to balance is not found" do
       balance = insert(:balance)
       minted_token = insert(:minted_token)
 
-      response = provider_request_with_idempotency("/transfer", UUID.generate(), %{
-        from_address: balance.address,
-        to_address: "00000000-0000-0000-0000-000000000000",
-        token_id: minted_token.id,
-        amount: 100_000,
-        metadata: %{}
-      })
+      response =
+        provider_request_with_idempotency("/transfer", UUID.generate(), %{
+          from_address: balance.address,
+          to_address: "00000000-0000-0000-0000-000000000000",
+          token_id: minted_token.id,
+          amount: 100_000,
+          metadata: %{}
+        })
 
       assert response == %{
-       "success" => false,
-       "version" => "1",
-       "data" => %{
-         "code" => "user:to_address_not_found",
-         "description" =>
-           "No balance found for the provided to_address.",
-         "messages" => nil,
-         "object" => "error"
-       }}
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:to_address_not_found",
+                 "description" => "No balance found for the provided to_address.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns minted_token_not_found when the minted token is not found" do
       balance1 = insert(:balance)
       balance2 = insert(:balance)
 
-      response = provider_request_with_idempotency("/transfer", UUID.generate(), %{
-        from_address: balance1.address,
-        to_address: balance2.address,
-        token_id: "BTC:456",
-        amount: 100_000,
-        metadata: %{}
-      })
+      response =
+        provider_request_with_idempotency("/transfer", UUID.generate(), %{
+          from_address: balance1.address,
+          to_address: balance2.address,
+          token_id: "BTC:456",
+          amount: 100_000,
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "minted_token:minted_token_not_found",
-          "description" =>
-            "There is no minted token matching the provided token_id.",
-          "messages" => nil,
-          "object" => "error"
-        }}
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "minted_token:minted_token_not_found",
+                 "description" => "There is no minted token matching the provided token_id.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
   end
 
@@ -241,167 +253,175 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       {:ok, user} = :user |> params_for() |> User.insert()
       {:ok, minted_token} = :minted_token |> params_for() |> MintedToken.insert()
 
-      response = provider_request("/user.credit_balance", %{
-        provider_user_id: user.provider_user_id,
-        token_id: minted_token.id,
-        amount: 100_000,
-        metadata: %{}
-      })
+      response =
+        provider_request("/user.credit_balance", %{
+          provider_user_id: user.provider_user_id,
+          token_id: minted_token.id,
+          amount: 100_000,
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "client:no_idempotency_token_provided",
-          "description" =>
-            "The call you made requires the Idempotency-Token header to prevent duplication.",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "client:no_idempotency_token_provided",
+                 "description" =>
+                   "The call you made requires the Idempotency-Token header to prevent duplication.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "updates the user balance and returns the updated amount" do
-      {:ok, user}    = :user |> params_for() |> User.insert()
-      user_balance   = User.get_primary_balance(user)
-      account        = Account.get_master_account()
-      minted_token   = insert(:minted_token, account: account)
-      _mint          = mint!(minted_token)
+      {:ok, user} = :user |> params_for() |> User.insert()
+      user_balance = User.get_primary_balance(user)
+      account = Account.get_master_account()
+      minted_token = insert(:minted_token, account: account)
+      _mint = mint!(minted_token)
 
-      response = provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
-        provider_user_id: user.provider_user_id,
-        token_id: minted_token.id,
-        amount: 1_000 * minted_token.subunit_to_unit,
-        metadata: %{something: "interesting"},
-        encrypted_metadata: %{something: "secret"}
-      })
+      response =
+        provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
+          provider_user_id: user.provider_user_id,
+          token_id: minted_token.id,
+          amount: 1_000 * minted_token.subunit_to_unit,
+          metadata: %{something: "interesting"},
+          encrypted_metadata: %{something: "secret"}
+        })
 
       transfer = get_last_inserted(Transfer)
       assert transfer.metadata == %{"something" => "interesting"}
       assert transfer.encrypted_metadata == %{"something" => "secret"}
 
       assert response == %{
-        "success" => true,
-        "version" => "1",
-        "data" => %{
-          "object" => "list",
-          "data" => [
-            %{
-              "object" => "address",
-              "socket_topic" => "address:#{user_balance.address}",
-              "address" => user_balance.address,
-              "balances" => [
-                %{
-                  "object" => "balance",
-                  "amount" => 1_000 * minted_token.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => minted_token.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => 100,
-                    "id" => minted_token.id,
-                    "symbol" => minted_token.symbol,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(minted_token.inserted_at),
-                    "updated_at" => Date.to_iso8601(minted_token.updated_at)
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
+               "success" => true,
+               "version" => "1",
+               "data" => %{
+                 "object" => "list",
+                 "data" => [
+                   %{
+                     "object" => "address",
+                     "socket_topic" => "address:#{user_balance.address}",
+                     "address" => user_balance.address,
+                     "balances" => [
+                       %{
+                         "object" => "balance",
+                         "amount" => 1_000 * minted_token.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => minted_token.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => 100,
+                           "id" => minted_token.id,
+                           "symbol" => minted_token.symbol,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(minted_token.inserted_at),
+                           "updated_at" => Date.to_iso8601(minted_token.updated_at)
+                         }
+                       }
+                     ]
+                   }
+                 ]
+               }
+             }
     end
 
     test "returns invalid_parameter when the provider_user_id is missing" do
       {:ok, minted_token} = :minted_token |> params_for() |> MintedToken.insert()
 
-      response = provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
-        token_id: minted_token.id,
-        amount: 100_000,
-        metadata: %{}
-      })
+      response =
+        provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
+          token_id: minted_token.id,
+          amount: 100_000,
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
-          "messages" => nil,
-          "object" => "error"
-        }}
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Invalid parameter provided",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns user_not_found when the user is not found" do
       {:ok, account} = :account |> params_for() |> Account.insert()
       {:ok, minted_token} = :minted_token |> params_for(account: account) |> MintedToken.insert()
 
-      response = provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
-        provider_user_id: "fake",
-        token_id: minted_token.id,
-        amount: 100_000,
-        metadata: %{}
-      })
+      response =
+        provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
+          provider_user_id: "fake",
+          token_id: minted_token.id,
+          amount: 100_000,
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "user:provider_user_id_not_found",
-          "description" =>
-            "There is no user corresponding to the provided " <>
-            "provider_user_id",
-          "messages" => nil,
-          "object" => "error"
-        }}
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:provider_user_id_not_found",
+                 "description" =>
+                   "There is no user corresponding to the provided " <> "provider_user_id",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns account_id when the account is not found" do
       {:ok, user} = :user |> params_for() |> User.insert()
       {:ok, minted_token} = :minted_token |> params_for() |> MintedToken.insert()
 
-      response = provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
-        provider_user_id: user.provider_user_id,
-        token_id: minted_token.id,
-        amount: 100_000,
-        account_id: "acc_12345678901234567890123456",
-        metadata: %{}
-      })
+      response =
+        provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
+          provider_user_id: user.provider_user_id,
+          token_id: minted_token.id,
+          amount: 100_000,
+          account_id: "acc_12345678901234567890123456",
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "user:account_id_not_found",
-          "description" => "There is no account corresponding to the provided account_id",
-          "messages" => nil, "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:account_id_not_found",
+                 "description" => "There is no account corresponding to the provided account_id",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns minted_token_not_found when the minted token is not found" do
       {:ok, user} = :user |> params_for() |> User.insert()
       {:ok, account} = :account |> params_for() |> Account.insert()
 
-      response = provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
-        provider_user_id: user.provider_user_id,
-        token_id: "BTC:456",
-        amount: 100_000,
-        metadata: %{},
-        account_id: account.id
-      })
+      response =
+        provider_request_with_idempotency("/user.credit_balance", UUID.generate(), %{
+          provider_user_id: user.provider_user_id,
+          token_id: "BTC:456",
+          amount: 100_000,
+          metadata: %{},
+          account_id: account.id
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "minted_token:minted_token_not_found",
-          "description" =>
-            "There is no minted token matching the provided token_id.",
-          "messages" => nil,
-          "object" => "error"
-        }}
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "minted_token:minted_token_not_found",
+                 "description" => "There is no minted token matching the provided token_id.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
   end
 
@@ -411,109 +431,117 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       {:ok, account} = :account |> params_for() |> Account.insert()
       {:ok, minted_token} = :minted_token |> params_for(account: account) |> MintedToken.insert()
 
-       response = provider_request("/user.debit_balance", %{
-        provider_user_id: user.provider_user_id,
-        token_id: minted_token.id,
-        amount: 100_000,
-        metadata: %{}
-      })
+      response =
+        provider_request("/user.debit_balance", %{
+          provider_user_id: user.provider_user_id,
+          token_id: minted_token.id,
+          amount: 100_000,
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "client:no_idempotency_token_provided",
-          "description" =>
-            "The call you made requires the Idempotency-Token header to prevent duplication.",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "client:no_idempotency_token_provided",
+                 "description" =>
+                   "The call you made requires the Idempotency-Token header to prevent duplication.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns insufficient_funds when the user is too poor" do
       {:ok, account} = :account |> params_for() |> Account.insert()
       {:ok, user} = :user |> params_for() |> User.insert()
-      user_balance   = User.get_primary_balance(user)
+      user_balance = User.get_primary_balance(user)
       {:ok, minted_token} = :minted_token |> params_for(account: account) |> MintedToken.insert()
 
-      response = provider_request_with_idempotency("/user.debit_balance", UUID.generate(), %{
-        provider_user_id: user.provider_user_id,
-        token_id: minted_token.id,
-        amount: 100_000,
-        metadata: %{}
-      })
+      response =
+        provider_request_with_idempotency("/user.debit_balance", UUID.generate(), %{
+          provider_user_id: user.provider_user_id,
+          token_id: minted_token.id,
+          amount: 100_000,
+          metadata: %{}
+        })
 
       assert response == %{
-        "success" => false,
-        "version" => "1",
-        "data" => %{
-          "code" => "transaction:insufficient_funds",
-          "description" => "The specified balance (#{user_balance.address})" <>
-          " does not contain enough funds. Available: 0.0 " <>
-          "#{minted_token.id} - Attempted debit: 1000.0 " <>
-          "#{minted_token.id}",
-          "messages" => nil,
-          "object" => "error"
-        }
-      }
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction:insufficient_funds",
+                 "description" =>
+                   "The specified balance (#{user_balance.address})" <>
+                     " does not contain enough funds. Available: 0.0 " <>
+                     "#{minted_token.id} - Attempted debit: 1000.0 " <> "#{minted_token.id}",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
     end
 
     test "returns the updated balances when the user has enough funds" do
       account = Account.get_master_account()
       master_balance = Account.get_primary_balance(account)
       {:ok, user} = :user |> params_for() |> User.insert()
-      user_balance   = User.get_primary_balance(user)
+      user_balance = User.get_primary_balance(user)
       {:ok, minted_token} = :minted_token |> params_for(account: account) |> MintedToken.insert()
       mint!(minted_token)
 
-      transfer!(master_balance.address, user_balance.address,
-                minted_token, 200_000 * minted_token.subunit_to_unit)
+      transfer!(
+        master_balance.address,
+        user_balance.address,
+        minted_token,
+        200_000 * minted_token.subunit_to_unit
+      )
 
-      response = provider_request_with_idempotency("/user.debit_balance", UUID.generate(), %{
-        provider_user_id: user.provider_user_id,
-        token_id: minted_token.id,
-        amount: 150_000 * minted_token.subunit_to_unit,
-        metadata: %{something: "interesting"},
-        encrypted_metadata: %{something: "secret"}
-      })
+      response =
+        provider_request_with_idempotency("/user.debit_balance", UUID.generate(), %{
+          provider_user_id: user.provider_user_id,
+          token_id: minted_token.id,
+          amount: 150_000 * minted_token.subunit_to_unit,
+          metadata: %{something: "interesting"},
+          encrypted_metadata: %{something: "secret"}
+        })
 
       transfer = get_last_inserted(Transfer)
       assert transfer.metadata == %{"something" => "interesting"}
       assert transfer.encrypted_metadata == %{"something" => "secret"}
 
       address = User.get_primary_balance(user).address
+
       assert response == %{
-        "version" => "1",
-        "success" => true,
-        "data" => %{
-          "object" => "list",
-          "data" => [
-            %{
-              "object" => "address",
-              "socket_topic" => "address:#{address}",
-              "address" => address,
-              "balances" => [
-                %{
-                  "object" => "balance",
-                  "amount" => 50_000 * minted_token.subunit_to_unit,
-                  "minted_token" => %{
-                    "name" => minted_token.name,
-                    "object" => "minted_token",
-                    "subunit_to_unit" => 100,
-                    "symbol" => minted_token.symbol,
-                    "id" => minted_token.id,
-                    "metadata" => %{},
-                    "encrypted_metadata" => %{},
-                    "created_at" => Date.to_iso8601(minted_token.inserted_at),
-                    "updated_at" => Date.to_iso8601(minted_token.updated_at)
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
+               "version" => "1",
+               "success" => true,
+               "data" => %{
+                 "object" => "list",
+                 "data" => [
+                   %{
+                     "object" => "address",
+                     "socket_topic" => "address:#{address}",
+                     "address" => address,
+                     "balances" => [
+                       %{
+                         "object" => "balance",
+                         "amount" => 50_000 * minted_token.subunit_to_unit,
+                         "minted_token" => %{
+                           "name" => minted_token.name,
+                           "object" => "minted_token",
+                           "subunit_to_unit" => 100,
+                           "symbol" => minted_token.symbol,
+                           "id" => minted_token.id,
+                           "metadata" => %{},
+                           "encrypted_metadata" => %{},
+                           "created_at" => Date.to_iso8601(minted_token.inserted_at),
+                           "updated_at" => Date.to_iso8601(minted_token.updated_at)
+                         }
+                       }
+                     ]
+                   }
+                 ]
+               }
+             }
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/user_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/user_controller_test.exs
@@ -4,14 +4,17 @@ defmodule EWalletAPI.V1.UserControllerTest do
 
   describe "/user.create" do
     test "creates and responds with a newly created user if attributes are valid" do
-      request_data = params_for(:user,
-        metadata: %{something: "interesting"},
-        encrypted_metadata: %{something: "secret"}
-      )
-      response     = provider_request("/user.create", request_data)
+      request_data =
+        params_for(
+          :user,
+          metadata: %{something: "interesting"},
+          encrypted_metadata: %{something: "secret"}
+        )
+
+      response = provider_request("/user.create", request_data)
 
       assert response["version"] == @expected_version
-      assert response["success"] == :true
+      assert response["success"] == true
       assert Map.has_key?(response["data"], "id")
 
       data = response["data"]
@@ -28,27 +31,31 @@ defmodule EWalletAPI.V1.UserControllerTest do
 
     test "returns an error if provider_user_id is not provided" do
       request_data = params_for(:user, provider_user_id: "")
-      response     = provider_request("/user.create", request_data)
+      response = provider_request("/user.create", request_data)
 
       assert response["version"] == @expected_version
-      assert response["success"] == :false
+      assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided "
-        <> "`provider_user_id` can't be blank."
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided " <> "`provider_user_id` can't be blank."
+
       assert response["data"]["messages"] == %{"provider_user_id" => ["required"]}
     end
 
     test "returns an error if username is not provided" do
       request_data = params_for(:user, username: "")
-      response     = provider_request("/user.create", request_data)
+      response = provider_request("/user.create", request_data)
 
       assert response["version"] == @expected_version
-      assert response["success"] == :false
+      assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided "
-        <> "`username` can't be blank."
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided " <> "`username` can't be blank."
+
       assert response["data"]["messages"] == %{"username" => ["required"]}
     end
   end
@@ -58,19 +65,20 @@ defmodule EWalletAPI.V1.UserControllerTest do
       user = insert(:user)
 
       # Prepare the update data while keeping only provider_user_id the same
-      request_data = params_for(:user, %{
-        provider_user_id: user.provider_user_id,
-        username: "updated_username",
-        metadata: %{
-          first_name: "updated_first_name",
-          last_name: "updated_last_name"
-        }
-      })
+      request_data =
+        params_for(:user, %{
+          provider_user_id: user.provider_user_id,
+          username: "updated_username",
+          metadata: %{
+            first_name: "updated_first_name",
+            last_name: "updated_last_name"
+          }
+        })
 
       response = provider_request("/user.update", request_data)
 
       assert response["version"] == @expected_version
-      assert response["success"] == :true
+      assert response["success"] == true
 
       data = response["data"]
       assert data["object"] == "user"
@@ -85,11 +93,12 @@ defmodule EWalletAPI.V1.UserControllerTest do
     test "updates the metadata and encrypted metadata" do
       user = insert(:user)
 
-      request_data = params_for(:user, %{
-        provider_user_id: user.provider_user_id,
-        metadata: %{first_name: "updated_first_name"},
-        encrypted_metadata: %{my_secret_stuff: "123"}
-      })
+      request_data =
+        params_for(:user, %{
+          provider_user_id: user.provider_user_id,
+          metadata: %{first_name: "updated_first_name"},
+          encrypted_metadata: %{my_secret_stuff: "123"}
+        })
 
       response = provider_request("/user.update", request_data)
 
@@ -99,15 +108,17 @@ defmodule EWalletAPI.V1.UserControllerTest do
     end
 
     test "does not change the metadata/encrypted_metadata if not sent" do
-      user = insert(:user, %{
-        metadata: %{first_name: "updated_first_name"},
-        encrypted_metadata: %{my_secret_stuff: "123"}
-      })
+      user =
+        insert(:user, %{
+          metadata: %{first_name: "updated_first_name"},
+          encrypted_metadata: %{my_secret_stuff: "123"}
+        })
 
-      response = provider_request("/user.update", %{
-        provider_user_id: user.provider_user_id,
-        username: "new_username"
-      })
+      response =
+        provider_request("/user.update", %{
+          provider_user_id: user.provider_user_id,
+          username: "new_username"
+        })
 
       assert response["success"] == true
       assert response["data"]["username"] == "new_username"
@@ -116,17 +127,19 @@ defmodule EWalletAPI.V1.UserControllerTest do
     end
 
     test "resets the metadata/encrypted_metadata when sending empty hashes" do
-      user = insert(:user, %{
-        metadata: %{first_name: "updated_first_name"},
-        encrypted_metadata: %{my_secret_stuff: "123"}
-      })
+      user =
+        insert(:user, %{
+          metadata: %{first_name: "updated_first_name"},
+          encrypted_metadata: %{my_secret_stuff: "123"}
+        })
 
-      response = provider_request("/user.update", %{
-        provider_user_id: user.provider_user_id,
-        username: "new_username",
-        metadata: %{},
-        encrypted_metadata: %{}
-      })
+      response =
+        provider_request("/user.update", %{
+          provider_user_id: user.provider_user_id,
+          username: "new_username",
+          metadata: %{},
+          encrypted_metadata: %{}
+        })
 
       assert response["success"] == true
       assert response["data"]["metadata"] == %{}
@@ -134,32 +147,35 @@ defmodule EWalletAPI.V1.UserControllerTest do
     end
 
     test "returns an 'invalid parameter' error when sending nil for metadata/encrypted_metadata" do
-      user = insert(:user, %{
-        metadata: %{first_name: "updated_first_name"},
-        encrypted_metadata: %{my_secret_stuff: "123"}
-      })
+      user =
+        insert(:user, %{
+          metadata: %{first_name: "updated_first_name"},
+          encrypted_metadata: %{my_secret_stuff: "123"}
+        })
 
-      response = provider_request("/user.update", %{
-        provider_user_id: user.provider_user_id,
-        username: "new_username",
-        metadata: nil,
-        encrypted_metadata: nil
-      })
+      response =
+        provider_request("/user.update", %{
+          provider_user_id: user.provider_user_id,
+          username: "new_username",
+          metadata: nil,
+          encrypted_metadata: nil
+        })
 
       assert response["success"] == false
       assert response["data"]["code"] == "client:invalid_parameter"
+
       assert response["data"]["messages"] == %{
-        "metadata" => ["required"],
-        "encrypted_metadata" => ["required"]
-      }
+               "metadata" => ["required"],
+               "encrypted_metadata" => ["required"]
+             }
     end
 
     test "returns an error if provider_user_id is not provided" do
       request_data = params_for(:user, %{provider_user_id: ""})
-      response     = provider_request("/user.update", request_data)
+      response = provider_request("/user.update", request_data)
 
       assert response["version"] == @expected_version
-      assert response["success"] == :false
+      assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
       assert response["data"]["description"] == "Invalid parameter provided"
@@ -167,23 +183,26 @@ defmodule EWalletAPI.V1.UserControllerTest do
 
     test "returns an error if user for provider_user_id is not found" do
       request_data = params_for(:user, %{provider_user_id: "unknown_id"})
-      response     = provider_request("/user.update", request_data)
+      response = provider_request("/user.update", request_data)
 
       assert response["version"] == @expected_version
-      assert response["success"] == :false
+      assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:provider_user_id_not_found"
-      assert response["data"]["description"] == "There is no user corresponding to the provided provider_user_id"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided provider_user_id"
     end
 
     test "returns an error if username is not provided" do
       user = insert(:user)
 
       # ExMachine will remove the param if set to nil.
-      request_data = params_for(:user, %{
-        provider_user_id: user.provider_user_id,
-        username: nil
-      })
+      request_data =
+        params_for(:user, %{
+          provider_user_id: user.provider_user_id,
+          username: nil
+        })
 
       response = provider_request("/user.update", request_data)
 
@@ -202,8 +221,8 @@ defmodule EWalletAPI.V1.UserControllerTest do
         |> build(provider_user_id: "provider_id_1")
         |> insert()
 
-      request_data  = %{provider_user_id: inserted_user.provider_user_id}
-      response      = provider_request("/user.get", request_data)
+      request_data = %{provider_user_id: inserted_user.provider_user_id}
+      response = provider_request("/user.get", request_data)
 
       expected = %{
         "version" => @expected_version,
@@ -227,7 +246,7 @@ defmodule EWalletAPI.V1.UserControllerTest do
             "original" => nil,
             "small" => nil,
             "thumb" => nil
-          },
+          }
         }
       }
 
@@ -247,7 +266,7 @@ defmodule EWalletAPI.V1.UserControllerTest do
       }
 
       request_data = %{provider_user_id: "unknown_id999"}
-      response     = provider_request("/user.get", request_data)
+      response = provider_request("/user.get", request_data)
 
       assert response == expected
     end

--- a/apps/ewallet_api/test/ewallet_api/v1/error_handler_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/error_handler_test.exs
@@ -9,9 +9,9 @@ defmodule EWalletAPI.V1.ErrorHandlerTest do
     use Ecto.Schema
 
     schema "test_schema" do
-      field :field1, :string
-      field :field2, :string
-      field :field3, :string
+      field(:field1, :string)
+      field(:field2, :string)
+      field(:field3, :string)
     end
   end
 
@@ -48,9 +48,9 @@ defmodule EWalletAPI.V1.ErrorHandlerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided"
-            <> " `field2` can't be blank."
-            <> " `field3` can't be blank.",
+          "description" =>
+            "Invalid parameter provided" <>
+              " `field2` can't be blank." <> " `field3` can't be blank.",
           "messages" => %{
             "field2" => ["required"],
             "field3" => ["required"]

--- a/apps/ewallet_api/test/ewallet_api/v1/plugs/client_auth_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/plugs/client_auth_test.exs
@@ -80,6 +80,7 @@ defmodule EWalletAPI.V1.Plug.ClientAuthTest do
   end
 
   defp invoke_conn(api_key, auth_token), do: invoke_conn("OMGClient", api_key, auth_token)
+
   defp invoke_conn(type, api_key, auth_token) do
     build_conn()
     |> put_auth_header(type, api_key, auth_token)

--- a/apps/ewallet_api/test/ewallet_api/v1/plugs/provider_auth_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/plugs/provider_auth_test.exs
@@ -84,6 +84,7 @@ defmodule EWalletAPI.V1.Plug.ProviderAuthTest do
   end
 
   defp invoke_conn(api_key, auth_token), do: invoke_conn("OMGServer", api_key, auth_token)
+
   defp invoke_conn(type, api_key, auth_token) do
     build_conn()
     |> put_auth_header(type, api_key, auth_token)

--- a/apps/ewallet_api/test/ewallet_api/v1/views/self_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/self_view_test.exs
@@ -47,7 +47,7 @@ defmodule EWalletAPI.V1.SelfViewTest do
           object: "setting",
           minted_tokens: [
             MintedTokenSerializer.serialize(token1),
-            MintedTokenSerializer.serialize(token2),
+            MintedTokenSerializer.serialize(token2)
           ]
         }
       }

--- a/apps/ewallet_api/test/ewallet_api/v1/views/settings_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/settings_view_test.exs
@@ -4,7 +4,6 @@ defmodule EWalletAPI.V1.SettingsViewTest do
   alias EWallet.Web.V1.MintedTokenSerializer
 
   describe "EWalletAPI.V1.SettingsView.render/2" do
-
     test "renders settings.json with correct structure" do
       token1 = build(:minted_token)
       token2 = build(:minted_token)

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_consumption_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_consumption_view_test.exs
@@ -8,19 +8,22 @@ defmodule EWalletAPI.V1.TransactionConsumptionViewTest do
       request = insert(:transaction_consumption)
       consumption = TransactionConsumption.get(request.id, preload: [:minted_token])
 
-      result = render(TransactionConsumptionView,
-                      "transaction_consumption.json",
-                      transaction_consumption: consumption)
+      result =
+        render(
+          TransactionConsumptionView,
+          "transaction_consumption.json",
+          transaction_consumption: consumption
+        )
 
       # The serializer tests should cover data transformation already, so we only test that
       # the view builds the expected object and wraps the data into the expected response format.
       assert %{
-          version: _,
-          success: _,
-          data: %{
-            object: "transaction_consumption",
-          }
-        } = result
+               version: _,
+               success: _,
+               data: %{
+                 object: "transaction_consumption"
+               }
+             } = result
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_request_view_test.exs
@@ -15,8 +15,11 @@ defmodule EWalletAPI.V1.TransactionRequestViewTest do
         data: TransactionRequestSerializer.serialize(transaction_request)
       }
 
-      assert render(TransactionRequestView, "transaction_request.json",
-                    transaction_request: transaction_request) == expected
+      assert render(
+               TransactionRequestView,
+               "transaction_request.json",
+               transaction_request: transaction_request
+             ) == expected
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
@@ -29,7 +29,7 @@ defmodule EWalletAPI.V1.TransactionViewTest do
           },
           exchange: %{
             object: "exchange",
-            rate: 1,
+            rate: 1
           },
           metadata: %{some: "metadata"},
           encrypted_metadata: %{},
@@ -39,8 +39,7 @@ defmodule EWalletAPI.V1.TransactionViewTest do
         }
       }
 
-      assert render(TransactionView, "transaction.json",
-                    transaction: transaction) == expected
+      assert render(TransactionView, "transaction.json", transaction: transaction) == expected
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/user_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/user_view_test.exs
@@ -7,7 +7,7 @@ defmodule EWalletAPI.V1.UserViewTest do
   describe "EWalletAPI.V1.UserView.render/2" do
     test "renders user.json with correct structure" do
       user = %User{
-        id: UUID.generate,
+        id: UUID.generate(),
         username: "johndoe",
         provider_user_id: "provider_id_9999",
         metadata: %{
@@ -34,7 +34,7 @@ defmodule EWalletAPI.V1.UserViewTest do
           },
           metadata: %{
             first_name: "John",
-            last_name: "Doe",
+            last_name: "Doe"
           },
           created_at: nil,
           updated_at: nil,

--- a/apps/ewallet_api/test/ewallet_api/versioned_router_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/versioned_router_test.exs
@@ -5,12 +5,13 @@ defmodule EWalletAPI.VersionedRouterTest do
   # credo:disable-for-next-line Credo.Check.Design.DuplicatedCode
   describe "versioned router" do
     test "accepts v1+json requests" do
-      response = build_conn()
-      |> put_req_header("accept", "application/vnd.omisego.v1+json")
-      |> post(@base_dir <> "/status")
-      |> json_response(:ok)
+      response =
+        build_conn()
+        |> put_req_header("accept", "application/vnd.omisego.v1+json")
+        |> post(@base_dir <> "/status")
+        |> json_response(:ok)
 
-      assert response == %{"success" => :true}
+      assert response == %{"success" => true}
     end
 
     test "rejects unrecognized version requests" do
@@ -20,15 +21,17 @@ defmodule EWalletAPI.VersionedRouterTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_version",
-          "description" => "Invalid API version Given: 'application/vnd.omisego.invalid_ver+json'.",
+          "description" =>
+            "Invalid API version Given: 'application/vnd.omisego.invalid_ver+json'.",
           "messages" => nil
         }
       }
 
-      response = build_conn()
-      |> put_req_header("accept", "application/vnd.omisego.invalid_ver+json")
-      |> post(@base_dir <> "/status")
-      |> json_response(:ok)
+      response =
+        build_conn()
+        |> put_req_header("accept", "application/vnd.omisego.invalid_ver+json")
+        |> post(@base_dir <> "/status")
+        |> json_response(:ok)
 
       assert response == expected
     end

--- a/apps/ewallet_api/test/support/channel_case.ex
+++ b/apps/ewallet_api/test/support/channel_case.ex
@@ -1,5 +1,4 @@
 defmodule EWalletAPI.ChannelCase do
-
   @moduledoc """
   This module defines the test case to be used by
   channel tests.

--- a/apps/ewallet_api/test/support/conn_case.ex
+++ b/apps/ewallet_api/test/support/conn_case.ex
@@ -25,8 +25,10 @@ defmodule EWalletAPI.ConnCase do
   @endpoint EWalletAPI.Endpoint
 
   # Attributes for all calls
-  @expected_version "1" # The expected response version
-  @header_accept "application/vnd.omisego.v1+json" # The expected response version
+  # The expected response version
+  @expected_version "1"
+  # The expected response version
+  @header_accept "application/vnd.omisego.v1+json"
 
   # Attributes for provider calls
   @access_key "test_access_key"
@@ -72,19 +74,20 @@ defmodule EWalletAPI.ConnCase do
     {:ok, user} =
       :user
       |> params_for(%{username: @username, provider_user_id: @provider_user_id})
-      |> User.insert() # Insert user via `User.insert/1` to initialize balances, etc.
+      # Insert user via `User.insert/1` to initialize balances, etc.
+      |> User.insert()
 
-    _api_key    = insert(:api_key, %{key: @api_key, owner_app: "ewallet_api"})
+    _api_key = insert(:api_key, %{key: @api_key, owner_app: "ewallet_api"})
     _auth_token = insert(:auth_token, %{user: user, token: @auth_token, owner_app: "ewallet_api"})
 
     # Keys need to be inserted through `EWalletDB.Key.insert/1`
     # so that the secret key is hashed and usable by the tests.
     :key
     |> params_for(%{
-        account: account,
-        access_key: @access_key,
-        secret_key: @secret_key
-      })
+      account: account,
+      access_key: @access_key,
+      secret_key: @secret_key
+    })
     |> Key.insert()
 
     # Setup could return all the inserted credentials using ExUnit context
@@ -97,6 +100,7 @@ defmodule EWalletAPI.ConnCase do
   def stringify_keys(map) when is_map(map) do
     for {key, val} <- map, into: %{}, do: {convert_key(key), stringify_keys(val)}
   end
+
   def stringify_keys(value), do: value
   def convert_key(key) when is_atom(key), do: Atom.to_string(key)
   def convert_key(key), do: key
@@ -111,43 +115,51 @@ defmodule EWalletAPI.ConnCase do
   def get_last_inserted(schema) do
     schema
     |> last(:inserted_at)
-    |> Repo.one
+    |> Repo.one()
   end
 
   def set_initial_balance(%{
-    address: address,
-    minted_token: minted_token,
-    amount: amount
-  }) do
-    account        = Account.get_master_account()
+        address: address,
+        minted_token: minted_token,
+        amount: amount
+      }) do
+    account = Account.get_master_account()
     master_balance = Account.get_primary_balance(account)
 
     mint!(minted_token, amount * 100)
-    transfer!(master_balance.address, address, minted_token, amount * minted_token.subunit_to_unit)
+
+    transfer!(
+      master_balance.address,
+      address,
+      minted_token,
+      amount * minted_token.subunit_to_unit
+    )
   end
 
   def mint!(minted_token, amount \\ 1_000_000) do
-    {:ok, mint, _ledger_response} = MintGate.insert(%{
-      "idempotency_token" => UUID.generate(),
-      "token_id" => minted_token.id,
-      "amount" => amount * minted_token.subunit_to_unit,
-      "description" => "Minting #{amount} #{minted_token.symbol}",
-      "metadata" => %{}
-    })
+    {:ok, mint, _ledger_response} =
+      MintGate.insert(%{
+        "idempotency_token" => UUID.generate(),
+        "token_id" => minted_token.id,
+        "amount" => amount * minted_token.subunit_to_unit,
+        "description" => "Minting #{amount} #{minted_token.symbol}",
+        "metadata" => %{}
+      })
 
     assert mint.confirmed == true
     mint
   end
 
   def transfer!(from, to, minted_token, amount) do
-    {:ok, transfer, _balances, _minted_token} = TransactionGate.process_with_addresses(%{
-      "from_address" => from,
-      "to_address" => to,
-      "token_id" => minted_token.id,
-      "amount" => amount,
-      "metadata" => %{},
-      "idempotency_token" => UUID.generate()
-    })
+    {:ok, transfer, _balances, _minted_token} =
+      TransactionGate.process_with_addresses(%{
+        "from_address" => from,
+        "to_address" => to,
+        "token_id" => minted_token.id,
+        "amount" => amount,
+        "metadata" => %{},
+        "idempotency_token" => UUID.generate()
+      })
 
     transfer
   end
@@ -156,7 +168,8 @@ defmodule EWalletAPI.ConnCase do
   A helper function that generates a valid public request
   with given path and data, and return the parsed JSON response.
   """
-  def public_request(path, data \\ %{}, status \\ :ok) when is_binary(path) and byte_size(path) > 0 do
+  def public_request(path, data \\ %{}, status \\ :ok)
+      when is_binary(path) and byte_size(path) > 0 do
     build_conn()
     |> put_req_header("accept", @header_accept)
     |> post(@base_dir <> path, data)
@@ -167,7 +180,8 @@ defmodule EWalletAPI.ConnCase do
   A helper function that generates a valid provider request
   with given path and data, and return the parsed JSON response.
   """
-  def provider_request(path, data \\ %{}, status \\ :ok) when is_binary(path) and byte_size(path) > 0 do
+  def provider_request(path, data \\ %{}, status \\ :ok)
+      when is_binary(path) and byte_size(path) > 0 do
     build_conn()
     |> put_req_header("accept", @header_accept)
     |> put_auth_header("OMGServer", @access_key, @secret_key)
@@ -180,9 +194,7 @@ defmodule EWalletAPI.ConnCase do
   with given path and data, and return the parsed JSON response.
   """
   def provider_request_with_idempotency(path, idempotency_token, data \\ %{}, status \\ :ok)
-    when is_binary(path)
-    and byte_size(path) > 0
-  do
+      when is_binary(path) and byte_size(path) > 0 do
     build_conn()
     |> put_req_header("idempotency-token", idempotency_token)
     |> put_req_header("accept", @header_accept)
@@ -195,7 +207,8 @@ defmodule EWalletAPI.ConnCase do
   A helper function that generates a valid client request
   with given path and data, and return the parsed JSON response.
   """
-  def client_request(path, data \\ %{}, status \\ :ok) when is_binary(path) and byte_size(path) > 0 do
+  def client_request(path, data \\ %{}, status \\ :ok)
+      when is_binary(path) and byte_size(path) > 0 do
     build_conn()
     |> put_req_header("accept", @header_accept)
     |> put_auth_header("OMGClient", @api_key, @auth_token)
@@ -208,8 +221,7 @@ defmodule EWalletAPI.ConnCase do
   with given path and data, and return the parsed JSON response.
   """
   def client_request_with_idempotency(path, idempotency_token, data \\ %{}, status \\ :ok)
-  when is_binary(path) and byte_size(path) > 0
-  do
+      when is_binary(path) and byte_size(path) > 0 do
     build_conn()
     |> put_req_header("idempotency-token", idempotency_token)
     |> put_req_header("accept", @header_accept)
@@ -226,6 +238,7 @@ defmodule EWalletAPI.ConnCase do
   def put_auth_header(conn, type, access_key, secret_key) do
     put_auth_header(conn, type, Base.encode64(access_key <> ":" <> secret_key))
   end
+
   def put_auth_header(conn, type, content) do
     put_req_header(conn, "authorization", type <> " " <> content)
   end

--- a/apps/ewallet_api/test/support/view_case.ex
+++ b/apps/ewallet_api/test/support/view_case.ex
@@ -15,7 +15,8 @@ defmodule EWalletAPI.ViewCase do
         :ok = Sandbox.checkout(Repo)
       end
 
-      @expected_version "1" # The expected response version
+      # The expected response version
+      @expected_version "1"
     end
   end
 

--- a/apps/ewallet_db/config/adapters/gcs.exs
+++ b/apps/ewallet_db/config/adapters/gcs.exs
@@ -9,5 +9,4 @@ config :arc,
   storage: Arc.Storage.GCS,
   bucket: System.get_env("GCS_BUCKET")
 
-config :goth,
-  json: System.get_env("GCS_CREDENTIALS")
+config :goth, json: System.get_env("GCS_CREDENTIALS")

--- a/apps/ewallet_db/config/adapters/local.exs
+++ b/apps/ewallet_db/config/adapters/local.exs
@@ -1,4 +1,3 @@
 use Mix.Config
 
-config :arc,
-  storage: EWallet.Storage.Local
+config :arc, storage: EWallet.Storage.Local

--- a/apps/ewallet_db/config/config.exs
+++ b/apps/ewallet_db/config/config.exs
@@ -2,15 +2,16 @@ use Mix.Config
 
 config :ewallet_db,
   ecto_repos: [EWalletDB.Repo],
-  env: Mix.env,
+  env: Mix.env(),
   base_url: System.get_env("BASE_URL") || "http://localhost:4000",
   min_password_length: 8
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"
 
 storage_adapter = System.get_env("FILE_STORAGE_ADAPTER") || "local"
+
 case storage_adapter do
-  "aws"   -> import_config "adapters/aws.exs"
-  "gcs"   -> import_config "adapters/gcs.exs"
+  "aws" -> import_config "adapters/aws.exs"
+  "gcs" -> import_config "adapters/gcs.exs"
   "local" -> import_config "adapters/local.exs"
 end

--- a/apps/ewallet_db/config/dev.exs
+++ b/apps/ewallet_db/config/dev.exs
@@ -7,9 +7,9 @@ config :ewallet_db, EWalletDB.Repo,
 key = "j6fy7rZP9ASvf1bmywWGRjrmh8gKANrg40yWZ-rSKpI"
 
 config :cloak, Salty.SecretBox.Cloak,
-       tag: "SBX",
-       default: true,
-       keys: [%{tag: <<1>>, key: key, default: true}]
+  tag: "SBX",
+  default: true,
+  keys: [%{tag: <<1>>, key: key, default: true}]
 
 config :ewallet_db, EWalletDB.Scheduler,
   global: true,

--- a/apps/ewallet_db/config/prod.exs
+++ b/apps/ewallet_db/config/prod.exs
@@ -4,15 +4,14 @@ config :ewallet_db, EWalletDB.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: System.get_env("DATABASE_URL") || "postgres://localhost/ewallet_prod"
 
-config :ewallet_db,
-  base_url: System.get_env("BASE_URL")
+config :ewallet_db, base_url: System.get_env("BASE_URL")
 
 key = System.get_env("EWALLET_SECRET_KEY")
 
 config :cloak, Salty.SecretBox.Cloak,
-       tag: "SBX",
-       default: true,
-       keys: [%{tag: <<1>>, key: key, default: true}]
+  tag: "SBX",
+  default: true,
+  keys: [%{tag: <<1>>, key: key, default: true}]
 
 config :ewallet_db, EWalletDB.Scheduler,
   global: true,

--- a/apps/ewallet_db/config/test.exs
+++ b/apps/ewallet_db/config/test.exs
@@ -8,6 +8,6 @@ config :ewallet_db, EWalletDB.Repo,
 key = "j6fy7rZP9ASvf1bmywWGRjrmh8gKANrg40yWZ-rSKpI"
 
 config :cloak, Salty.SecretBox.Cloak,
-       tag: "SBX",
-       default: true,
-       keys: [%{tag: <<1>>, key: key, default: true}]
+  tag: "SBX",
+  default: true,
+  keys: [%{tag: <<1>>, key: key, default: true}]

--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -20,39 +20,63 @@ defmodule EWalletDB.Account do
   @child_level_limit 1
 
   schema "account" do
-    external_id prefix: "acc_"
+    external_id(prefix: "acc_")
 
-    field :name, :string
-    field :description, :string
-    field :relative_depth, :integer, virtual: true
-    field :avatar, EWalletDB.Uploaders.Avatar.Type
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
-    field :encryption_version, :binary
+    field(:name, :string)
+    field(:description, :string)
+    field(:relative_depth, :integer, virtual: true)
+    field(:avatar, EWalletDB.Uploaders.Avatar.Type)
+    field(:metadata, :map, default: %{})
+    field(:encrypted_metadata, Cloak.EncryptedMapField, default: %{})
+    field(:encryption_version, :binary)
 
-    belongs_to :parent, Account, foreign_key: :parent_uuid,
-                                 references: :uuid,
-                                 type: UUID
+    belongs_to(
+      :parent,
+      Account,
+      foreign_key: :parent_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
-    has_many :balances, Balance, foreign_key: :account_uuid,
-                                 references: :uuid
+    has_many(
+      :balances,
+      Balance,
+      foreign_key: :account_uuid,
+      references: :uuid
+    )
 
-    has_many :minted_tokens, MintedToken, foreign_key: :account_uuid,
-                                          references: :uuid
+    has_many(
+      :minted_tokens,
+      MintedToken,
+      foreign_key: :account_uuid,
+      references: :uuid
+    )
 
-    has_many :keys, Key, foreign_key: :account_uuid,
-                         references: :uuid
+    has_many(
+      :keys,
+      Key,
+      foreign_key: :account_uuid,
+      references: :uuid
+    )
 
-    has_many :api_keys, APIKey, foreign_key: :account_uuid,
-                                references: :uuid
+    has_many(
+      :api_keys,
+      APIKey,
+      foreign_key: :account_uuid,
+      references: :uuid
+    )
 
-    has_many :memberships, Membership, foreign_key: :account_uuid,
-                                       references: :uuid
+    has_many(
+      :memberships,
+      Membership,
+      foreign_key: :account_uuid,
+      references: :uuid
+    )
 
     timestamps()
   end
 
-  @spec changeset(account :: %Account{}, attrs :: map()) :: Ecto.Changeset.t
+  @spec changeset(account :: %Account{}, attrs :: map()) :: Ecto.Changeset.t()
   defp changeset(%Account{} = account, attrs) do
     account
     |> cast(attrs, [:name, :description, :parent_uuid, :metadata, :encrypted_metadata])
@@ -61,10 +85,10 @@ defmodule EWalletDB.Account do
     |> validate_account_level(@child_level_limit)
     |> unique_constraint(:name)
     |> assoc_constraint(:parent)
-    |> put_change(:encryption_version, Cloak.version)
+    |> put_change(:encryption_version, Cloak.version())
   end
 
-  @spec avatar_changeset(changeset :: Ecto.Changeset.t, attrs :: map()) :: Ecto.Changeset.t
+  @spec avatar_changeset(changeset :: Ecto.Changeset.t(), attrs :: map()) :: Ecto.Changeset.t()
   defp avatar_changeset(changeset, attrs) do
     changeset
     |> cast_attachments(attrs, [:avatar])
@@ -73,20 +97,21 @@ defmodule EWalletDB.Account do
   @doc """
   Create a new account with the passed attributes, as well as a primary and a burn balances.
   """
-  @spec insert(attrs :: map()) :: {:ok, %Account{}} | {:error, Ecto.Changeset.t}
+  @spec insert(attrs :: map()) :: {:ok, %Account{}} | {:error, Ecto.Changeset.t()}
   def insert(attrs) do
     multi =
-      Multi.new
+      Multi.new()
       |> Multi.insert(:account, changeset(%Account{}, attrs))
       |> Multi.run(:balance, fn %{account: account} ->
-        insert_balance(account, Balance.primary)
-        insert_balance(account, Balance.burn)
+        insert_balance(account, Balance.primary())
+        insert_balance(account, Balance.burn())
       end)
 
     case Repo.transaction(multi) do
       {:ok, result} ->
         account = result.account |> Repo.preload([:balances])
         {:ok, account}
+
       # Only the account insertion should fail. If the balance insert fails, there is
       # something wrong with our code.
       {:error, _failed_operation, changeset, _changes_so_far} ->
@@ -98,13 +123,14 @@ defmodule EWalletDB.Account do
   Updates an account with the provided attributes.
   """
   @spec update(account :: %Account{}, attrs :: map()) ::
-    {:ok, %Account{}} | {:error, Ecto.Changeset.t}
+          {:ok, %Account{}} | {:error, Ecto.Changeset.t()}
   def update(%Account{} = account, attrs) do
     changeset = changeset(account, attrs)
 
     case Repo.update(changeset) do
       {:ok, account} ->
         {:ok, get(account.id)}
+
       result ->
         result
     end
@@ -113,8 +139,8 @@ defmodule EWalletDB.Account do
   @doc """
   Inserts a balance for the given account.
   """
-  @spec insert_balance(account :: %Account{}, identifier :: String.t) ::
-    {:ok, %Balance{}} | {:error, Ecto.Changeset.t}
+  @spec insert_balance(account :: %Account{}, identifier :: String.t()) ::
+          {:ok, %Balance{}} | {:error, Ecto.Changeset.t()}
   def insert_balance(%Account{} = account, identifier) do
     %{
       account_uuid: account.uuid,
@@ -132,7 +158,7 @@ defmodule EWalletDB.Account do
   def store_avatar(%Account{} = account, attrs) do
     attrs =
       case attrs["avatar"] do
-        ""     -> %{avatar: nil}
+        "" -> %{avatar: nil}
         "null" -> %{avatar: nil}
         avatar -> %{avatar: avatar}
       end
@@ -141,7 +167,7 @@ defmodule EWalletDB.Account do
 
     case Repo.update(changeset) do
       {:ok, account} -> get(account.id)
-      result         -> result
+      result -> result
     end
   end
 
@@ -150,6 +176,7 @@ defmodule EWalletDB.Account do
   """
   @spec all(opts :: keyword()) :: list(%Account{})
   def all(opts \\ [])
+
   def all(opts) do
     Account
     |> Repo.all()
@@ -159,11 +186,13 @@ defmodule EWalletDB.Account do
   @doc """
   Retrieves an account with the given ID.
   """
-  @spec get(id :: ExternalID.t, opts :: keyword()) :: %Account{} | nil
+  @spec get(id :: ExternalID.t(), opts :: keyword()) :: %Account{} | nil
   def get(id, opts \\ [])
+
   def get(id, opts) when is_external_id(id) do
     get_by([id: id], opts)
   end
+
   def get(_id, _opts), do: nil
 
   @doc """
@@ -200,7 +229,7 @@ defmodule EWalletDB.Account do
   """
   @spec get_preloaded_primary_balance(account :: %Account{}) :: %Balance{}
   def get_preloaded_primary_balance(account) do
-    Enum.find(account.balances, fn balance -> balance.identifier == Balance.primary end)
+    Enum.find(account.balances, fn balance -> balance.identifier == Balance.primary() end)
   end
 
   @doc """
@@ -208,7 +237,7 @@ defmodule EWalletDB.Account do
   """
   @spec get_primary_balance(account :: %Account{}) :: %Balance{}
   def get_primary_balance(account) do
-    get_balance_by_identifier(account, Balance.primary)
+    get_balance_by_identifier(account, Balance.primary())
   end
 
   @doc """
@@ -216,13 +245,13 @@ defmodule EWalletDB.Account do
   """
   @spec get_default_burn_balance(account :: %Account{}) :: %Balance{}
   def get_default_burn_balance(account) do
-    get_balance_by_identifier(account, Balance.burn)
+    get_balance_by_identifier(account, Balance.burn())
   end
 
   @doc """
   Retrieve a balance by name for the given account.
   """
-  @spec get_balance_by_identifier(account :: %Account{}, identifier :: String.t) :: %Balance{}
+  @spec get_balance_by_identifier(account :: %Account{}, identifier :: String.t()) :: %Balance{}
   def get_balance_by_identifier(account, identifier) do
     Balance
     |> where([b], b.identifier == ^identifier)
@@ -235,12 +264,15 @@ defmodule EWalletDB.Account do
 
   The master account has a relative depth of 0.
   """
-  @spec get_depth(account :: %Account{} | account_uuid :: String.t) :: non_neg_integer()
+  @spec get_depth(account :: %Account{} | account_uuid :: String.t()) :: non_neg_integer()
   def get_depth(%Account{} = account), do: get_depth(account.uuid)
+
   def get_depth(account_uuid) do
     case Account.get_master_account() do
       nil ->
-        0 # No master account means that this account is at level 0.
+        # No master account means that this account is at level 0.
+        0
+
       master_account ->
         account_uuid
         |> query_depth(master_account.uuid)
@@ -248,25 +280,31 @@ defmodule EWalletDB.Account do
     end
   end
 
-  @spec query_depth(account_uuid :: String.t, parent_uuid :: String.t) :: Ecto.Query.t
+  @spec query_depth(account_uuid :: String.t(), parent_uuid :: String.t()) :: Ecto.Query.t()
   defp query_depth(account_uuid, parent_uuid) do
     # Traverses up the account tree and count each step up until it reaches the master account.
-    from a in Account,
-      join: account_tree in fragment("""
-        WITH RECURSIVE account_tree AS (
-          SELECT uuid, parent_uuid, 0 AS depth
-          FROM account a
-          WHERE a.uuid = ?
-        UNION
-          SELECT parent.uuid, parent.parent_uuid, account_tree.depth + 1 as depth
-          FROM account parent
-          JOIN account_tree ON account_tree.parent_uuid = parent.uuid
-        )
-        SELECT uuid, depth FROM account_tree
-        WHERE account_tree.uuid = ?
-        """,
-        type(^account_uuid, UUID), type(^parent_uuid, UUID)
-      ), on: a.uuid == account_tree.uuid,
+    from(
+      a in Account,
+      join:
+        account_tree in fragment(
+          """
+          WITH RECURSIVE account_tree AS (
+            SELECT uuid, parent_uuid, 0 AS depth
+            FROM account a
+            WHERE a.uuid = ?
+          UNION
+            SELECT parent.uuid, parent.parent_uuid, account_tree.depth + 1 as depth
+            FROM account parent
+            JOIN account_tree ON account_tree.parent_uuid = parent.uuid
+          )
+          SELECT uuid, depth FROM account_tree
+          WHERE account_tree.uuid = ?
+          """,
+          type(^account_uuid, UUID),
+          type(^parent_uuid, UUID)
+        ),
+      on: a.uuid == account_tree.uuid,
       select: account_tree.depth
+    )
   end
 end

--- a/apps/ewallet_db/lib/ewallet_db/account_validator.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account_validator.ex
@@ -8,16 +8,15 @@ defmodule EWalletDB.AccountValidator do
   @doc """
   Validates that there can be only one master account in the system.
   """
-  @spec validate_parent_uuid(changeset :: Ecto.Changeset.t) :: Ecto.Changeset.t
+  @spec validate_parent_uuid(changeset :: Ecto.Changeset.t()) :: Ecto.Changeset.t()
   def validate_parent_uuid(changeset) do
     # Require a `parent_uuid` if:
     #   1. This changeset has `parent_uuid` == nil
     #   2. The master account already exists
     #   3. This changeset is not for the master account
-    with nil          <- get_field(changeset, :parent_uuid),
+    with nil <- get_field(changeset, :parent_uuid),
          %{} = master <- Account.get_master_account(),
-         false        <- master.uuid == get_field(changeset, :uuid)
-    do
+         false <- master.uuid == get_field(changeset, :uuid) do
       validate_required(changeset, :parent_uuid)
     else
       _ -> changeset
@@ -36,17 +35,20 @@ defmodule EWalletDB.AccountValidator do
     - `2` : valid if the account is the master account, its direct children, or one more level down
     - ...
   """
-  @spec validate_account_level(changeset :: Ecto.Changeset.t,
-                               child_level_limit :: non_neg_integer()) :: Ecto.Changeset.t
+  @spec validate_account_level(
+          changeset :: Ecto.Changeset.t(),
+          child_level_limit :: non_neg_integer()
+        ) :: Ecto.Changeset.t()
   def validate_account_level(changeset, child_level_limit) do
     with {_, parent_uuid} <- fetch_field(changeset, :parent_uuid),
-         depth          <- Account.get_depth(parent_uuid),
-         true           <- depth >= child_level_limit
-    do
-      add_error(changeset,
-                :parent_uuid,
-                "is at the maximum child level",
-                [validation: :account_level_limit])
+         depth <- Account.get_depth(parent_uuid),
+         true <- depth >= child_level_limit do
+      add_error(
+        changeset,
+        :parent_uuid,
+        "is at the maximum child level",
+        validation: :account_level_limit
+      )
     else
       _ -> changeset
     end

--- a/apps/ewallet_db/lib/ewallet_db/balance.ex
+++ b/apps/ewallet_db/lib/ewallet_db/balance.ex
@@ -8,9 +8,9 @@ defmodule EWalletDB.Balance do
   alias Ecto.UUID
   alias EWalletDB.{Repo, Account, Balance, MintedToken, User}
 
-  @genesis   "genesis"
-  @burn      "burn"
-  @primary   "primary"
+  @genesis "genesis"
+  @burn "burn"
+  @primary "primary"
   @secondary "secondary"
 
   def genesis, do: @genesis
@@ -23,32 +23,51 @@ defmodule EWalletDB.Balance do
   schema "balance" do
     # Balance does not have an external ID. Use `address` instead.
 
-    field :address, :string
-    field :name, :string
-    field :identifier, :string
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
-    field :encryption_version, :binary
+    field(:address, :string)
+    field(:name, :string)
+    field(:identifier, :string)
+    field(:metadata, :map, default: %{})
+    field(:encrypted_metadata, Cloak.EncryptedMapField, default: %{})
+    field(:encryption_version, :binary)
 
-    belongs_to :user, User, foreign_key: :user_uuid,
-                            references: :uuid,
-                            type: UUID
+    belongs_to(
+      :user,
+      User,
+      foreign_key: :user_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
-    belongs_to :minted_token, MintedToken, foreign_key: :minted_token_uuid,
-                                           references: :uuid,
-                                           type: UUID
+    belongs_to(
+      :minted_token,
+      MintedToken,
+      foreign_key: :minted_token_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
-    belongs_to :account, Account, foreign_key: :account_uuid,
-                                  references: :uuid,
-                                  type: UUID
+    belongs_to(
+      :account,
+      Account,
+      foreign_key: :account_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
     timestamps()
   end
 
   defp changeset(%Balance{} = balance, attrs) do
     balance
     |> cast(attrs, [
-      :address, :account_uuid, :minted_token_uuid, :user_uuid, :metadata,
-      :encrypted_metadata, :name, :identifier
+      :address,
+      :account_uuid,
+      :minted_token_uuid,
+      :user_uuid,
+      :metadata,
+      :encrypted_metadata,
+      :name,
+      :identifier
     ])
     |> validate_required([:address, :name, :identifier, :metadata, :encrypted_metadata])
     |> validate_format(:identifier, ~r/#{@genesis}|#{@burn}|#{@primary}|#{@secondary}:.*/)
@@ -61,13 +80,14 @@ defmodule EWalletDB.Balance do
     |> unique_constraint(:unique_user_name, name: :balance_user_id_name_index)
     |> unique_constraint(:unique_account_identifier, name: :balance_account_id_identifier_index)
     |> unique_constraint(:unique_user_identifier, name: :balance_user_id_identifier_index)
-    |> put_change(:encryption_version, Cloak.version)
+    |> put_change(:encryption_version, Cloak.version())
   end
 
   @doc """
   Retrieve a balance using the specified address.
   """
   def get(nil), do: nil
+
   def get(address) do
     Repo.get_by(Balance, address: address)
   end
@@ -92,6 +112,7 @@ defmodule EWalletDB.Balance do
       nil ->
         {:ok, genesis} = insert_genesis()
         genesis
+
       balance ->
         balance
     end
@@ -107,6 +128,7 @@ defmodule EWalletDB.Balance do
     case Repo.insert(changeset, opts) do
       {:ok, _balance} ->
         {:ok, get(@genesis)}
+
       {:error, changeset} ->
         {:error, changeset}
     end

--- a/apps/ewallet_db/lib/ewallet_db/forget_password_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/forget_password_request.ex
@@ -12,10 +12,16 @@ defmodule EWalletDB.ForgetPasswordRequest do
   @token_length 32
 
   schema "forget_password_request" do
-    field :token, :string
-    belongs_to :user, User, foreign_key: :user_uuid,
-                            references: :uuid,
-                            type: UUID
+    field(:token, :string)
+
+    belongs_to(
+      :user,
+      User,
+      foreign_key: :user_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
     timestamps()
   end
 
@@ -42,6 +48,7 @@ defmodule EWalletDB.ForgetPasswordRequest do
   end
 
   defp check_token(nil, _token), do: nil
+
   defp check_token(request, token) do
     if Crypto.secure_compare(request.token, token), do: request, else: nil
   end

--- a/apps/ewallet_db/lib/ewallet_db/helpers/assoc.ex
+++ b/apps/ewallet_db/lib/ewallet_db/helpers/assoc.ex
@@ -52,6 +52,7 @@ defmodule EWalletDB.Helpers.Assoc do
       assoc -> get(assoc, remaining)
     end
   end
+
   def get(struct, nested) when length(nested) == 1 do
     field = List.first(nested)
     Map.get(struct, field)

--- a/apps/ewallet_db/lib/ewallet_db/helpers/crypto.ex
+++ b/apps/ewallet_db/lib/ewallet_db/helpers/crypto.ex
@@ -14,21 +14,21 @@ defmodule EWalletDB.Helpers.Crypto do
   @spec hash_password(nil) :: nil
   def hash_password(nil), do: nil
 
-  @spec hash_password(String.t) :: String.t
+  @spec hash_password(String.t()) :: String.t()
   def hash_password(password) do
     Bcrypt.hash_pwd_salt(password)
   end
 
-  @spec verify_password(String.t, String.t) :: boolean
+  @spec verify_password(String.t(), String.t()) :: boolean
   def verify_password(password, hash) do
     Bcrypt.verify_pass(password, hash)
   end
 
   @spec fake_verify :: boolean
   def fake_verify do
-    Bcrypt.no_user_verify
+    Bcrypt.no_user_verify()
   end
 
-  @spec secure_compare(String.t, String.t) :: boolean
+  @spec secure_compare(String.t(), String.t()) :: boolean
   def secure_compare(left, right), do: Crypto.secure_compare(left, right)
 end

--- a/apps/ewallet_db/lib/ewallet_db/helpers/preloader.ex
+++ b/apps/ewallet_db/lib/ewallet_db/helpers/preloader.ex
@@ -9,7 +9,7 @@ defmodule EWalletDB.Helpers.Preloader do
   """
   def preload_option(records, opts) do
     case opts[:preload] do
-      nil     -> records
+      nil -> records
       preload -> Repo.preload(records, preload)
     end
   end

--- a/apps/ewallet_db/lib/ewallet_db/membership.ex
+++ b/apps/ewallet_db/lib/ewallet_db/membership.ex
@@ -11,15 +11,29 @@ defmodule EWalletDB.Membership do
   @primary_key {:uuid, UUID, autogenerate: true}
 
   schema "membership" do
-    belongs_to :user, User, foreign_key: :user_uuid,
-                            references: :uuid,
-                            type: UUID
-    belongs_to :account, Account, foreign_key: :account_uuid,
-                            references: :uuid,
-                            type: UUID
-    belongs_to :role, Role, foreign_key: :role_uuid,
-                            references: :uuid,
-                            type: UUID
+    belongs_to(
+      :user,
+      User,
+      foreign_key: :user_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :account,
+      Account,
+      foreign_key: :account_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :role,
+      Role,
+      foreign_key: :role_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
     timestamps()
   end
@@ -45,7 +59,7 @@ defmodule EWalletDB.Membership do
   Retrieves all memberships for the given user.
   """
   def all_by_user(user) do
-    Repo.all from m in Membership, where: m.user_uuid == ^user.uuid
+    Repo.all(from(m in Membership, where: m.user_uuid == ^user.uuid))
   end
 
   @doc """
@@ -55,10 +69,12 @@ defmodule EWalletDB.Membership do
     case Role.get_by_name(role) do
       nil ->
         {:error, :role_not_found}
+
       role ->
         assign(user, account, role)
     end
   end
+
   def assign(%User{} = user, %Account{} = account, %Role{} = role) do
     case get_by_user_and_account(user, account) do
       nil ->
@@ -67,6 +83,7 @@ defmodule EWalletDB.Membership do
           user_uuid: user.uuid,
           role_uuid: role.uuid
         })
+
       existing ->
         update(existing, %{role_uuid: role.uuid})
     end
@@ -79,6 +96,7 @@ defmodule EWalletDB.Membership do
     case get_by_user_and_account(user, account) do
       nil ->
         {:error, :membership_not_found}
+
       membership ->
         delete(membership)
     end

--- a/apps/ewallet_db/lib/ewallet_db/mint.ex
+++ b/apps/ewallet_db/lib/ewallet_db/mint.ex
@@ -11,20 +11,36 @@ defmodule EWalletDB.Mint do
   @primary_key {:uuid, Ecto.UUID, autogenerate: true}
 
   schema "mint" do
-    external_id prefix: "mnt_"
+    external_id(prefix: "mnt_")
 
-    field :description, :string
-    field :amount, EWalletDB.Types.Integer
-    field :confirmed, :boolean, default: false
-    belongs_to :minted_token, MintedToken, foreign_key: :minted_token_uuid,
-                                           references: :uuid,
-                                           type: UUID
-    belongs_to :account, Account, foreign_key: :account_uuid,
-                                  references: :uuid,
-                                  type: UUID
-    belongs_to :transfer, Transfer, foreign_key: :transfer_uuid,
-                                    references: :uuid,
-                                    type: UUID
+    field(:description, :string)
+    field(:amount, EWalletDB.Types.Integer)
+    field(:confirmed, :boolean, default: false)
+
+    belongs_to(
+      :minted_token,
+      MintedToken,
+      foreign_key: :minted_token_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :account,
+      Account,
+      foreign_key: :account_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :transfer,
+      Transfer,
+      foreign_key: :transfer_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
     timestamps()
   end
 
@@ -55,14 +71,14 @@ defmodule EWalletDB.Mint do
   @doc """
   Updates a mint with the provided attributes.
   """
-  @spec update(mint :: %Mint{}, attrs :: map()) ::
-    {:ok, %Mint{}} | {:error, Ecto.Changeset.t}
+  @spec update(mint :: %Mint{}, attrs :: map()) :: {:ok, %Mint{}} | {:error, Ecto.Changeset.t()}
   def update(%Mint{} = mint, attrs) do
     changeset = update_changeset(mint, attrs)
 
     case Repo.update(changeset) do
       {:ok, mint} ->
         {:ok, mint}
+
       result ->
         result
     end
@@ -72,6 +88,7 @@ defmodule EWalletDB.Mint do
   Confirms a mint.
   """
   def confirm(%Mint{confirmed: true} = mint), do: mint
+
   def confirm(%Mint{confirmed: false} = mint) do
     {:ok, mint} =
       mint

--- a/apps/ewallet_db/lib/ewallet_db/minted_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/minted_token.ex
@@ -14,40 +14,74 @@ defmodule EWalletDB.MintedToken do
   @primary_key {:uuid, UUID, autogenerate: true}
 
   schema "minted_token" do
-    field :id, :string # tok_eur_01cbebcdjprhpbzp1pt7h0nzvt
+    # tok_eur_01cbebcdjprhpbzp1pt7h0nzvt
+    field(:id, :string)
 
-    field :symbol, :string # "eur"
-    field :iso_code, :string # "EUR"
-    field :name, :string # "Euro"
-    field :description, :string # Official currency of the European Union
-    field :short_symbol, :string # "€"
-    field :subunit, :string # "Cent"
-    field :subunit_to_unit, EWalletDB.Types.Integer # 100
-    field :symbol_first, :boolean # true
-    field :html_entity, :string # "&#x20AC;"
-    field :iso_numeric, :string # "978"
-    field :smallest_denomination, :integer # 1
-    field :locked, :boolean # false
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
-    field :encryption_version, :binary
-    belongs_to :account, Account, foreign_key: :account_uuid,
-                                           references: :uuid,
-                                           type: UUID
+    # "eur"
+    field(:symbol, :string)
+    # "EUR"
+    field(:iso_code, :string)
+    # "Euro"
+    field(:name, :string)
+    # Official currency of the European Union
+    field(:description, :string)
+    # "€"
+    field(:short_symbol, :string)
+    # "Cent"
+    field(:subunit, :string)
+    # 100
+    field(:subunit_to_unit, EWalletDB.Types.Integer)
+    # true
+    field(:symbol_first, :boolean)
+    # "&#x20AC;"
+    field(:html_entity, :string)
+    # "978"
+    field(:iso_numeric, :string)
+    # 1
+    field(:smallest_denomination, :integer)
+    # false
+    field(:locked, :boolean)
+    field(:metadata, :map, default: %{})
+    field(:encrypted_metadata, Cloak.EncryptedMapField, default: %{})
+    field(:encryption_version, :binary)
+
+    belongs_to(
+      :account,
+      Account,
+      foreign_key: :account_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
     timestamps()
   end
 
   defp changeset(%MintedToken{} = minted_token, attrs) do
     minted_token
     |> cast(attrs, [
-      :symbol, :iso_code, :name, :description, :short_symbol,
-      :subunit, :subunit_to_unit, :symbol_first, :html_entity,
-      :iso_numeric, :smallest_denomination, :locked, :account_uuid,
-      :metadata, :encrypted_metadata
+      :symbol,
+      :iso_code,
+      :name,
+      :description,
+      :short_symbol,
+      :subunit,
+      :subunit_to_unit,
+      :symbol_first,
+      :html_entity,
+      :iso_numeric,
+      :smallest_denomination,
+      :locked,
+      :account_uuid,
+      :metadata,
+      :encrypted_metadata
     ])
     |> validate_required([
-      :symbol, :name, :subunit_to_unit, :account_uuid,
-      :metadata, :encrypted_metadata
+      :symbol,
+      :name,
+      :subunit_to_unit,
+      :account_uuid,
+      :metadata,
+      :encrypted_metadata
     ])
     |> validate_number(:subunit_to_unit, greater_than: 0, less_than_or_equal_to: 1.0e18)
     |> validate_immutable(:symbol)
@@ -57,7 +91,7 @@ defmodule EWalletDB.MintedToken do
     |> unique_constraint(:short_symbol)
     |> unique_constraint(:iso_numeric)
     |> assoc_constraint(:account)
-    |> put_change(:encryption_version, Cloak.version)
+    |> put_change(:encryption_version, Cloak.version())
     |> set_id(prefix: "tok_")
   end
 
@@ -67,6 +101,7 @@ defmodule EWalletDB.MintedToken do
         symbol = get_field(changeset, :symbol)
         ulid = ULID.generate()
         put_change(changeset, :id, build_id(symbol, ulid, opts))
+
       _ ->
         changeset
     end
@@ -76,6 +111,7 @@ defmodule EWalletDB.MintedToken do
     case opts[:prefix] do
       nil ->
         "#{symbol}_#{ulid}"
+
       prefix ->
         "#{prefix}#{symbol}_#{ulid}"
     end
@@ -97,6 +133,7 @@ defmodule EWalletDB.MintedToken do
     case Repo.insert(changeset) do
       {:ok, minted_token} ->
         {:ok, get(minted_token.id)}
+
       {:error, changeset} ->
         {:error, changeset}
     end
@@ -108,6 +145,7 @@ defmodule EWalletDB.MintedToken do
   @spec get_by(String.t(), opts :: keyword()) :: %MintedToken{} | nil
   def get(id, opts \\ [])
   def get(nil, _), do: nil
+
   def get(id, opts) do
     get_by([id: id], opts)
   end
@@ -126,7 +164,6 @@ defmodule EWalletDB.MintedToken do
   Retrieve a list of minted tokens by supplying a list of IDs.
   """
   def get_all(ids) do
-    Repo.all(from m in MintedToken,
-                       where: m.id in ^ids)
+    Repo.all(from(m in MintedToken, where: m.id in ^ids))
   end
 end

--- a/apps/ewallet_db/lib/ewallet_db/role.ex
+++ b/apps/ewallet_db/lib/ewallet_db/role.ex
@@ -10,10 +10,15 @@ defmodule EWalletDB.Role do
   @primary_key {:uuid, UUID, autogenerate: true}
 
   schema "role" do
-    field :name, :string
-    field :display_name, :string
-    many_to_many :users, User, join_through: Membership,
-                               join_keys: [role_uuid: :uuid, user_uuid: :uuid]
+    field(:name, :string)
+    field(:display_name, :string)
+
+    many_to_many(
+      :users,
+      User,
+      join_through: Membership,
+      join_keys: [role_uuid: :uuid, user_uuid: :uuid]
+    )
 
     timestamps()
   end
@@ -40,6 +45,7 @@ defmodule EWalletDB.Role do
   def get_by_name(name) when is_binary(name) do
     Repo.get_by(Role, name: name)
   end
+
   def get_by_name(_), do: nil
 
   @doc """

--- a/apps/ewallet_db/lib/ewallet_db/soft_delete.ex
+++ b/apps/ewallet_db/lib/ewallet_db/soft_delete.ex
@@ -82,7 +82,7 @@ defmodule EWalletDB.SoftDelete do
   """
   defmacro soft_delete do
     quote do
-      field :deleted_at, :naive_datetime
+      field(:deleted_at, :naive_datetime)
     end
   end
 

--- a/apps/ewallet_db/lib/ewallet_db/storage/local.ex
+++ b/apps/ewallet_db/lib/ewallet_db/storage/local.ex
@@ -10,11 +10,12 @@ defmodule EWallet.Storage.Local do
   def put(definition, version, {file, scope}) do
     destination_dir = definition.storage_dir(version, {file, scope})
 
-    path = Path.join([
-      Application.get_env(:ewallet, :root),
-      destination_dir,
-      file.file_name
-    ])
+    path =
+      Path.join([
+        Application.get_env(:ewallet, :root),
+        destination_dir,
+        file.file_name
+      ])
 
     path |> Path.dirname() |> File.mkdir_p!()
 
@@ -31,11 +32,12 @@ defmodule EWallet.Storage.Local do
     base_url = Application.get_env(:ewallet_db, :base_url)
     local_path = build_local_path(definition, version, file_and_scope)
 
-    url = if String.starts_with?(local_path, "/") do
-      base_url <> local_path
-    else
-      base_url <> "/" <> local_path
-    end
+    url =
+      if String.starts_with?(local_path, "/") do
+        base_url <> local_path
+      else
+        base_url <> "/" <> local_path
+      end
 
     url |> URI.encode()
   end

--- a/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
@@ -6,8 +6,17 @@ defmodule EWalletDB.TransactionConsumption do
   use EWalletDB.Types.ExternalID
   import Ecto.{Changeset, Query}
   alias Ecto.UUID
-  alias EWalletDB.{TransactionConsumption, Repo, User, MintedToken,
-                   TransactionRequest, Balance, Transfer, Account}
+
+  alias EWalletDB.{
+    TransactionConsumption,
+    Repo,
+    User,
+    MintedToken,
+    TransactionRequest,
+    Balance,
+    Transfer,
+    Account
+  }
 
   @pending "pending"
   @confirmed "confirmed"
@@ -20,54 +29,97 @@ defmodule EWalletDB.TransactionConsumption do
   @primary_key {:uuid, Ecto.UUID, autogenerate: true}
 
   schema "transaction_consumption" do
-    external_id prefix: "txc_"
+    external_id(prefix: "txc_")
 
-    field :amount, EWalletDB.Types.Integer
-    field :correlation_id, :string
-    field :idempotency_token, :string
+    field(:amount, EWalletDB.Types.Integer)
+    field(:correlation_id, :string)
+    field(:idempotency_token, :string)
 
     # State
-    field :status, :string, default: @pending
-    field :approved_at, :naive_datetime
-    field :rejected_at, :naive_datetime
-    field :confirmed_at, :naive_datetime
-    field :failed_at, :naive_datetime
-    field :expired_at, :naive_datetime
+    field(:status, :string, default: @pending)
+    field(:approved_at, :naive_datetime)
+    field(:rejected_at, :naive_datetime)
+    field(:confirmed_at, :naive_datetime)
+    field(:failed_at, :naive_datetime)
+    field(:expired_at, :naive_datetime)
 
-    field :expiration_date, :naive_datetime
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
-    belongs_to :transfer, Transfer, foreign_key: :transfer_uuid,
-                                    references: :uuid,
-                                    type: UUID
-    belongs_to :user, User, foreign_key: :user_uuid,
-                                         references: :uuid,
-                                         type: UUID
-    belongs_to :account, Account, foreign_key: :account_uuid,
-                                  references: :uuid,
-                                  type: UUID
-    belongs_to :transaction_request, TransactionRequest, foreign_key: :transaction_request_uuid,
-                                     references: :uuid,
-                                     type: UUID
-    belongs_to :minted_token, MintedToken, foreign_key: :minted_token_uuid,
-                                           references: :uuid,
-                                           type: UUID
-    belongs_to :balance, Balance, foreign_key: :balance_address,
-                                  references: :address,
-                                  type: :string
+    field(:expiration_date, :naive_datetime)
+    field(:metadata, :map, default: %{})
+    field(:encrypted_metadata, Cloak.EncryptedMapField, default: %{})
+
+    belongs_to(
+      :transfer,
+      Transfer,
+      foreign_key: :transfer_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :user,
+      User,
+      foreign_key: :user_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :account,
+      Account,
+      foreign_key: :account_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :transaction_request,
+      TransactionRequest,
+      foreign_key: :transaction_request_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :minted_token,
+      MintedToken,
+      foreign_key: :minted_token_uuid,
+      references: :uuid,
+      type: UUID
+    )
+
+    belongs_to(
+      :balance,
+      Balance,
+      foreign_key: :balance_address,
+      references: :address,
+      type: :string
+    )
+
     timestamps()
   end
 
   defp changeset(%TransactionConsumption{} = consumption, attrs) do
     consumption
     |> cast(attrs, [
-      :amount, :idempotency_token, :correlation_id, :user_uuid, :account_uuid,
-      :transaction_request_uuid, :balance_address, :minted_token_uuid,
-      :metadata, :encrypted_metadata, :expiration_date
+      :amount,
+      :idempotency_token,
+      :correlation_id,
+      :user_uuid,
+      :account_uuid,
+      :transaction_request_uuid,
+      :balance_address,
+      :minted_token_uuid,
+      :metadata,
+      :encrypted_metadata,
+      :expiration_date
     ])
     |> validate_required([
-      :status, :amount, :idempotency_token, :transaction_request_uuid,
-      :balance_address, :minted_token_uuid
+      :status,
+      :amount,
+      :idempotency_token,
+      :transaction_request_uuid,
+      :balance_address,
+      :minted_token_uuid
     ])
     |> validate_number(:amount, greater_than: 0)
     |> validate_inclusion(:status, @statuses)
@@ -77,7 +129,7 @@ defmodule EWalletDB.TransactionConsumption do
     |> assoc_constraint(:transaction_request)
     |> assoc_constraint(:balance)
     |> assoc_constraint(:account)
-    |> put_change(:encryption_version, Cloak.version)
+    |> put_change(:encryption_version, Cloak.version())
   end
 
   def approved_changeset(%TransactionConsumption{} = consumption, attrs) do
@@ -115,23 +167,25 @@ defmodule EWalletDB.TransactionConsumption do
   @doc """
   Gets a transaction request consumption.
   """
-  @spec get(ExternalID.t) :: %TransactionConsumption{} | nil
-  @spec get(ExternalID.t, keyword()) :: %TransactionConsumption{} | nil
+  @spec get(ExternalID.t()) :: %TransactionConsumption{} | nil
+  @spec get(ExternalID.t(), keyword()) :: %TransactionConsumption{} | nil
   def get(id, opts \\ [])
+
   def get(id, opts) when is_external_id(id) do
     get_by([id: id], opts)
   end
+
   def get(_id, _opts), do: nil
 
   @doc """
   Get a consumption using one or more fields.
   """
-  @spec get_by(Map.t, List.t) :: %TransactionConsumption{} | nil
+  @spec get_by(Map.t(), List.t()) :: %TransactionConsumption{} | nil
   def get_by(map, opts \\ []) do
     query = TransactionConsumption |> Repo.get_by(map)
 
     case opts[:preload] do
-      nil     -> query
+      nil -> query
       preload -> Repo.preload(query, preload)
     end
   end
@@ -144,16 +198,18 @@ defmodule EWalletDB.TransactionConsumption do
     |> where([t], t.status == @pending)
     |> where([t], not is_nil(t.expiration_date))
     |> where([t], t.expiration_date <= ^now)
-    |> Repo.update_all(set: [
-      status: @expired,
-      expired_at: NaiveDateTime.utc_now()
-    ])
+    |> Repo.update_all(
+      set: [
+        status: @expired,
+        expired_at: NaiveDateTime.utc_now()
+      ]
+    )
   end
 
   @doc """
   Expires the given consumption.
   """
-  @spec expire(%TransactionConsumption{}) :: {:ok, %TransactionConsumption{}} | {:error, Map.t}
+  @spec expire(%TransactionConsumption{}) :: {:ok, %TransactionConsumption{}} | {:error, Map.t()}
   def expire(consumption) do
     consumption
     |> expired_changeset(%{
@@ -167,21 +223,22 @@ defmodule EWalletDB.TransactionConsumption do
   Expires the given consumption if the expiration date is past.
   """
   @spec expire_if_past_expiration_date(%TransactionConsumption{}) ::
-                                       {:ok, %TransactionConsumption{}} | {:error, Map.t}
+          {:ok, %TransactionConsumption{}} | {:error, Map.t()}
   def expire_if_past_expiration_date(consumption) do
-    expired? = consumption.expiration_date &&
-               NaiveDateTime.compare(consumption.expiration_date, NaiveDateTime.utc_now()) == :lt
+    expired? =
+      consumption.expiration_date &&
+        NaiveDateTime.compare(consumption.expiration_date, NaiveDateTime.utc_now()) == :lt
 
     case expired? do
       true -> expire(consumption)
-      _    -> {:ok, consumption}
+      _ -> {:ok, consumption}
     end
   end
 
   @doc """
   Get all confirmed and pending transaction consumptions.
   """
-  @spec all_active_for_request(UUID.t) :: List.t
+  @spec all_active_for_request(UUID.t()) :: List.t()
   def all_active_for_request(request_uuid) do
     TransactionConsumption
     |> where([t], t.status == @confirmed)
@@ -192,7 +249,7 @@ defmodule EWalletDB.TransactionConsumption do
   @doc """
   Inserts a transaction request consumption.
   """
-  @spec insert(Map.t) :: {:ok, %TransactionConsumption{}} | {:error, Map.t}
+  @spec insert(Map.t()) :: {:ok, %TransactionConsumption{}} | {:error, Map.t()}
   def insert(attrs) do
     changeset = changeset(%TransactionConsumption{}, attrs)
     opts = [on_conflict: :nothing, conflict_target: :idempotency_token]
@@ -200,6 +257,7 @@ defmodule EWalletDB.TransactionConsumption do
     case Repo.insert(changeset, opts) do
       {:ok, consumption} ->
         {:ok, get_by(%{idempotency_token: consumption.idempotency_token})}
+
       error ->
         error
     end
@@ -250,13 +308,15 @@ defmodule EWalletDB.TransactionConsumption do
   end
 
   defp state_transition(consumption, status, transfer_uuid \\ nil) do
-    fun              = String.to_existing_atom("#{status}_changeset")
+    fun = String.to_existing_atom("#{status}_changeset")
     timestamp_column = String.to_existing_atom("#{status}_at")
 
-    data = %{
-      status: status,
-      transfer_uuid: transfer_uuid
-    } |> Map.put(timestamp_column, NaiveDateTime.utc_now())
+    data =
+      %{
+        status: status,
+        transfer_uuid: transfer_uuid
+      }
+      |> Map.put(timestamp_column, NaiveDateTime.utc_now())
 
     {:ok, consumption} =
       __MODULE__

--- a/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
@@ -8,68 +8,112 @@ defmodule EWalletDB.TransactionRequest do
   import EWalletDB.Helpers.Preloader
   alias Ecto.{UUID, Changeset}
 
-  alias EWalletDB.{Account, Balance, MintedToken, TransactionRequest,
-                   TransactionConsumption, Repo, User}
+  alias EWalletDB.{
+    Account,
+    Balance,
+    MintedToken,
+    TransactionRequest,
+    TransactionConsumption,
+    Repo,
+    User
+  }
 
   @valid "valid"
   @expired "expired"
   @statuses [@valid, @expired]
 
-  @send    "send"
+  @send "send"
   @receive "receive"
-  @types   [@send, @receive]
+  @types [@send, @receive]
 
   @primary_key {:uuid, Ecto.UUID, autogenerate: true}
 
   schema "transaction_request" do
-    external_id prefix: "txr_"
+    external_id(prefix: "txr_")
 
-    field :type, :string
-    field :amount, EWalletDB.Types.Integer
-    field :status, :string, default: @valid # valid -> expired
-    field :correlation_id, :string
+    field(:type, :string)
+    field(:amount, EWalletDB.Types.Integer)
+    # valid -> expired
+    field(:status, :string, default: @valid)
+    field(:correlation_id, :string)
 
-    field :require_confirmation, :boolean, default: false
-    field :max_consumptions, :integer # nil -> unlimited
-    field :consumption_lifetime, :integer # milliseconds
-    field :expiration_date, :naive_datetime
-    field :expired_at, :naive_datetime
-    field :expiration_reason, :string
-    field :allow_amount_override, :boolean, default: true
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
+    field(:require_confirmation, :boolean, default: false)
+    # nil -> unlimited
+    field(:max_consumptions, :integer)
+    # milliseconds
+    field(:consumption_lifetime, :integer)
+    field(:expiration_date, :naive_datetime)
+    field(:expired_at, :naive_datetime)
+    field(:expiration_reason, :string)
+    field(:allow_amount_override, :boolean, default: true)
+    field(:metadata, :map, default: %{})
+    field(:encrypted_metadata, Cloak.EncryptedMapField, default: %{})
 
-    has_many :consumptions, TransactionConsumption, foreign_key: :transaction_request_uuid,
-                                                    references: :uuid
+    has_many(
+      :consumptions,
+      TransactionConsumption,
+      foreign_key: :transaction_request_uuid,
+      references: :uuid
+    )
 
-    belongs_to :user, User, foreign_key: :user_uuid,
-                                         references: :uuid,
-                                         type: UUID
+    belongs_to(
+      :user,
+      User,
+      foreign_key: :user_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
-    belongs_to :account, Account, foreign_key: :account_uuid,
-                                  references: :uuid,
-                                  type: UUID
+    belongs_to(
+      :account,
+      Account,
+      foreign_key: :account_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
-    belongs_to :minted_token, MintedToken, foreign_key: :minted_token_uuid,
-                                           references: :uuid,
-                                           type: UUID
+    belongs_to(
+      :minted_token,
+      MintedToken,
+      foreign_key: :minted_token_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
-    belongs_to :balance, Balance, foreign_key: :balance_address,
-                                  references: :address,
-                                  type: :string
+    belongs_to(
+      :balance,
+      Balance,
+      foreign_key: :balance_address,
+      references: :address,
+      type: :string
+    )
+
     timestamps()
   end
 
   defp changeset(%TransactionRequest{} = transaction_request, attrs) do
     transaction_request
     |> cast(attrs, [
-      :type, :amount, :correlation_id, :user_uuid, :account_uuid,
-      :minted_token_uuid, :balance_address, :require_confirmation, :max_consumptions,
-      :consumption_lifetime, :expiration_date, :metadata, :encrypted_metadata,
+      :type,
+      :amount,
+      :correlation_id,
+      :user_uuid,
+      :account_uuid,
+      :minted_token_uuid,
+      :balance_address,
+      :require_confirmation,
+      :max_consumptions,
+      :consumption_lifetime,
+      :expiration_date,
+      :metadata,
+      :encrypted_metadata,
       :allow_amount_override
     ])
     |> validate_required([
-      :type, :status, :minted_token_uuid, :balance_address
+      :type,
+      :status,
+      :minted_token_uuid,
+      :balance_address
     ])
     |> validate_amount_if_disallow_override()
     |> validate_inclusion(:type, @types)
@@ -79,7 +123,7 @@ defmodule EWalletDB.TransactionRequest do
     |> assoc_constraint(:user)
     |> assoc_constraint(:balance)
     |> assoc_constraint(:account)
-    |> put_change(:encryption_version, Cloak.version)
+    |> put_change(:encryption_version, Cloak.version())
   end
 
   defp expire_changeset(%TransactionRequest{} = transaction_request, attrs) do
@@ -96,28 +140,31 @@ defmodule EWalletDB.TransactionRequest do
   end
 
   defp validate_amount_if_disallow_override(changeset) do
-    amount                = Changeset.get_field(changeset, :amount)
+    amount = Changeset.get_field(changeset, :amount)
     allow_amount_override = Changeset.get_field(changeset, :allow_amount_override)
 
     validate_amount_if_disallow_override(changeset, allow_amount_override, amount)
   end
+
   defp validate_amount_if_disallow_override(changeset, false, nil) do
-    Changeset.add_error(changeset,
-                        :amount, "needs to be set if amount override is not allowed.")
+    Changeset.add_error(changeset, :amount, "needs to be set if amount override is not allowed.")
   end
+
   defp validate_amount_if_disallow_override(changeset, _, _amount), do: changeset
 
   @doc """
   Gets a transaction request.
   """
-  @spec get(ExternalID.t) :: %TransactionRequest{} | nil
-  @spec get(ExternalID.t, keyword()) :: %TransactionRequest{} | nil
+  @spec get(ExternalID.t()) :: %TransactionRequest{} | nil
+  @spec get(ExternalID.t(), keyword()) :: %TransactionRequest{} | nil
   def get(id, opts \\ [])
+
   def get(id, opts) when is_external_id(id) do
     TransactionRequest
     |> Repo.get_by(id: id)
     |> preload_option(opts)
   end
+
   def get(_id, _opts), do: nil
 
   @doc """
@@ -131,11 +178,13 @@ defmodule EWalletDB.TransactionRequest do
     |> where([t], t.status == @valid)
     |> where([t], not is_nil(t.expiration_date))
     |> where([t], t.expiration_date <= ^now)
-    |> Repo.update_all(set: [
-      status: @expired,
-      expired_at: NaiveDateTime.utc_now(),
-      expiration_reason: "expired_transaction_request"
-    ])
+    |> Repo.update_all(
+      set: [
+        status: @expired,
+        expired_at: NaiveDateTime.utc_now(),
+        expiration_reason: "expired_transaction_request"
+      ]
+    )
   end
 
   @doc """
@@ -148,13 +197,15 @@ defmodule EWalletDB.TransactionRequest do
     |> lock("FOR UPDATE")
     |> Repo.one()
   end
+
   def get_with_lock(_), do: nil
 
   @doc """
   Touches a request by updating the `updated_at` field.
   """
-  @spec touch(%TransactionRequest{}) :: {:ok, %TransactionRequest{}} |
-                                                {:error, Map.t}
+  @spec touch(%TransactionRequest{}) ::
+          {:ok, %TransactionRequest{}}
+          | {:error, Map.t()}
   def touch(request) do
     request
     |> touch_changeset(%{updated_at: NaiveDateTime.utc_now()})
@@ -164,7 +215,7 @@ defmodule EWalletDB.TransactionRequest do
   @doc """
   Inserts a transaction request.
   """
-  @spec insert(Map.t) :: {:ok, %TransactionRequest{}} | {:error, Map.t}
+  @spec insert(Map.t()) :: {:ok, %TransactionRequest{}} | {:error, Map.t()}
   def insert(attrs) do
     %TransactionRequest{}
     |> changeset(attrs)
@@ -174,7 +225,7 @@ defmodule EWalletDB.TransactionRequest do
   @doc """
   Updates a transaction request.
   """
-  @spec insert(Map.t) :: {:ok, %TransactionRequest{}} | {:error, Map.t}
+  @spec insert(Map.t()) :: {:ok, %TransactionRequest{}} | {:error, Map.t()}
   def update(%TransactionRequest{} = request, attrs) do
     request
     |> changeset(attrs)
@@ -191,25 +242,26 @@ defmodule EWalletDB.TransactionRequest do
     request.status == @expired
   end
 
-  @spec expiration_from_lifetime(%TransactionRequest{}) :: NaiveDateTime.t | nil
+  @spec expiration_from_lifetime(%TransactionRequest{}) :: NaiveDateTime.t() | nil
   def expiration_from_lifetime(request) do
     lifetime? =
-      request.require_confirmation &&
-      request.consumption_lifetime &&
-      request.consumption_lifetime > 0
+      request.require_confirmation && request.consumption_lifetime &&
+        request.consumption_lifetime > 0
 
     case lifetime? do
-      true  ->
+      true ->
         NaiveDateTime.utc_now()
         |> NaiveDateTime.add(request.consumption_lifetime, :millisecond)
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
   @doc """
   Expires the given request with the specified reason.
   """
-  @spec expire(%TransactionRequest{}) :: {:ok, %TransactionRequest{}} | {:error, Map.t}
+  @spec expire(%TransactionRequest{}) :: {:ok, %TransactionRequest{}} | {:error, Map.t()}
   def expire(request, reason \\ "expired_transaction_request") do
     request
     |> expire_changeset(%{
@@ -224,36 +276,37 @@ defmodule EWalletDB.TransactionRequest do
   Expires the given request if the expiration date is past.
   """
   @spec expire_if_past_expiration_date(%TransactionRequest{}) ::
-                                       {:ok, %TransactionRequest{}} | {:error, Map.t}
+          {:ok, %TransactionRequest{}} | {:error, Map.t()}
   def expire_if_past_expiration_date(request) do
-    expired? = request.expiration_date &&
-               NaiveDateTime.compare(request.expiration_date, NaiveDateTime.utc_now()) == :lt
+    expired? =
+      request.expiration_date &&
+        NaiveDateTime.compare(request.expiration_date, NaiveDateTime.utc_now()) == :lt
 
     case expired? do
-      true  -> expire(request)
-      _     -> {:ok, request}
+      true -> expire(request)
+      _ -> {:ok, request}
     end
   end
 
   @doc """
   Expires the given request if the maximum number of consumptions has been reached.
   """
-  @spec expire_if_max_consumption(%TransactionRequest{}) :: {:ok, %TransactionRequest{}} |
-                                                            {:error, Map.t}
+  @spec expire_if_max_consumption(%TransactionRequest{}) ::
+          {:ok, %TransactionRequest{}}
+          | {:error, Map.t()}
   def expire_if_max_consumption(request) do
     consumptions = TransactionConsumption.all_active_for_request(request.uuid)
 
     case max_consumptions_reached?(request, consumptions) do
-      true  -> expire(request, "max_consumptions_reached")
+      true -> expire(request, "max_consumptions_reached")
       false -> touch(request)
     end
   end
 
   @spec max_consumptions_reached?(%TransactionRequest{}, list(%TransactionConsumption{})) ::
-    true | false
+          true | false
   defp max_consumptions_reached?(request, consumptions) do
-    limited_consumptions?(request) &&
-    length(consumptions) >= request.max_consumptions
+    limited_consumptions?(request) && length(consumptions) >= request.max_consumptions
   end
 
   @spec limited_consumptions?(%TransactionRequest{}) :: true | false

--- a/apps/ewallet_db/lib/ewallet_db/transfer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transfer.ex
@@ -26,41 +26,75 @@ defmodule EWalletDB.Transfer do
   @primary_key {:uuid, UUID, autogenerate: true}
 
   schema "transfer" do
-    external_id prefix: "tfr_"
+    external_id(prefix: "tfr_")
 
-    field :idempotency_token, :string
-    field :amount, EWalletDB.Types.Integer
-    field :status, :string, default: @pending # pending -> confirmed
-    field :type, :string, default: @internal # internal / external
-    field :payload, Cloak.EncryptedMapField # Payload received from client
-    field :ledger_response, Cloak.EncryptedMapField # Response returned by ledger
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
-    field :encryption_version, :binary
+    field(:idempotency_token, :string)
+    field(:amount, EWalletDB.Types.Integer)
+    # pending -> confirmed
+    field(:status, :string, default: @pending)
+    # internal / external
+    field(:type, :string, default: @internal)
+    # Payload received from client
+    field(:payload, Cloak.EncryptedMapField)
+    # Response returned by ledger
+    field(:ledger_response, Cloak.EncryptedMapField)
+    field(:metadata, :map, default: %{})
+    field(:encrypted_metadata, Cloak.EncryptedMapField, default: %{})
+    field(:encryption_version, :binary)
 
-    belongs_to :minted_token, MintedToken, foreign_key: :minted_token_uuid,
-                                           references: :uuid,
-                                           type: UUID
+    belongs_to(
+      :minted_token,
+      MintedToken,
+      foreign_key: :minted_token_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
-    belongs_to :to_balance, Balance, foreign_key: :to,
-                                     references: :address,
-                                     type: :string
+    belongs_to(
+      :to_balance,
+      Balance,
+      foreign_key: :to,
+      references: :address,
+      type: :string
+    )
 
-    belongs_to :from_balance, Balance, foreign_key: :from,
-                                       references: :address,
-                                       type: :string
+    belongs_to(
+      :from_balance,
+      Balance,
+      foreign_key: :from,
+      references: :address,
+      type: :string
+    )
+
     timestamps()
   end
 
   defp changeset(%Transfer{} = transfer, attrs) do
     transfer
     |> cast(attrs, [
-      :idempotency_token, :status, :type, :payload, :ledger_response, :metadata,
-      :encrypted_metadata, :amount, :minted_token_uuid, :to, :from
+      :idempotency_token,
+      :status,
+      :type,
+      :payload,
+      :ledger_response,
+      :metadata,
+      :encrypted_metadata,
+      :amount,
+      :minted_token_uuid,
+      :to,
+      :from
     ])
     |> validate_required([
-      :idempotency_token, :status, :type, :payload, :amount,
-      :minted_token_uuid, :to, :from, :metadata, :encrypted_metadata
+      :idempotency_token,
+      :status,
+      :type,
+      :payload,
+      :amount,
+      :minted_token_uuid,
+      :to,
+      :from,
+      :metadata,
+      :encrypted_metadata
     ])
     |> validate_inclusion(:status, @statuses)
     |> validate_inclusion(:type, @types)
@@ -69,14 +103,14 @@ defmodule EWalletDB.Transfer do
     |> assoc_constraint(:minted_token)
     |> assoc_constraint(:to_balance)
     |> assoc_constraint(:from_balance)
-    |> put_change(:encryption_version, Cloak.version)
+    |> put_change(:encryption_version, Cloak.version())
   end
 
   @doc """
   Gets all transfers for the given address.
   """
   def all_for_address(address) do
-    from t in Transfer, where: (t.from == ^address) or (t.to == ^address)
+    from(t in Transfer, where: t.from == ^address or t.to == ^address)
   end
 
   @doc """
@@ -86,6 +120,7 @@ defmodule EWalletDB.Transfer do
     case get_by_idempotency_token(idempotency_token) do
       nil ->
         insert(attrs)
+
       transfer ->
         {:ok, transfer}
     end
@@ -97,9 +132,11 @@ defmodule EWalletDB.Transfer do
   @spec get(ExternalID.t()) :: %Transfer{} | nil
   @spec get(ExternalID.t(), keyword()) :: %Transfer{} | nil
   def get(id, opts \\ [])
+
   def get(id, opts) when is_external_id(id) do
     get_by([id: id], opts)
   end
+
   def get(_id, _opts), do: nil
 
   @doc """
@@ -110,7 +147,7 @@ defmodule EWalletDB.Transfer do
     query = Transfer |> Repo.get_by(map)
 
     case opts[:preload] do
-      nil     -> query
+      nil -> query
       preload -> Repo.preload(query, preload)
     end
   end
@@ -119,11 +156,14 @@ defmodule EWalletDB.Transfer do
   Helper function to get a transfer with an idempotency token and loads all the required
   associations.
   """
-  @spec get_by_idempotency_token(String.t) :: %Transfer{} | nil
+  @spec get_by_idempotency_token(String.t()) :: %Transfer{} | nil
   def get_by_idempotency_token(idempotency_token) do
-    get_by(%{
-      idempotency_token: idempotency_token
-    }, preload: [:from_balance, :to_balance, :minted_token])
+    get_by(
+      %{
+        idempotency_token: idempotency_token
+      },
+      preload: [:from_balance, :to_balance, :minted_token]
+    )
   end
 
   @doc """
@@ -133,9 +173,11 @@ defmodule EWalletDB.Transfer do
   def insert(attrs) do
     changeset = changeset(%Transfer{}, attrs)
     opts = [on_conflict: :nothing, conflict_target: :idempotency_token]
+
     case Repo.insert(changeset, opts) do
       {:ok, transfer} ->
         {:ok, get_by_idempotency_token(transfer.idempotency_token)}
+
       changeset ->
         changeset
     end

--- a/apps/ewallet_db/lib/ewallet_db/types/external_id.ex
+++ b/apps/ewallet_db/lib/ewallet_db/types/external_id.ex
@@ -31,29 +31,33 @@ defmodule EWalletDB.Types.ExternalID do
   Returns `{:ok, value}` on successful casting where `value` is a string of 3-character symbol,
   an underscore and 26-character ULID string. Returns `:error` on failure.
   """
-  @spec cast(String.t) :: {:ok, String.t} | :error
+  @spec cast(String.t()) :: {:ok, String.t()} | :error
   def cast(<<_::bytes-size(3), "_", _::bytes-size(26)>> = ulid_string) do
     {:ok, String.downcase(ulid_string)}
   end
+
   def cast(_), do: :error
 
   @doc """
   Transforms the value after loaded from the database.
   """
-  @spec load(String.t) :: {:ok, String.t}
+  @spec load(String.t()) :: {:ok, String.t()}
   def load(value), do: {:ok, value}
 
   @doc """
   Prepares the value for saving to database.
   """
-  @spec dump(String.t) :: {:ok, String.t}
+  @spec dump(String.t()) :: {:ok, String.t()}
   def dump(value), do: {:ok, value}
 
   # The defaults to use to define the External ID field.
   @external_id_defaults [
-    field_name: :id, # The field name
-    prefix: "", # The prefix to prepend to the generated ULID
-    autogenerate: nil # The function to use for autogenerating the value
+    # The field name
+    field_name: :id,
+    # The prefix to prepend to the generated ULID
+    prefix: "",
+    # The function to use for autogenerating the value
+    autogenerate: nil
   ]
 
   @doc """
@@ -87,14 +91,15 @@ defmodule EWalletDB.Types.ExternalID do
 
   Returns a ULID if the prefix is not given, otherwise prepends the ULID with the given prefix.
   """
-  @spec generate(String.t) :: String.t
-  def generate(<<symbol::bytes-size(3), "_" >> = prefix) do
+  @spec generate(String.t()) :: String.t()
+  def generate(<<symbol::bytes-size(3), "_">> = prefix) do
     if String.match?(symbol, ~r/^[0-9a-z]{3}$/) do
       String.downcase(prefix <> ULID.generate())
     else
       :error
     end
   end
+
   def generate(_), do: :error
 
   # Callback invoked by autogenerate fields.
@@ -105,9 +110,11 @@ defmodule EWalletDB.Types.ExternalID do
   # Ref: https://stackoverflow.com/questions/21261696/create-new-guard-clause
   defmacro is_external_id(id) do
     quote do
-      is_binary(unquote(id)) # is a string
-      and binary_part(unquote(id), 3, 1) == "_" # 4th character is an underscore
-      and byte_size(unquote(id)) == 30 # 3-char symbol, 1-char underscore, 26-char ULID
+      # is a string
+      # 4th character is an underscore
+      # 3-char symbol, 1-char underscore, 26-char ULID
+      is_binary(unquote(id)) and binary_part(unquote(id), 3, 1) == "_" and
+        byte_size(unquote(id)) == 30
     end
   end
 

--- a/apps/ewallet_db/lib/ewallet_db/uploaders/avatar.ex
+++ b/apps/ewallet_db/lib/ewallet_db/uploaders/avatar.ex
@@ -5,7 +5,7 @@ defmodule EWalletDB.Uploaders.Avatar do
   use Arc.Definition
   use Arc.Ecto.Definition
 
-  @acl      :public_read
+  @acl :public_read
   @versions [:original, :large, :small, :thumb]
 
   def validate({file, _}) do
@@ -30,7 +30,7 @@ defmodule EWalletDB.Uploaders.Avatar do
 
   # Override the storage directory:
   def storage_dir(_version, {_file, scope}) do
-    "public/uploads/#{Mix.env}/#{get_schema_name(scope)}/avatars/#{scope.id}"
+    "public/uploads/#{Mix.env()}/#{get_schema_name(scope)}/avatars/#{scope.id}"
   end
 
   defp get_schema_name(scope) do

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -354,7 +354,7 @@ defmodule EWalletDB.User do
       r in Role,
       join:
         account_tree in fragment(
-          """
+          ~s/
             WITH RECURSIVE account_tree AS (
               SELECT a.*, m.role_uuid, m.user_uuid
               FROM account a
@@ -370,7 +370,7 @@ defmodule EWalletDB.User do
             JOIN "role" AS r ON r.uuid = role_uuid
             JOIN "user" AS u ON u.uuid = user_uuid
             WHERE u.id = ? LIMIT 1
-          """,
+          /,
           ^account_id,
           ^user_id
         ),

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -8,49 +8,93 @@ defmodule EWalletDB.User do
   import Ecto.{Changeset, Query}
   import EWalletDB.Validator
   alias Ecto.{Multi, UUID}
-  alias EWalletDB.{Repo, Account, AuthToken, Balance, Invite,
-                   Membership, Role, User, Helpers.Crypto}
+
+  alias EWalletDB.{
+    Repo,
+    Account,
+    AuthToken,
+    Balance,
+    Invite,
+    Membership,
+    Role,
+    User,
+    Helpers.Crypto
+  }
 
   @primary_key {:uuid, UUID, autogenerate: true}
 
   schema "user" do
-    external_id prefix: "usr_"
+    external_id(prefix: "usr_")
 
-    field :username, :string
-    field :email, :string
-    field :password, :string, virtual: true
-    field :password_confirmation, :string, virtual: true
-    field :password_hash, :string
-    field :provider_user_id, :string
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
-    field :encryption_version, :binary
-    field :avatar, EWalletDB.Uploaders.Avatar.Type
+    field(:username, :string)
+    field(:email, :string)
+    field(:password, :string, virtual: true)
+    field(:password_confirmation, :string, virtual: true)
+    field(:password_hash, :string)
+    field(:provider_user_id, :string)
+    field(:metadata, :map, default: %{})
+    field(:encrypted_metadata, Cloak.EncryptedMapField, default: %{})
+    field(:encryption_version, :binary)
+    field(:avatar, EWalletDB.Uploaders.Avatar.Type)
 
-    belongs_to :invite, Invite, foreign_key: :invite_uuid,
-                                references: :uuid,
-                                type: UUID
+    belongs_to(
+      :invite,
+      Invite,
+      foreign_key: :invite_uuid,
+      references: :uuid,
+      type: UUID
+    )
 
-    has_many :balances, Balance, foreign_key: :user_uuid,
-                                 references: :uuid
-    has_many :auth_tokens, AuthToken, foreign_key: :user_uuid,
-                                      references: :uuid
-    has_many :memberships, Membership, foreign_key: :user_uuid,
-                                       references: :uuid
+    has_many(
+      :balances,
+      Balance,
+      foreign_key: :user_uuid,
+      references: :uuid
+    )
 
-    many_to_many :roles, Role, join_through: Membership,
-                               join_keys: [user_uuid: :uuid, role_uuid: :uuid]
-    many_to_many :accounts, Account, join_through: Membership,
-                                     join_keys: [user_uuid: :uuid, account_uuid: :uuid]
+    has_many(
+      :auth_tokens,
+      AuthToken,
+      foreign_key: :user_uuid,
+      references: :uuid
+    )
+
+    has_many(
+      :memberships,
+      Membership,
+      foreign_key: :user_uuid,
+      references: :uuid
+    )
+
+    many_to_many(
+      :roles,
+      Role,
+      join_through: Membership,
+      join_keys: [user_uuid: :uuid, role_uuid: :uuid]
+    )
+
+    many_to_many(
+      :accounts,
+      Account,
+      join_through: Membership,
+      join_keys: [user_uuid: :uuid, account_uuid: :uuid]
+    )
 
     timestamps()
   end
 
   defp changeset(changeset, attrs) do
     changeset
-    |> cast(attrs, [:username, :provider_user_id, :email, :password,
-                    :password_confirmation, :metadata, :encrypted_metadata,
-                    :invite_uuid])
+    |> cast(attrs, [
+      :username,
+      :provider_user_id,
+      :email,
+      :password,
+      :password_confirmation,
+      :metadata,
+      :encrypted_metadata,
+      :invite_uuid
+    ])
     |> validate_required([:metadata, :encrypted_metadata])
     |> validate_confirmation(:password, message: "does not match password!")
     |> validate_immutable(:provider_user_id)
@@ -59,7 +103,7 @@ defmodule EWalletDB.User do
     |> unique_constraint(:email)
     |> assoc_constraint(:invite)
     |> put_change(:password_hash, Crypto.hash_password(attrs[:password]))
-    |> put_change(:encryption_version, Cloak.version)
+    |> put_change(:encryption_version, Cloak.version())
     |> validate_by_roles(attrs)
   end
 
@@ -82,8 +126,10 @@ defmodule EWalletDB.User do
     cond do
       user.email != nil ->
         do_validate_loginable(changeset, attrs)
+
       User.has_membership?(user) ->
         do_validate_loginable(changeset, attrs)
+
       true ->
         do_validate_provider_user(changeset, attrs)
     end
@@ -104,6 +150,7 @@ defmodule EWalletDB.User do
   """
   def addresses(user) do
     user = user |> Repo.preload(:balances)
+
     Enum.map(user.balances, fn balance ->
       balance.address
     end)
@@ -115,17 +162,20 @@ defmodule EWalletDB.User do
   @spec get(ExternalID.t()) :: %User{} | nil
   @spec get(ExternalID.t(), Ecto.Queryable.t()) :: %User{} | nil
   def get(id, queryable \\ User)
+
   def get(id, queryable) when is_external_id(id) do
     queryable
     |> Repo.get_by(id: id)
     |> Repo.preload(:balances)
   end
+
   def get(_, _), do: nil
 
   @doc """
   Retrieves a specific user from its provider_user_id.
   """
   def get_by_provider_user_id(nil), do: nil
+
   def get_by_provider_user_id(provider_user_id) do
     User
     |> Repo.get_by(provider_user_id: provider_user_id)
@@ -153,16 +203,17 @@ defmodule EWalletDB.User do
   """
   def insert(attrs) do
     multi =
-      Multi.new
+      Multi.new()
       |> Multi.insert(:user, changeset(%User{}, attrs))
       |> Multi.run(:balance, fn %{user: user} ->
-        insert_balance(user, Balance.primary)
+        insert_balance(user, Balance.primary())
       end)
 
     case Repo.transaction(multi) do
       {:ok, result} ->
         user = result.user |> Repo.preload([:balances])
         {:ok, user}
+
       # Only the account insertion should fail. If the balance insert fails, there is
       # something wrong with our code.
       {:error, _failed_operation, changeset, _changes_so_far} ->
@@ -191,6 +242,7 @@ defmodule EWalletDB.User do
     case Repo.update(changeset) do
       {:ok, user} ->
         {:ok, get(user.id)}
+
       result ->
         result
     end
@@ -202,15 +254,16 @@ defmodule EWalletDB.User do
   def store_avatar(%User{} = user, attrs) do
     attrs =
       case attrs["avatar"] do
-        ""     -> %{avatar: nil}
+        "" -> %{avatar: nil}
         "null" -> %{avatar: nil}
         avatar -> %{avatar: avatar}
       end
 
     changeset = avatar_changeset(user, attrs)
+
     case Repo.update(changeset) do
       {:ok, user} -> get(user.id)
-      result      -> result
+      result -> result
     end
   end
 
@@ -220,7 +273,7 @@ defmodule EWalletDB.User do
   def get_primary_balance(user) do
     Balance
     |> where([b], b.user_uuid == ^user.uuid)
-    |> where([b], b.identifier == ^Balance.primary)
+    |> where([b], b.identifier == ^Balance.primary())
     |> Repo.one()
   end
 
@@ -228,7 +281,7 @@ defmodule EWalletDB.User do
   Retrieve the primary balance for a user with preloaded balances.
   """
   def get_preloaded_primary_balance(user) do
-    Enum.find(user.balances, fn balance -> balance.identifier == Balance.primary end)
+    Enum.find(user.balances, fn balance -> balance.identifier == Balance.primary() end)
   end
 
   @doc """
@@ -253,6 +306,7 @@ defmodule EWalletDB.User do
   # User does not have any membership if it has not been saved yet.
   # Without pattern matching for nil id, Ecto will return an unsafe nil comparison error.
   def has_membership?(%{uuid: nil}), do: false
+
   def has_membership?(user) do
     query = from(m in Membership, where: m.user_uuid == ^user.uuid)
     Repo.aggregate(query, :count, :uuid) > 0
@@ -277,7 +331,7 @@ defmodule EWalletDB.User do
     user
     |> Repo.preload(:roles)
     |> Map.get(:roles, [])
-    |> Enum.map(fn(role) -> Map.fetch!(role, :name) end)
+    |> Enum.map(fn role -> Map.fetch!(role, :name) end)
     |> Enum.uniq()
   end
 
@@ -296,37 +350,45 @@ defmodule EWalletDB.User do
 
   defp query_role(user_id, account_id) do
     # Traverses up the account tree to find the user's role in the closest parent.
-    from r in Role,
-      join: account_tree in fragment("""
-        WITH RECURSIVE account_tree AS (
-          SELECT a.*, m.role_uuid, m.user_uuid
-          FROM account a
-          LEFT JOIN membership AS m ON m.account_uuid = a.uuid
-          WHERE a.id = ?
-        UNION
-          SELECT parent.*, m.role_uuid, m.user_uuid
-          FROM account parent
-          LEFT JOIN membership AS m ON m.account_uuid = parent.uuid
-          JOIN account_tree ON account_tree.parent_uuid = parent.uuid
-        )
-        SELECT role_uuid FROM account_tree
-        JOIN "role" AS r ON r.uuid = role_uuid
-        JOIN "user" AS u ON u.uuid = user_uuid
-        WHERE u.id = ? LIMIT 1
-      """,
-        ^account_id,
-        ^user_id
-      ), on: r.uuid == account_tree.role_uuid,
+    from(
+      r in Role,
+      join:
+        account_tree in fragment(
+          """
+            WITH RECURSIVE account_tree AS (
+              SELECT a.*, m.role_uuid, m.user_uuid
+              FROM account a
+              LEFT JOIN membership AS m ON m.account_uuid = a.uuid
+              WHERE a.id = ?
+            UNION
+              SELECT parent.*, m.role_uuid, m.user_uuid
+              FROM account parent
+              LEFT JOIN membership AS m ON m.account_uuid = parent.uuid
+              JOIN account_tree ON account_tree.parent_uuid = parent.uuid
+            )
+            SELECT role_uuid FROM account_tree
+            JOIN "role" AS r ON r.uuid = role_uuid
+            JOIN "user" AS u ON u.uuid = user_uuid
+            WHERE u.id = ? LIMIT 1
+          """,
+          ^account_id,
+          ^user_id
+        ),
+      on: r.uuid == account_tree.role_uuid,
       select: r.name
+    )
   end
 
   @doc """
   Retrieves the upper-most account that the given user has membership in.
   """
   def get_account(user) do
-    query = from [q, child] in query_accounts(user),
-      order_by: [asc: child.depth],
-      limit: 1
+    query =
+      from(
+        [q, child] in query_accounts(user),
+        order_by: [asc: child.depth],
+        limit: 1
+      )
 
     Repo.one(query)
   end
@@ -347,23 +409,28 @@ defmodule EWalletDB.User do
     account_uuids =
       user
       |> Membership.all_by_user()
-      |> Enum.map(fn(m) -> Map.fetch!(m, :account_uuid) end)
+      |> Enum.map(fn m -> Map.fetch!(m, :account_uuid) end)
 
     # Traverses down the account tree
-    from a in Account,
-      join: child in fragment("""
-        WITH RECURSIVE account_tree AS (
-          SELECT account.*, 0 AS depth
-          FROM account
-          WHERE account.uuid = ANY(?)
-        UNION
-          SELECT child.*, account_tree.depth + 1 as depth
-          FROM account child
-          JOIN account_tree ON account_tree.uuid = child.parent_uuid
-        ) SELECT * FROM account_tree
-      """,
-        type(^account_uuids, {:array, UUID})
-      ), on: a.uuid == child.uuid,
+    from(
+      a in Account,
+      join:
+        child in fragment(
+          """
+            WITH RECURSIVE account_tree AS (
+              SELECT account.*, 0 AS depth
+              FROM account
+              WHERE account.uuid = ANY(?)
+            UNION
+              SELECT child.*, account_tree.depth + 1 as depth
+              FROM account child
+              JOIN account_tree ON account_tree.uuid = child.parent_uuid
+            ) SELECT * FROM account_tree
+          """,
+          type(^account_uuids, {:array, UUID})
+        ),
+      on: a.uuid == child.uuid,
       select: %{a | relative_depth: child.depth}
+    )
   end
 end

--- a/apps/ewallet_db/lib/ewallet_db/user_query.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user_query.ex
@@ -13,6 +13,7 @@ defmodule EWalletDB.UserQuery do
     queryable
     |> join(:inner, [u], m in Membership, u.uuid == m.user_uuid)
     |> distinct(true)
-    |> select([c], c) # Returns only the User struct, not the Memberships
+    # Returns only the User struct, not the Memberships
+    |> select([c], c)
   end
 end

--- a/apps/ewallet_db/lib/ewallet_db/validator.ex
+++ b/apps/ewallet_db/lib/ewallet_db/validator.ex
@@ -13,8 +13,10 @@ defmodule EWalletDB.Validator do
     case count_fields_present(changeset, attrs) do
       1 ->
         changeset
+
       n when n > 1 ->
         Changeset.add_error(changeset, attrs, "only one must be present")
+
       _ ->
         Changeset.add_error(changeset, attrs, "can't all be blank")
     end
@@ -25,31 +27,36 @@ defmodule EWalletDB.Validator do
   """
   def validate_required_all_or_none(changeset, attrs) do
     num_attrs = Enum.count(attrs)
-    missing_attrs = Enum.filter(attrs, fn(attr) -> !field_present?(changeset, attr) end)
+    missing_attrs = Enum.filter(attrs, fn attr -> !field_present?(changeset, attr) end)
 
     case Enum.count(missing_attrs) do
       0 ->
         changeset
+
       ^num_attrs ->
         changeset
+
       _ ->
         Changeset.add_error(
           changeset,
           attrs,
           "either all or none of them must be present",
-          [validation: "all_or_none"])
+          validation: "all_or_none"
+        )
     end
   end
 
   def count_fields_present(changeset, attrs) do
-    Enum.count(attrs, fn(attr) -> field_present?(changeset, attr) end)
+    Enum.count(attrs, fn attr -> field_present?(changeset, attr) end)
   end
 
   def field_present?(changeset, attr) when is_atom(attr) do
     value = Changeset.get_field(changeset, attr)
     value && value != ""
   end
+
   def field_present?(changeset, {attr, nil}), do: field_present?(changeset, attr)
+
   def field_present?(changeset, {attr, attr_value}) do
     value = Changeset.get_field(changeset, attr)
     value && value != "" && value == attr_value
@@ -72,6 +79,7 @@ defmodule EWalletDB.Validator do
   Validates the given string with the password requirements.
   """
   def validate_password(nil), do: {:error, :too_short, [min_length: @min_password_length]}
+
   def validate_password(password) do
     with len when len >= @min_password_length <- String.length(password) do
       {:ok, password}
@@ -89,8 +97,10 @@ defmodule EWalletDB.Validator do
     case validate_password(password) do
       {:ok, _} ->
         changeset
+
       {:error, :too_short, data} ->
         Changeset.add_error(changeset, key, "must be #{data[:min_length]} characters or more")
+
       {:error, _} ->
         Changeset.add_error(changeset, key, "does not meet the password requirements")
     end

--- a/apps/ewallet_db/test/ewallet_db/account_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/account_test.exs
@@ -4,20 +4,20 @@ defmodule EWalletDB.AccountTest do
   alias EWalletDB.Account
 
   describe "Account factory" do
-    test_has_valid_factory Account
-    test_encrypted_map_field Account, "account", :encrypted_metadata
+    test_has_valid_factory(Account)
+    test_encrypted_map_field(Account, "account", :encrypted_metadata)
   end
 
   describe "Account.insert/1" do
-    test_insert_generate_uuid Account, :uuid
-    test_insert_generate_external_id Account, :id, "acc_"
-    test_insert_generate_timestamps Account
-    test_insert_prevent_blank Account, :name
-    test_insert_prevent_duplicate Account, :name
-    test_default_metadata_fields Account, "account"
+    test_insert_generate_uuid(Account, :uuid)
+    test_insert_generate_external_id(Account, :id, "acc_")
+    test_insert_generate_timestamps(Account)
+    test_insert_prevent_blank(Account, :name)
+    test_insert_prevent_duplicate(Account, :name)
+    test_default_metadata_fields(Account, "account")
 
     test "inserts a non-master account by default" do
-      {:ok, account} = :account |> params_for() |> Account.insert
+      {:ok, account} = :account |> params_for() |> Account.insert()
       refute Account.master?(account)
     end
 
@@ -25,15 +25,18 @@ defmodule EWalletDB.AccountTest do
       {res, changeset} =
         :account
         |> params_for(parent: nil)
-        |> Account.insert
+        |> Account.insert()
 
       assert res == :error
-      assert Enum.member?(changeset.errors,
-                          {:parent_uuid, {"can't be blank", [validation: :required]}})
+
+      assert Enum.member?(
+               changeset.errors,
+               {:parent_uuid, {"can't be blank", [validation: :required]}}
+             )
     end
 
     test "inserts primary/burn balances for the account" do
-      {:ok, account} = :account |> params_for() |> Account.insert
+      {:ok, account} = :account |> params_for() |> Account.insert()
       primary = Account.get_primary_balance(account)
       burn = Account.get_default_burn_balance(account)
 
@@ -44,6 +47,7 @@ defmodule EWalletDB.AccountTest do
 
     test "prevents inserting an account beyond 1 child level" do
       account0 = Account.get_master_account()
+
       {:ok, account1} =
         :account
         |> params_for(%{parent: account0})
@@ -55,14 +59,18 @@ defmodule EWalletDB.AccountTest do
         |> Account.insert()
 
       assert res == :error
+
       assert changeset.errors ==
-        [{:parent_uuid, {"is at the maximum child level", [validation: :account_level_limit]}}]
+               [
+                 {:parent_uuid,
+                  {"is at the maximum child level", [validation: :account_level_limit]}}
+               ]
     end
   end
 
   describe "get/1" do
     test "accepts a uuid" do
-      {:ok, account} = :account |> params_for() |> Account.insert
+      {:ok, account} = :account |> params_for() |> Account.insert()
       result = Account.get(account.id)
 
       assert result.id == account.id
@@ -79,7 +87,7 @@ defmodule EWalletDB.AccountTest do
 
   describe "get/2" do
     test "accepts a uuid and preload" do
-      {:ok, account} = :account |> params_for() |> Account.insert
+      {:ok, account} = :account |> params_for() |> Account.insert()
       result = Account.get(account.id, preload: :balances)
 
       assert result.id == account.id
@@ -89,7 +97,7 @@ defmodule EWalletDB.AccountTest do
 
   describe "get_by_name/1" do
     test "accepts a non-empty string" do
-      {:ok, account} = :account |> params_for() |> Account.insert
+      {:ok, account} = :account |> params_for() |> Account.insert()
       result = Account.get_by(name: account.name)
 
       assert result.id == account.id
@@ -103,7 +111,7 @@ defmodule EWalletDB.AccountTest do
 
   describe "get_master_account/1" do
     test "returns the master account" do
-      result  = Account.get_master_account()
+      result = Account.get_master_account()
 
       assert result.id == get_or_insert_master_account().id
       assert %Ecto.Association.NotLoaded{} = result.balances
@@ -120,7 +128,7 @@ defmodule EWalletDB.AccountTest do
 
   describe "get_primary_balance/1" do
     test "returns the primary balance" do
-      {:ok, inserted} = :account |> params_for() |> Account.insert
+      {:ok, inserted} = :account |> params_for() |> Account.insert()
       balance = Account.get_primary_balance(inserted)
 
       [name: inserted.name]
@@ -135,7 +143,7 @@ defmodule EWalletDB.AccountTest do
 
   describe "get_default_burn_balance/1" do
     test "returns the burn balance" do
-      {:ok, inserted} = :account |> params_for() |> Account.insert
+      {:ok, inserted} = :account |> params_for() |> Account.insert()
       balance = Account.get_default_burn_balance(inserted)
 
       [name: inserted.name]

--- a/apps/ewallet_db/test/ewallet_db/account_validator_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/account_validator_test.exs
@@ -53,7 +53,8 @@ defmodule EWalletDB.AccountValidatorTest do
       changeset =
         %Account{}
         |> cast(%{parent_uuid: account1.uuid}, [:parent_uuid])
-        |> validate_account_level(2) # account0 -> account1 so far, there's room for account2
+        # account0 -> account1 so far, there's room for account2
+        |> validate_account_level(2)
 
       assert changeset.valid?
     end
@@ -72,8 +73,12 @@ defmodule EWalletDB.AccountValidatorTest do
         |> validate_account_level(1)
 
       refute changeset.valid?
+
       assert changeset.errors ==
-        [{:parent_uuid, {"is at the maximum child level", [validation: :account_level_limit]}}]
+               [
+                 {:parent_uuid,
+                  {"is at the maximum child level", [validation: :account_level_limit]}}
+               ]
     end
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/api_key_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/api_key_test.exs
@@ -6,7 +6,7 @@ defmodule EWalletDB.APIKeyTest do
   @owner_app :some_app
 
   describe "APIKey factory" do
-    test_has_valid_factory APIKey
+    test_has_valid_factory(APIKey)
   end
 
   describe "get/1" do
@@ -31,13 +31,14 @@ defmodule EWalletDB.APIKeyTest do
   end
 
   describe "APIKey.insert/1" do
-    test_insert_generate_uuid APIKey, :uuid
-    test_insert_generate_external_id APIKey, :id, "api_"
-    test_insert_generate_timestamps APIKey
-    test_insert_generate_length APIKey, :key, 43 # 32 bytes = ceil(32 / 3 * 4)
+    test_insert_generate_uuid(APIKey, :uuid)
+    test_insert_generate_external_id(APIKey, :id, "api_")
+    test_insert_generate_timestamps(APIKey)
+    # 32 bytes = ceil(32 / 3 * 4)
+    test_insert_generate_length(APIKey, :key, 43)
 
-    test_insert_allow_duplicate APIKey, :account, insert(:account)
-    test_insert_prevent_duplicate APIKey, :key
+    test_insert_allow_duplicate(APIKey, :account, insert(:account))
+    test_insert_prevent_duplicate(APIKey, :key)
 
     test "defaults to master account if not provided" do
       master_account = get_or_insert_master_account()
@@ -57,7 +58,7 @@ defmodule EWalletDB.APIKeyTest do
         account: account,
         owner_app: Atom.to_string(@owner_app)
       })
-      |> APIKey.insert
+      |> APIKey.insert()
 
       assert APIKey.authenticate("apikey123", @owner_app).uuid == account.uuid
     end
@@ -65,7 +66,7 @@ defmodule EWalletDB.APIKeyTest do
     test "returns false if API key does not exists" do
       :api_key
       |> params_for(%{key: "apikey123", owner_app: Atom.to_string(@owner_app)})
-      |> APIKey.insert
+      |> APIKey.insert()
 
       assert APIKey.authenticate("unmatched", @owner_app) == false
     end
@@ -73,7 +74,7 @@ defmodule EWalletDB.APIKeyTest do
     test "returns false if API key exists but for a different owner app" do
       :api_key
       |> params_for(%{key: "apikey123", owner_app: "wrong_app"})
-      |> APIKey.insert
+      |> APIKey.insert()
 
       assert APIKey.authenticate("unmatched", @owner_app) == false
     end
@@ -94,17 +95,17 @@ defmodule EWalletDB.APIKeyTest do
           account: account,
           owner_app: Atom.to_string(@owner_app)
         })
-        |> APIKey.insert
+        |> APIKey.insert()
 
       assert APIKey.authenticate(api_key.id, api_key.key, @owner_app).uuid == account.uuid
     end
 
     test "returns false if API key does not exists" do
-      key_id = UUID.generate
+      key_id = UUID.generate()
 
       :api_key
       |> params_for(%{id: key_id, key: "apikey123", owner_app: Atom.to_string(@owner_app)})
-      |> APIKey.insert
+      |> APIKey.insert()
 
       assert APIKey.authenticate(key_id, "unmatched", @owner_app) == false
     end
@@ -112,17 +113,17 @@ defmodule EWalletDB.APIKeyTest do
     test "returns false if API key ID does not exists" do
       :api_key
       |> params_for(%{key: "apikey123", owner_app: Atom.to_string(@owner_app)})
-      |> APIKey.insert
+      |> APIKey.insert()
 
-      assert APIKey.authenticate(UUID.generate, "apikey123", @owner_app) == false
+      assert APIKey.authenticate(UUID.generate(), "apikey123", @owner_app) == false
     end
 
     test "returns false if API key ID and its key exist but for a different owner app" do
-      key_id = UUID.generate
+      key_id = UUID.generate()
 
       :api_key
       |> params_for(%{key: "apikey123", owner_app: "wrong_app"})
-      |> APIKey.insert
+      |> APIKey.insert()
 
       assert APIKey.authenticate(key_id, "apikey123", @owner_app) == false
     end
@@ -130,31 +131,31 @@ defmodule EWalletDB.APIKeyTest do
     test "returns false if API key ID is not provided" do
       :api_key
       |> params_for(%{key: "apikey123", owner_app: Atom.to_string(@owner_app)})
-      |> APIKey.insert
+      |> APIKey.insert()
 
       assert APIKey.authenticate(nil, "apikey123", @owner_app) == false
     end
 
     test "returns false if API key is not provided" do
-      key_id = UUID.generate
+      key_id = UUID.generate()
 
       :api_key
       |> params_for(%{key: "apikey123", owner_app: Atom.to_string(@owner_app)})
-      |> APIKey.insert
+      |> APIKey.insert()
 
       assert APIKey.authenticate(key_id, nil, @owner_app) == false
     end
   end
 
   describe "deleted?/1" do
-    test_deleted_checks_nil_deleted_at APIKey
+    test_deleted_checks_nil_deleted_at(APIKey)
   end
 
   describe "delete/1" do
-    test_delete_causes_record_deleted APIKey
+    test_delete_causes_record_deleted(APIKey)
   end
 
   describe "restore/1" do
-    test_restore_causes_record_undeleted APIKey
+    test_restore_causes_record_undeleted(APIKey)
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
@@ -48,7 +48,8 @@ defmodule EWalletDB.AuthTokenTest do
     end
 
     test "returns :token_expired if token exists but expired" do
-      {:ok, token} = :auth_token
+      {:ok, token} =
+        :auth_token
         |> insert(%{owner_app: Atom.to_string(@owner_app)})
         |> AuthToken.expire()
 
@@ -56,7 +57,8 @@ defmodule EWalletDB.AuthTokenTest do
     end
 
     test "returns false if token exists but for a different owner app" do
-      {:ok, token} = :auth_token
+      {:ok, token} =
+        :auth_token
         |> insert(%{owner_app: "wrong_app"})
         |> AuthToken.expire()
 
@@ -132,7 +134,8 @@ defmodule EWalletDB.AuthTokenTest do
       token = insert(:auth_token, %{owner_app: Atom.to_string(@owner_app)})
       token_string = token.token
 
-      assert AuthToken.authenticate(token_string, @owner_app) # Ensure token is usable.
+      # Ensure token is usable.
+      assert AuthToken.authenticate(token_string, @owner_app)
       AuthToken.expire(token)
       assert AuthToken.authenticate(token_string, @owner_app) == :token_expired
     end
@@ -141,7 +144,8 @@ defmodule EWalletDB.AuthTokenTest do
       token = insert(:auth_token, %{owner_app: Atom.to_string(@owner_app)})
       token_string = token.token
 
-      assert AuthToken.authenticate(token_string, @owner_app) # Ensure token is usable.
+      # Ensure token is usable.
+      assert AuthToken.authenticate(token_string, @owner_app)
       AuthToken.expire(token_string, @owner_app)
       assert AuthToken.authenticate(token_string, @owner_app) == :token_expired
     end

--- a/apps/ewallet_db/test/ewallet_db/balance_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/balance_test.exs
@@ -3,27 +3,27 @@ defmodule EWalletDB.BalanceTest do
   alias EWalletDB.{Balance, Account, User}
 
   describe "Balance factory" do
-    test_has_valid_factory Balance
-    test_encrypted_map_field Balance, "balance", :encrypted_metadata
+    test_has_valid_factory(Balance)
+    test_encrypted_map_field(Balance, "balance", :encrypted_metadata)
   end
 
   describe "Balance.insert/1" do
-    test_insert_ok Balance, :address, "an_address"
+    test_insert_ok(Balance, :address, "an_address")
 
-    test_insert_generate_uuid Balance, :uuid
-    test_insert_generate_uuid Balance, :address
-    test_insert_generate_timestamps Balance
+    test_insert_generate_uuid(Balance, :uuid)
+    test_insert_generate_uuid(Balance, :address)
+    test_insert_generate_timestamps(Balance)
 
-    test_insert_prevent_blank Balance, :address
-    test_insert_prevent_all_blank Balance, [:account, :user]
-    test_insert_prevent_duplicate Balance, :address
-    test_default_metadata_fields Balance, "balance"
+    test_insert_prevent_blank(Balance, :address)
+    test_insert_prevent_all_blank(Balance, [:account, :user])
+    test_insert_prevent_duplicate(Balance, :address)
+    test_default_metadata_fields(Balance, "balance")
 
     test "allows insert if provided a user without account_uuid" do
       {res, _balance} =
         :balance
         |> params_for(%{user: insert(:user), account_uuid: nil})
-        |> Balance.insert
+        |> Balance.insert()
 
       assert res == :ok
     end
@@ -32,7 +32,7 @@ defmodule EWalletDB.BalanceTest do
       {res, _balance} =
         :balance
         |> params_for(%{account: insert(:account), user: nil})
-        |> Balance.insert
+        |> Balance.insert()
 
       assert res == :ok
     end
@@ -41,34 +41,40 @@ defmodule EWalletDB.BalanceTest do
       {res, _balance} =
         :balance
         |> params_for(%{account: nil, user: nil, identifier: Balance.genesis()})
-        |> Balance.insert
+        |> Balance.insert()
 
       assert res == :ok
     end
 
     test "prevents creation of a balance with both a user and account" do
       params = %{user: insert(:user), account: insert(:account)}
-      {result, changeset} = :balance |> params_for(params) |> Balance.insert
+      {result, changeset} = :balance |> params_for(params) |> Balance.insert()
 
       assert result == :error
+
       assert changeset.errors ==
-        [{%{account_uuid: nil, identifier: "genesis", user_uuid: nil},
-         {"only one must be present", []}}]
+               [
+                 {%{account_uuid: nil, identifier: "genesis", user_uuid: nil},
+                  {"only one must be present", []}}
+               ]
     end
 
     test "prevents creation of a balance without a user and an account" do
       params = %{user: nil, account: nil}
-      {result, changeset} = :balance |> params_for(params) |> Balance.insert
+      {result, changeset} = :balance |> params_for(params) |> Balance.insert()
 
       assert result == :error
+
       assert changeset.errors ==
-        [{%{account_uuid: nil, identifier: "genesis", user_uuid: nil},
-         {"can't all be blank", []}}]
+               [
+                 {%{account_uuid: nil, identifier: "genesis", user_uuid: nil},
+                  {"can't all be blank", []}}
+               ]
     end
 
     test "allows insert of a balance with the same name than one for another account" do
-      {:ok, account1} = :account |> params_for() |> Account.insert
-      {:ok, account2} = :account |> params_for() |> Account.insert
+      {:ok, account1} = :account |> params_for() |> Account.insert()
+      {:ok, account2} = :account |> params_for() |> Account.insert()
       balance1 = Account.get_primary_balance(account1)
       balance2 = Account.get_primary_balance(account2)
 
@@ -76,8 +82,8 @@ defmodule EWalletDB.BalanceTest do
     end
 
     test "allows insert of a balance with the same name than one for another user" do
-      {:ok, user1} = :user |> params_for() |> User.insert
-      {:ok, user2} = :user |> params_for() |> User.insert
+      {:ok, user1} = :user |> params_for() |> User.insert()
+      {:ok, user2} = :user |> params_for() |> User.insert()
       balance1 = User.get_primary_balance(user1)
       balance2 = User.get_primary_balance(user2)
 
@@ -85,7 +91,7 @@ defmodule EWalletDB.BalanceTest do
     end
 
     test "prevents creation of a balance with the same name for the same account" do
-      {:ok, account} = :account |> params_for() |> Account.insert
+      {:ok, account} = :account |> params_for() |> Account.insert()
       balance = Account.get_primary_balance(account)
       {res, changeset} = Account.insert_balance(account, balance.name)
 
@@ -94,7 +100,7 @@ defmodule EWalletDB.BalanceTest do
     end
 
     test "prevents creation of a balance with the same name for the same user" do
-      {:ok, user} = :user |> params_for() |> User.insert
+      {:ok, user} = :user |> params_for() |> User.insert()
       balance = User.get_primary_balance(user)
       {res, changeset} = User.insert_balance(user, balance.name)
 
@@ -107,7 +113,7 @@ defmodule EWalletDB.BalanceTest do
     test "returns an existing balance using an address" do
       :balance
       |> params_for(%{address: "balance_address1234"})
-      |> Balance.insert
+      |> Balance.insert()
 
       balance = Balance.get("balance_address1234")
       assert balance.address == "balance_address1234"

--- a/apps/ewallet_db/test/ewallet_db/helpers/crypto_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/helpers/crypto_test.exs
@@ -5,11 +5,13 @@ defmodule EWalletDB.Helpers.CryptoTest do
   describe "generate_key/1" do
     test "returns a key with the specified length" do
       key = Crypto.generate_key(32)
-      assert String.length(key) == 43 # ceil(32 * 4 / 3)
+      # ceil(32 * 4 / 3)
+      assert String.length(key) == 43
 
       # Test with another length to make sure it's not hardcoded.
       key = Crypto.generate_key(64)
-      assert String.length(key) == 86 # ceil(64 * 4 / 3)
+      # ceil(64 * 4 / 3)
+      assert String.length(key) == 86
     end
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/invite_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/invite_test.exs
@@ -21,10 +21,12 @@ defmodule EWalletDB.InviteTest do
   describe "Invite.get/2" do
     test "returns an Invite if the given email and token combo is found" do
       invite = insert(:invite, %{token: "the_token"})
-      _user  = insert(:admin, %{
-        email: "testemail@omise.co",
-        invite: invite
-      })
+
+      _user =
+        insert(:admin, %{
+          email: "testemail@omise.co",
+          invite: invite
+        })
 
       assert %Invite{} = Invite.get("testemail@omise.co", "the_token")
     end
@@ -61,7 +63,7 @@ defmodule EWalletDB.InviteTest do
 
   describe "Invite.generate/2" do
     test "returns {:ok, invite} for the given user" do
-      user             = insert(:admin)
+      user = insert(:admin)
       {result, invite} = Invite.generate(user)
 
       assert result == :ok
@@ -69,7 +71,7 @@ defmodule EWalletDB.InviteTest do
     end
 
     test "associates the invite_uuid to the user" do
-      user          = insert(:admin)
+      user = insert(:admin)
       {:ok, invite} = Invite.generate(user)
 
       user = User.get(user.id)
@@ -77,7 +79,7 @@ defmodule EWalletDB.InviteTest do
     end
 
     test "preloads the invite if the option is given" do
-      user          = insert(:admin)
+      user = insert(:admin)
       {:ok, invite} = Invite.generate(user, preload: :user)
 
       assert invite.user.uuid == user.uuid
@@ -87,20 +89,20 @@ defmodule EWalletDB.InviteTest do
   describe "Invite.accept/2" do
     test "sets user to :active status" do
       invite = insert(:invite)
-      user   = insert(:admin, %{invite: invite})
+      user = insert(:admin, %{invite: invite})
 
       :pending_confirmation = User.get_status(user)
-      {:ok, _invite}        = Invite.accept(invite, "some_password")
-      status                = user.id |> User.get() |> User.get_status()
+      {:ok, _invite} = Invite.accept(invite, "some_password")
+      status = user.id |> User.get() |> User.get_status()
 
-      assert status  == :active
+      assert status == :active
     end
 
     test "sets user with the given password" do
-      invite         = insert(:invite)
-      user           = insert(:admin, %{invite: invite})
+      invite = insert(:invite)
+      user = insert(:admin, %{invite: invite})
       {res, _invite} = Invite.accept(invite, "some_password")
-      user           = User.get(user.id)
+      user = User.get(user.id)
 
       assert res == :ok
       assert Crypto.verify_password("some_password", user.password_hash)
@@ -108,7 +110,7 @@ defmodule EWalletDB.InviteTest do
 
     test "deletes the invite" do
       invite = insert(:invite)
-      _user  = insert(:admin, %{invite: invite})
+      _user = insert(:admin, %{invite: invite})
 
       {res, _invite} = Invite.accept(invite, "some_password")
 

--- a/apps/ewallet_db/test/ewallet_db/key_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/key_test.exs
@@ -4,23 +4,24 @@ defmodule EWalletDB.KeyTest do
   alias EWalletDB.Key
 
   describe "Key factory" do
-    test_has_valid_factory Key
+    test_has_valid_factory(Key)
   end
 
   describe "all/0" do
     test "returns all minted tokens" do
-      assert Enum.empty?(Key.all)
+      assert Enum.empty?(Key.all())
       insert_list(3, :key)
 
-      assert length(Key.all) == 3
+      assert length(Key.all()) == 3
     end
 
     test "returns all minted tokens excluding soft deleted" do
-      assert Enum.empty?(Key.all)
+      assert Enum.empty?(Key.all())
       keys = insert_list(5, :key)
-      {:ok, _key} = keys |> Enum.at(0) |> Key.delete() # Soft delete d key
+      # Soft delete d key
+      {:ok, _key} = keys |> Enum.at(0) |> Key.delete()
 
-      assert length(Key.all) == 4
+      assert length(Key.all()) == 4
     end
   end
 
@@ -63,12 +64,12 @@ defmodule EWalletDB.KeyTest do
   end
 
   describe "insert/1" do
-    test_insert_generate_uuid Key, :uuid
-    test_insert_generate_external_id Key, :id, "key_"
-    test_insert_generate_timestamps Key
-    test_insert_generate_length Key, :access_key, 43
-    test_insert_generate_length Key, :secret_key, 43
-    test_insert_prevent_duplicate Key, :access_key
+    test_insert_generate_uuid(Key, :uuid)
+    test_insert_generate_external_id(Key, :id, "key_")
+    test_insert_generate_timestamps(Key)
+    test_insert_generate_length(Key, :access_key, 43)
+    test_insert_generate_length(Key, :secret_key, 43)
+    test_insert_prevent_duplicate(Key, :access_key)
 
     test "hashes secret_key with bcrypt before saving" do
       {res, key} = Key.insert(params_for(:key, %{secret_key: "my_secret"}))
@@ -94,7 +95,7 @@ defmodule EWalletDB.KeyTest do
         secret_key: "secret321",
         account: account
       })
-      |> Key.insert
+      |> Key.insert()
 
       auth_account = Key.authenticate("access123", "secret321")
       assert auth_account.uuid == account.uuid
@@ -103,7 +104,7 @@ defmodule EWalletDB.KeyTest do
     test "returns nil if access_key and/or secret_key do not match" do
       :key
       |> params_for(%{access_key: "access123", secret_key: "secret321"})
-      |> Key.insert
+      |> Key.insert()
 
       assert Key.authenticate("access123", "unmatched") == false
       assert Key.authenticate("unmatched", "secret321") == false
@@ -118,14 +119,14 @@ defmodule EWalletDB.KeyTest do
   end
 
   describe "deleted?/1" do
-    test_deleted_checks_nil_deleted_at Key
+    test_deleted_checks_nil_deleted_at(Key)
   end
 
   describe "delete/1" do
-    test_delete_causes_record_deleted Key
+    test_delete_causes_record_deleted(Key)
   end
 
   describe "restore/1" do
-    test_restore_causes_record_undeleted Key
+    test_restore_causes_record_undeleted(Key)
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/membership_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/membership_test.exs
@@ -14,9 +14,9 @@ defmodule EWalletDB.MembershipTest do
   end
 
   defp prepare_membership do
-    user       = insert(:user)
-    account    = insert(:account)
-    role       = insert(:role, %{name: "some_role"})
+    user = insert(:user)
+    account = insert(:account)
+    role = insert(:role, %{name: "some_role"})
     membership = insert(:membership, %{user: user, account: account, role: role})
 
     {membership, user, account, role}
@@ -42,9 +42,9 @@ defmodule EWalletDB.MembershipTest do
 
   describe "Membership.assign/3" do
     test "returns {:ok, membership} on successful assignment" do
-      user    = insert(:user)
+      user = insert(:user)
       account = insert(:account)
-      role    = insert(:role, %{name: "some_role"})
+      role = insert(:role, %{name: "some_role"})
 
       {res, membership} = Membership.assign(user, account, "some_role")
 
@@ -55,21 +55,21 @@ defmodule EWalletDB.MembershipTest do
     end
 
     test "re-assigns user to the new role if the user has an existing role on the account" do
-      user    = insert(:user)
+      user = insert(:user)
       account = insert(:account)
 
       insert(:role, %{name: "old_role"})
       insert(:role, %{name: "new_role"})
 
       {:ok, _membership} = Membership.assign(user, account, "old_role")
-      {:ok, _membership}  = Membership.assign(user, account, "new_role")
+      {:ok, _membership} = Membership.assign(user, account, "new_role")
 
       user = Repo.preload(user, :roles, force: true)
       assert User.get_roles(user) == ["new_role"]
     end
 
     test "returns {:error, :role_not_found} if the given role does not exist" do
-      user    = insert(:user)
+      user = insert(:user)
       account = insert(:account)
 
       {res, reason} = Membership.assign(user, account, "missing_role")
@@ -88,7 +88,7 @@ defmodule EWalletDB.MembershipTest do
     end
 
     test "returns {:error, :membership_not_found} if the user is not assigned to the account" do
-      user    = insert(:user)
+      user = insert(:user)
       account = insert(:account)
 
       assert Membership.unassign(user, account) == {:error, :membership_not_found}

--- a/apps/ewallet_db/test/ewallet_db/mint_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/mint_test.exs
@@ -3,14 +3,14 @@ defmodule EWalletDB.MintTest do
   alias EWalletDB.Mint
 
   describe "Mint factory" do
-    test_has_valid_factory Mint
+    test_has_valid_factory(Mint)
   end
 
   describe "insert/1" do
-    test_insert_generate_uuid Mint, :uuid
-    test_insert_generate_external_id Mint, :id, "mnt_"
-    test_insert_generate_timestamps Mint
-    test_insert_prevent_blank Mint, :amount
-    test_insert_prevent_blank Mint, :minted_token_uuid
+    test_insert_generate_uuid(Mint, :uuid)
+    test_insert_generate_external_id(Mint, :id, "mnt_")
+    test_insert_generate_timestamps(Mint)
+    test_insert_prevent_blank(Mint, :amount)
+    test_insert_prevent_blank(Mint, :minted_token_uuid)
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/minted_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/minted_token_test.exs
@@ -3,83 +3,85 @@ defmodule EWalletDB.MintedTokenTest do
   alias EWalletDB.MintedToken
 
   describe "MintedToken factory" do
-    test_has_valid_factory MintedToken
-    test_encrypted_map_field MintedToken, "minted_token", :encrypted_metadata
+    test_has_valid_factory(MintedToken)
+    test_encrypted_map_field(MintedToken, "minted_token", :encrypted_metadata)
   end
 
   describe "insert/1" do
-    test_insert_generate_uuid MintedToken, :uuid
-    test_insert_generate_timestamps MintedToken
-    test_insert_prevent_blank MintedToken, :symbol
-    test_insert_prevent_blank MintedToken, :name
-    test_insert_prevent_blank MintedToken, :subunit_to_unit
-    test_insert_prevent_duplicate MintedToken, :symbol
-    test_insert_prevent_duplicate MintedToken, :iso_code
-    test_insert_prevent_duplicate MintedToken, :name
-    test_default_metadata_fields MintedToken, "minted_token"
+    test_insert_generate_uuid(MintedToken, :uuid)
+    test_insert_generate_timestamps(MintedToken)
+    test_insert_prevent_blank(MintedToken, :symbol)
+    test_insert_prevent_blank(MintedToken, :name)
+    test_insert_prevent_blank(MintedToken, :subunit_to_unit)
+    test_insert_prevent_duplicate(MintedToken, :symbol)
+    test_insert_prevent_duplicate(MintedToken, :iso_code)
+    test_insert_prevent_duplicate(MintedToken, :name)
+    test_default_metadata_fields(MintedToken, "minted_token")
 
     test "generates an id with the schema prefix and token symbol" do
       {:ok, minted_token} =
-        :minted_token |> params_for(id: nil, symbol: "OMG") |> MintedToken.insert
+        :minted_token |> params_for(id: nil, symbol: "OMG") |> MintedToken.insert()
 
       assert "tok_OMG_" <> ulid = minted_token.id
-      assert String.length(ulid) == 26 # A ULID has 26 characters
+      # A ULID has 26 characters
+      assert String.length(ulid) == 26
     end
 
     test "allow subunit to be set between 0 and 1.0e18" do
       {:ok, minted_token} =
-        :minted_token |> params_for(subunit_to_unit: 1.0e18) |> MintedToken.insert
+        :minted_token |> params_for(subunit_to_unit: 1.0e18) |> MintedToken.insert()
 
       assert minted_token.subunit_to_unit == 1_000_000_000_000_000_000
     end
 
     test "fails to insert when subunit is equal to 1.0e19" do
       {:error, error} =
-        :minted_token |> params_for(subunit_to_unit: 1.0e19) |> MintedToken.insert
+        :minted_token |> params_for(subunit_to_unit: 1.0e19) |> MintedToken.insert()
 
       assert error.errors == [
-        subunit_to_unit: {"must be less than or equal to %{number}",
-                          [validation: :number, number: 1.0e18]}
-      ]
+               subunit_to_unit:
+                 {"must be less than or equal to %{number}",
+                  [validation: :number, number: 1.0e18]}
+             ]
     end
 
     test "fails to insert when subunit is inferior to 0" do
-      {:error, error} =
-        :minted_token |> params_for(subunit_to_unit: -2) |> MintedToken.insert
+      {:error, error} = :minted_token |> params_for(subunit_to_unit: -2) |> MintedToken.insert()
 
       assert error.errors == [
-        subunit_to_unit: {"must be greater than %{number}",
-                          [validation: :number, number: 0]}
-      ]
+               subunit_to_unit:
+                 {"must be greater than %{number}", [validation: :number, number: 0]}
+             ]
     end
 
     test "fails to insert when subunit is superior to 1.0e18" do
       {:error, error} =
-        :minted_token |> params_for(subunit_to_unit: 1.0e82) |> MintedToken.insert
+        :minted_token |> params_for(subunit_to_unit: 1.0e82) |> MintedToken.insert()
 
       assert error.errors == [
-        subunit_to_unit: {"must be less than or equal to %{number}",
-                          [validation: :number, number: 1.0e18]}
-      ]
+               subunit_to_unit:
+                 {"must be less than or equal to %{number}",
+                  [validation: :number, number: 1.0e18]}
+             ]
     end
   end
 
   describe "all/0" do
     test "returns all existing minted tokens" do
-      assert Enum.empty?(MintedToken.all)
+      assert Enum.empty?(MintedToken.all())
 
-      :minted_token |> params_for() |> MintedToken.insert
-      :minted_token |> params_for() |> MintedToken.insert
-      :minted_token |> params_for() |> MintedToken.insert
+      :minted_token |> params_for() |> MintedToken.insert()
+      :minted_token |> params_for() |> MintedToken.insert()
+      :minted_token |> params_for() |> MintedToken.insert()
 
-      assert length(MintedToken.all) == 3
+      assert length(MintedToken.all()) == 3
     end
   end
 
   describe "get/1" do
     test "returns an existing minted token using a symbol" do
       {:ok, inserted} =
-        :minted_token |> params_for(id: nil, symbol: "sym") |> MintedToken.insert
+        :minted_token |> params_for(id: nil, symbol: "sym") |> MintedToken.insert()
 
       token = MintedToken.get(inserted.id)
       assert "tok_sym_" <> _ = token.id

--- a/apps/ewallet_db/test/ewallet_db/role_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/role_test.exs
@@ -3,14 +3,14 @@ defmodule EWalletDB.RoleTest do
   alias EWalletDB.Role
 
   describe "Role factory" do
-    test_has_valid_factory Role
+    test_has_valid_factory(Role)
   end
 
   describe "Role.insert/1" do
-    test_insert_generate_uuid Role, :uuid
-    test_insert_generate_timestamps Role
-    test_insert_prevent_blank Role, :name
-    test_insert_prevent_duplicate Role, :name
+    test_insert_generate_uuid(Role, :uuid)
+    test_insert_generate_timestamps(Role)
+    test_insert_prevent_blank(Role, :name)
+    test_insert_prevent_duplicate(Role, :name)
   end
 
   describe "Role.get_by_name/1" do

--- a/apps/ewallet_db/test/ewallet_db/soft_delete_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/soft_delete_test.exs
@@ -5,7 +5,7 @@ defmodule EWalletDB.SoftDeleteTest do
 
   describe "exclude_deleted/1" do
     test "returns records that are not soft-deleted" do
-      key            = insert(:key)
+      key = insert(:key)
       {:ok, deleted} = :key |> insert() |> Key.delete()
 
       result =
@@ -13,8 +13,8 @@ defmodule EWalletDB.SoftDeleteTest do
         |> exclude_deleted()
         |> Repo.all()
 
-      refute Enum.any?(result, fn(k) -> k.id == deleted.id end)
-      assert Enum.any?(result, fn(k) -> k.id == key.id end)
+      refute Enum.any?(result, fn k -> k.id == deleted.id end)
+      assert Enum.any?(result, fn k -> k.id == key.id end)
     end
   end
 

--- a/apps/ewallet_db/test/ewallet_db/transaction_consumption_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_consumption_test.exs
@@ -3,7 +3,7 @@ defmodule EWalletDB.TransactionConsumptionTest do
   alias EWalletDB.TransactionConsumption
 
   describe "TransactionConsumption factory" do
-    test_has_valid_factory TransactionConsumption
+    test_has_valid_factory(TransactionConsumption)
   end
 
   describe "get/1" do
@@ -38,10 +38,17 @@ defmodule EWalletDB.TransactionConsumptionTest do
       now = NaiveDateTime.utc_now()
 
       # t1 and t2 have expiration dates in the past
-      t1 = insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, -60, :seconds))
-      t2 = insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, -600, :seconds))
-      t3 = insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, 600, :seconds))
-      t4 = insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, 160, :seconds))
+      t1 =
+        insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, -60, :seconds))
+
+      t2 =
+        insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, -600, :seconds))
+
+      t3 =
+        insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, 600, :seconds))
+
+      t4 =
+        insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, 160, :seconds))
 
       # They are still valid since we haven't made them expired yet
       assert TransactionConsumption.expired?(t1) == false
@@ -78,26 +85,41 @@ defmodule EWalletDB.TransactionConsumptionTest do
   describe "all_active_for_request" do
     test "it returns all pending and confirmed consumptions for the given request" do
       request = insert(:transaction_request)
-      _consumption_1 = insert(:transaction_consumption,
-        transaction_request_uuid: request.uuid,
-        status: "pending"
-      )
-      consumption_2 = insert(:transaction_consumption,
-        transaction_request_uuid: request.uuid,
-        status: "confirmed"
-      )
-      _consumption_3 = insert(:transaction_consumption,
-        transaction_request_uuid: request.uuid,
-        status: "failed"
-      )
-      _consumption_4 = insert(:transaction_consumption,
-        transaction_request_uuid: request.uuid,
-        status: "expired"
-      )
-      consumption_5 = insert(:transaction_consumption,
-        transaction_request_uuid: request.uuid,
-        status: "confirmed"
-      )
+
+      _consumption_1 =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "pending"
+        )
+
+      consumption_2 =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "confirmed"
+        )
+
+      _consumption_3 =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "failed"
+        )
+
+      _consumption_4 =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "expired"
+        )
+
+      consumption_5 =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "confirmed"
+        )
 
       consumptions = TransactionConsumption.all_active_for_request(request.uuid)
 
@@ -108,17 +130,19 @@ defmodule EWalletDB.TransactionConsumptionTest do
   end
 
   describe "insert/1" do
-    test_insert_generate_uuid TransactionConsumption, :uuid
-    test_insert_generate_external_id TransactionConsumption, :id, "txc_"
-    test_insert_generate_timestamps TransactionConsumption
-    test_insert_prevent_blank TransactionConsumption, :amount
-    test_insert_prevent_blank TransactionConsumption, :idempotency_token
-    test_insert_prevent_blank TransactionConsumption, :transaction_request_uuid
-    test_insert_prevent_blank TransactionConsumption, :balance_address
-    test_insert_prevent_blank TransactionConsumption, :minted_token_uuid
+    test_insert_generate_uuid(TransactionConsumption, :uuid)
+    test_insert_generate_external_id(TransactionConsumption, :id, "txc_")
+    test_insert_generate_timestamps(TransactionConsumption)
+    test_insert_prevent_blank(TransactionConsumption, :amount)
+    test_insert_prevent_blank(TransactionConsumption, :idempotency_token)
+    test_insert_prevent_blank(TransactionConsumption, :transaction_request_uuid)
+    test_insert_prevent_blank(TransactionConsumption, :balance_address)
+    test_insert_prevent_blank(TransactionConsumption, :minted_token_uuid)
 
     test "sets the status to 'pending'" do
-      {:ok, inserted} = :transaction_consumption |> params_for() |> TransactionConsumption.insert()
+      {:ok, inserted} =
+        :transaction_consumption |> params_for() |> TransactionConsumption.insert()
+
       assert inserted.status == "pending"
     end
   end

--- a/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
@@ -3,7 +3,7 @@ defmodule EWalletDB.TransactionRequestTest do
   alias EWalletDB.TransactionRequest
 
   describe "TransactionRequest factory" do
-    test_has_valid_factory TransactionRequest
+    test_has_valid_factory(TransactionRequest)
   end
 
   describe "get/1" do
@@ -93,12 +93,12 @@ defmodule EWalletDB.TransactionRequestTest do
   end
 
   describe "insert/1" do
-    test_insert_generate_uuid TransactionRequest, :uuid
-    test_insert_generate_external_id TransactionRequest, :id, "txr_"
-    test_insert_generate_timestamps TransactionRequest
-    test_insert_prevent_blank TransactionRequest, :type
-    test_insert_prevent_blank TransactionRequest, :minted_token_uuid
-    test_insert_prevent_duplicate TransactionRequest, :correlation_id
+    test_insert_generate_uuid(TransactionRequest, :uuid)
+    test_insert_generate_external_id(TransactionRequest, :id, "txr_")
+    test_insert_generate_timestamps(TransactionRequest)
+    test_insert_prevent_blank(TransactionRequest, :type)
+    test_insert_prevent_blank(TransactionRequest, :minted_token_uuid)
+    test_insert_prevent_duplicate(TransactionRequest, :correlation_id)
 
     test "sets the status to 'valid'" do
       {:ok, inserted} = :transaction_request |> params_for() |> TransactionRequest.insert()
@@ -138,8 +138,9 @@ defmodule EWalletDB.TransactionRequestTest do
         |> params_for(allow_amount_override: false, amount: nil)
         |> TransactionRequest.insert()
 
-      assert changeset.errors == [{:amount,
-                                  {"needs to be set if amount override is not allowed.", []}}]
+      assert changeset.errors == [
+               {:amount, {"needs to be set if amount override is not allowed.", []}}
+             ]
     end
   end
 
@@ -175,7 +176,9 @@ defmodule EWalletDB.TransactionRequestTest do
     end
 
     test "returns nil if no consumption lifetime" do
-      request = insert(:transaction_request, require_confirmation: true, consumption_lifetime: nil)
+      request =
+        insert(:transaction_request, require_confirmation: true, consumption_lifetime: nil)
+
       date = TransactionRequest.expiration_from_lifetime(request)
       assert date == nil
     end
@@ -188,8 +191,14 @@ defmodule EWalletDB.TransactionRequestTest do
 
     test "returns the expiration date based on consumption_lifetime" do
       now = NaiveDateTime.utc_now()
-      request = insert(:transaction_request, require_confirmation: true,
-                                             consumption_lifetime: 1_000)
+
+      request =
+        insert(
+          :transaction_request,
+          require_confirmation: true,
+          consumption_lifetime: 1_000
+        )
+
       date = TransactionRequest.expiration_from_lifetime(request)
       assert date > now
     end
@@ -268,10 +277,20 @@ defmodule EWalletDB.TransactionRequestTest do
 
     test "expires the request if max_consumptions has been reached" do
       request = insert(:transaction_request, max_consumptions: 2)
-      _consumption = insert(:transaction_consumption, transaction_request_uuid: request.uuid,
-                                                      status: "confirmed")
-      _consumption = insert(:transaction_consumption, transaction_request_uuid: request.uuid,
-                                                      status: "confirmed")
+
+      _consumption =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "confirmed"
+        )
+
+      _consumption =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: request.uuid,
+          status: "confirmed"
+        )
 
       {res, updated_request} = TransactionRequest.expire_if_max_consumption(request)
       assert res == :ok

--- a/apps/ewallet_db/test/ewallet_db/transfer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transfer_test.exs
@@ -3,10 +3,10 @@ defmodule EWalletDB.TransferTest do
   alias EWalletDB.Transfer
 
   describe "Transfer factory" do
-    test_has_valid_factory Transfer
-    test_encrypted_map_field Transfer, "transfer", :encrypted_metadata
-    test_encrypted_map_field Transfer, "transfer", :payload
-    test_encrypted_map_field Transfer, "transfer", :ledger_response
+    test_has_valid_factory(Transfer)
+    test_encrypted_map_field(Transfer, "transfer", :encrypted_metadata)
+    test_encrypted_map_field(Transfer, "transfer", :payload)
+    test_encrypted_map_field(Transfer, "transfer", :ledger_response)
   end
 
   describe "get_or_insert/1" do
@@ -14,7 +14,7 @@ defmodule EWalletDB.TransferTest do
       {:ok, transfer} = :transfer |> params_for() |> Transfer.get_or_insert()
 
       assert transfer.id != nil
-      assert transfer.type == Transfer.internal
+      assert transfer.type == Transfer.internal()
     end
 
     test "retrieves an existing transfer when idempotency token exists" do
@@ -36,19 +36,21 @@ defmodule EWalletDB.TransferTest do
   end
 
   describe "insert/1" do
-    test_insert_generate_uuid Transfer, :uuid
-    test_insert_generate_external_id Transfer, :id, "tfr_"
-    test_insert_generate_timestamps Transfer
-    test_insert_prevent_blank Transfer, :payload
-    test_insert_prevent_blank Transfer, :idempotency_token
-    test_default_metadata_fields Transfer, "transfer"
+    test_insert_generate_uuid(Transfer, :uuid)
+    test_insert_generate_external_id(Transfer, :id, "tfr_")
+    test_insert_generate_timestamps(Transfer)
+    test_insert_prevent_blank(Transfer, :payload)
+    test_insert_prevent_blank(Transfer, :idempotency_token)
+    test_default_metadata_fields(Transfer, "transfer")
 
     test "inserts a transfer if it does not existing" do
       assert Repo.all(Transfer) == []
+
       {:ok, transfer} =
         :transfer
         |> params_for()
-        |> Transfer.insert
+        |> Transfer.insert()
+
       transfers =
         Transfer |> Repo.all() |> Repo.preload([:from_balance, :to_balance, :minted_token])
 
@@ -57,33 +59,37 @@ defmodule EWalletDB.TransferTest do
 
     test "returns the existing transfer without error if already existing" do
       assert Repo.all(Transfer) == []
+
       {:ok, inserted_transfer} =
-        :transfer |> params_for(idempotency_token: "123") |> Transfer.insert
-      {:ok, transfer} = :transfer |> params_for(idempotency_token: "123") |> Transfer.insert
+        :transfer |> params_for(idempotency_token: "123") |> Transfer.insert()
+
+      {:ok, transfer} = :transfer |> params_for(idempotency_token: "123") |> Transfer.insert()
 
       assert inserted_transfer == transfer
     end
 
     test "returns an error when passing invalid arguments" do
       assert Repo.all(Transfer) == []
-      {res, changeset} = %{idempotency_token: nil, payload: %{}} |> Transfer.insert
+      {res, changeset} = %{idempotency_token: nil, payload: %{}} |> Transfer.insert()
       assert res == :error
-      assert changeset.errors == [idempotency_token: {"can't be blank", [validation: :required]},
-                                  amount: {"can't be blank", [validation: :required]},
-                                  minted_token_uuid: {"can't be blank",
-                                                             [validation: :required]},
-                                  to: {"can't be blank", [validation: :required]},
-                                  from: {"can't be blank", [validation: :required]}]
+
+      assert changeset.errors == [
+               idempotency_token: {"can't be blank", [validation: :required]},
+               amount: {"can't be blank", [validation: :required]},
+               minted_token_uuid: {"can't be blank", [validation: :required]},
+               to: {"can't be blank", [validation: :required]},
+               from: {"can't be blank", [validation: :required]}
+             ]
     end
   end
 
   describe "confirm/2" do
     test "confirms a transfer" do
       {:ok, inserted_transfer} = :transfer |> params_for() |> Transfer.get_or_insert()
-      assert inserted_transfer.status == Transfer.pending
+      assert inserted_transfer.status == Transfer.pending()
       transfer = Transfer.confirm(inserted_transfer, %{ledger: "response"})
       assert transfer.id == inserted_transfer.id
-      assert transfer.status == Transfer.confirmed
+      assert transfer.status == Transfer.confirmed()
       assert transfer.ledger_response == %{"ledger" => "response"}
     end
   end
@@ -91,10 +97,10 @@ defmodule EWalletDB.TransferTest do
   describe "fail/2" do
     test "sets a transfer as failed" do
       {:ok, inserted_transfer} = :transfer |> params_for() |> Transfer.get_or_insert()
-      assert inserted_transfer.status == Transfer.pending
+      assert inserted_transfer.status == Transfer.pending()
       transfer = Transfer.fail(inserted_transfer, %{ledger: "response"})
       assert transfer.id == inserted_transfer.id
-      assert transfer.status == Transfer.failed
+      assert transfer.status == Transfer.failed()
       assert transfer.ledger_response == %{"ledger" => "response"}
     end
   end

--- a/apps/ewallet_db/test/ewallet_db/types/external_id_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/types/external_id_test.exs
@@ -5,7 +5,7 @@ defmodule EWalletDB.Types.ExternalIDTest do
   describe "cast/1" do
     test "casts input to lower case" do
       assert ExternalID.cast("ACC_01CA56X1ZTJD9DZ7H10BZ6VMZX") ==
-        {:ok, "acc_01ca56x1ztjd9dz7h10bz6vmzx"}
+               {:ok, "acc_01ca56x1ztjd9dz7h10bz6vmzx"}
     end
 
     test "returns error if the input does not have prefix" do
@@ -22,7 +22,7 @@ defmodule EWalletDB.Types.ExternalIDTest do
     ## So no transformation needed.
     test "returns the same string" do
       assert ExternalID.load("acc_01ca56x1ztjd9dz7h10bz6vmzx") ==
-        {:ok, "acc_01ca56x1ztjd9dz7h10bz6vmzx"}
+               {:ok, "acc_01ca56x1ztjd9dz7h10bz6vmzx"}
     end
   end
 
@@ -31,7 +31,7 @@ defmodule EWalletDB.Types.ExternalIDTest do
     # So no transformation needed.
     test "returns the same string" do
       assert ExternalID.dump("acc_01ca56x1ztjd9dz7h10bz6vmzx") ==
-        {:ok, "acc_01ca56x1ztjd9dz7h10bz6vmzx"}
+               {:ok, "acc_01ca56x1ztjd9dz7h10bz6vmzx"}
     end
   end
 

--- a/apps/ewallet_db/test/ewallet_db/user_query_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/user_query_test.exs
@@ -5,10 +5,10 @@ defmodule EWalletDB.UserQueryTest do
   describe "UserQuery.where_has_membership/1" do
     test "returns only admins" do
       account = insert(:account)
-      role    = insert(:role, %{name: "some_role"})
-      admin1  = insert(:admin, %{email: "admin1@omise.co"})
-      admin2  = insert(:admin, %{email: "admin2@omise.co"})
-      user    = insert(:user, %{email: "user1@omise.co"})
+      role = insert(:role, %{name: "some_role"})
+      admin1 = insert(:admin, %{email: "admin1@omise.co"})
+      admin2 = insert(:admin, %{email: "admin2@omise.co"})
+      user = insert(:user, %{email: "user1@omise.co"})
 
       insert(:membership, %{user: admin1, account: account, role: role})
       insert(:membership, %{user: admin2, account: account, role: role})
@@ -19,16 +19,16 @@ defmodule EWalletDB.UserQueryTest do
         |> Repo.all()
 
       assert Enum.count(result) == 2
-      assert Enum.any?(result, fn(admin) -> admin.email == admin1.email end)
-      assert Enum.any?(result, fn(admin) -> admin.email == admin2.email end)
-      refute Enum.any?(result, fn(admin) -> admin.email == user.email end)
+      assert Enum.any?(result, fn admin -> admin.email == admin1.email end)
+      assert Enum.any?(result, fn admin -> admin.email == admin2.email end)
+      refute Enum.any?(result, fn admin -> admin.email == user.email end)
     end
 
     test "returns unique records" do
       account1 = insert(:account)
       account2 = insert(:account)
-      admin    = insert(:admin, %{email: "admin1@omise.co"})
-      role     = insert(:role, %{name: "some_role"})
+      admin = insert(:admin, %{email: "admin1@omise.co"})
+      role = insert(:role, %{name: "some_role"})
 
       insert(:membership, %{user: admin, account: account1, role: role})
       insert(:membership, %{user: admin, account: account2, role: role})
@@ -44,8 +44,8 @@ defmodule EWalletDB.UserQueryTest do
 
     test "uses `EWalletDB.User` if `queryable` is not given" do
       account = insert(:account)
-      role    = insert(:role, %{name: "some_role"})
-      admin   = insert(:admin, %{email: "admin@omise.co"})
+      role = insert(:role, %{name: "some_role"})
+      admin = insert(:admin, %{email: "admin@omise.co"})
       insert(:membership, %{user: admin, account: account, role: role})
 
       query = UserQuery.where_has_membership()

--- a/apps/ewallet_db/test/ewallet_db/user_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/user_test.exs
@@ -3,13 +3,13 @@ defmodule EWalletDB.UserTest do
   alias EWalletDB.{Invite, User}
 
   describe "User factory" do
-    test_has_valid_factory User
-    test_encrypted_map_field User, "user", :encrypted_metadata
+    test_has_valid_factory(User)
+    test_encrypted_map_field(User, "user", :encrypted_metadata)
   end
 
   describe "insert/1" do
     test "inserts a user if it does not exist" do
-      {:ok, inserted_user} = :user |> params_for |> User.insert
+      {:ok, inserted_user} = :user |> params_for |> User.insert()
       user = User.get(inserted_user.id)
 
       assert user.id == inserted_user.id
@@ -19,12 +19,12 @@ defmodule EWalletDB.UserTest do
       assert user.metadata["last_name"] == inserted_user.metadata["last_name"]
     end
 
-    test_insert_generate_uuid User, :uuid
-    test_insert_generate_external_id User, :id, "usr_"
-    test_insert_generate_timestamps User
-    test_insert_prevent_duplicate User, :username
-    test_insert_prevent_duplicate User, :provider_user_id
-    test_default_metadata_fields User, "user"
+    test_insert_generate_uuid(User, :uuid)
+    test_insert_generate_external_id(User, :id, "usr_")
+    test_insert_generate_timestamps(User)
+    test_insert_prevent_duplicate(User, :username)
+    test_insert_prevent_duplicate(User, :provider_user_id)
+    test_default_metadata_fields(User, "user")
 
     # The test below can't use `test_insert_prevent_duplicate/3` with :email
     # because we need to use :admin factory to get proper data for admin user.
@@ -39,16 +39,16 @@ defmodule EWalletDB.UserTest do
     end
 
     test "automatically creates a balance when user is created" do
-      {_result, user} = :user |> params_for |> User.insert
+      {_result, user} = :user |> params_for |> User.insert()
       User.get_primary_balance(user)
       assert length(User.get(user.id).balances) == 1
     end
   end
 
   describe "update/2" do
-    test_update_field_ok User, :username
-    test_update_field_ok User, :metadata, %{"field" => "old"}, %{"field" => "new"}
-    test_update_prevents_changing User, :provider_user_id
+    test_update_field_ok(User, :username)
+    test_update_field_ok(User, :metadata, %{"field" => "old"}, %{"field" => "new"})
+    test_update_prevents_changing(User, :provider_user_id)
 
     test "prevents updating an admin without email" do
       user = prepare_admin_user()
@@ -80,7 +80,7 @@ defmodule EWalletDB.UserTest do
       {_, inserted_user} =
         :user
         |> build(%{id: "usr_01caj9wth0vyestkmh7873qb9f"})
-        |> Repo.insert
+        |> Repo.insert()
 
       user = User.get("usr_01caj9wth0vyestkmh7873qb9f")
       assert user.uuid == inserted_user.uuid
@@ -97,7 +97,7 @@ defmodule EWalletDB.UserTest do
       {_, inserted_user} =
         :user
         |> build(%{provider_user_id: "1234"})
-        |> Repo.insert
+        |> Repo.insert()
 
       user = User.get_by_provider_user_id("1234")
       assert user.provider_user_id == inserted_user.provider_user_id
@@ -114,7 +114,7 @@ defmodule EWalletDB.UserTest do
       {_, inserted_user} =
         :user
         |> build(%{email: "test@example.com"})
-        |> Repo.insert
+        |> Repo.insert()
 
       user = User.get_by_email("test@example.com")
       assert user.email == inserted_user.email
@@ -203,12 +203,12 @@ defmodule EWalletDB.UserTest do
 
   describe "get_roles/1" do
     test "returns a list of unique roles that the given user has" do
-      user     = insert(:user)
+      user = insert(:user)
       account1 = insert(:account)
       account2 = insert(:account)
       account3 = insert(:account)
-      role1    = insert(:role, %{name: "role_one"})
-      role2    = insert(:role, %{name: "role_two"})
+      role1 = insert(:role, %{name: "role_one"})
+      role2 = insert(:role, %{name: "role_two"})
 
       insert(:membership, %{user: user, account: account1, role: role1})
       insert(:membership, %{user: user, account: account2, role: role2})
@@ -223,9 +223,9 @@ defmodule EWalletDB.UserTest do
 
   describe "get_role/2" do
     test "returns the role that the user has for the given account's id" do
-      user    = insert(:user)
+      user = insert(:user)
       account = insert(:account)
-      role    = insert(:role, %{name: "role_one"})
+      role = insert(:role, %{name: "role_one"})
 
       insert(:membership, %{user: user, account: account, role: role})
 
@@ -233,10 +233,10 @@ defmodule EWalletDB.UserTest do
     end
 
     test "returns the role that the user has in the closest parent account" do
-      user    = insert(:user)
-      parent  = insert(:account)
+      user = insert(:user)
+      parent = insert(:account)
       account = insert(:account, parent: parent)
-      role    = insert(:role, %{name: "role_from_parent"})
+      role = insert(:role, %{name: "role_from_parent"})
 
       insert(:membership, %{user: user, account: parent, role: role})
 
@@ -244,8 +244,8 @@ defmodule EWalletDB.UserTest do
     end
 
     test "returns nil if the given user is not a member in the account or any of its parents" do
-      user    = insert(:user)
-      parent  = insert(:account)
+      user = insert(:user)
+      parent = insert(:account)
       account = insert(:account, parent: parent)
 
       assert User.get_role(user.id, account.id) == nil
@@ -254,11 +254,11 @@ defmodule EWalletDB.UserTest do
 
   describe "get_account/1" do
     test "returns an upper-most account that the given user has membership in" do
-      user        = insert(:user)
+      user = insert(:user)
       top_account = insert(:account)
       mid_account = insert(:account, %{parent: top_account})
-      _unrelated  = insert(:account)
-      role        = insert(:role, %{name: "role_name"})
+      _unrelated = insert(:account)
+      role = insert(:role, %{name: "role_name"})
 
       insert(:membership, %{user: user, account: mid_account, role: role})
       account = User.get_account(user)
@@ -269,12 +269,12 @@ defmodule EWalletDB.UserTest do
 
   describe "get_accounts/1" do
     test "returns a list of user's accounts and their sub-accounts" do
-      user        = insert(:user)
+      user = insert(:user)
       top_account = insert(:account)
       mid_account = insert(:account, %{parent: top_account})
       sub_account = insert(:account, %{parent: mid_account})
-      _unrelated  = insert(:account)
-      role        = insert(:role, %{name: "role_name"})
+      _unrelated = insert(:account)
+      role = insert(:role, %{name: "role_name"})
 
       insert(:membership, %{user: user, account: mid_account, role: role})
       [account1, account2] = User.get_accounts(user)

--- a/apps/ewallet_db/test/ewallet_db/validator_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/validator_test.exs
@@ -7,9 +7,9 @@ defmodule EWalletDB.ValidatorTest do
     use Ecto.Schema
 
     schema "sample_structs" do
-      field :attr1, :string
-      field :attr2, :string
-      field :attr3, :string
+      field(:attr1, :string)
+      field(:attr2, :string)
+      field(:attr3, :string)
     end
   end
 
@@ -21,7 +21,8 @@ defmodule EWalletDB.ValidatorTest do
         attr3: nil
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_exclusive(%{attr1: nil, attr2: nil, attr3: nil})
 
@@ -35,7 +36,8 @@ defmodule EWalletDB.ValidatorTest do
         attr3: nil
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_exclusive(%{attr1: "value", attr2: nil, attr3: nil})
 
@@ -49,7 +51,8 @@ defmodule EWalletDB.ValidatorTest do
         attr3: nil
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_exclusive(%{attr1: "something", attr2: nil, attr3: nil})
 
@@ -63,29 +66,33 @@ defmodule EWalletDB.ValidatorTest do
         attr3: nil
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_exclusive(%{attr1: nil, attr2: nil, attr3: nil})
 
       refute changeset.valid?
+
       assert changeset.errors ==
-        [{%{attr1: nil, attr2: nil, attr3: nil}, {"can't all be blank", []}}]
+               [{%{attr1: nil, attr2: nil, attr3: nil}, {"can't all be blank", []}}]
     end
 
     test "invalid if more than one field is present" do
       attrs = %{
         attr1: "value",
         attr2: "extra_value",
-        attr3: "another_extra_value",
+        attr3: "another_extra_value"
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_exclusive(%{attr1: nil, attr2: nil, attr3: nil})
 
       refute changeset.valid?
+
       assert changeset.errors ==
-        [{%{attr1: nil, attr2: nil, attr3: nil}, {"only one must be present", []}}]
+               [{%{attr1: nil, attr2: nil, attr3: nil}, {"only one must be present", []}}]
     end
 
     test "invalid if more than one field is present with an attribute value given" do
@@ -95,13 +102,15 @@ defmodule EWalletDB.ValidatorTest do
         attr3: nil
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_exclusive(%{attr1: "value", attr2: nil, attr3: nil})
 
       refute changeset.valid?
+
       assert changeset.errors ==
-        [{%{attr1: "value", attr2: nil, attr3: nil}, {"only one must be present", []}}]
+               [{%{attr1: "value", attr2: nil, attr3: nil}, {"only one must be present", []}}]
     end
   end
 
@@ -113,7 +122,8 @@ defmodule EWalletDB.ValidatorTest do
         attr3: "value3"
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_all_or_none(%{attr1: nil, attr2: nil, attr3: nil})
 
@@ -127,7 +137,8 @@ defmodule EWalletDB.ValidatorTest do
         attr3: ""
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_all_or_none(%{attr1: nil, attr2: nil, attr3: nil})
 
@@ -141,13 +152,18 @@ defmodule EWalletDB.ValidatorTest do
         attr3: ""
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_all_or_none(%{attr1: nil, attr2: nil, attr3: nil})
 
       refute changeset.valid?
+
       assert changeset.errors ==
-        [{%{attr1: nil, attr2: nil, attr3: nil}, {"either all or none of them must be present", [validation: "all_or_none"]}}]
+               [
+                 {%{attr1: nil, attr2: nil, attr3: nil},
+                  {"either all or none of them must be present", [validation: "all_or_none"]}}
+               ]
     end
 
     test "returns invalid if only some of the attributes are present" do
@@ -157,13 +173,18 @@ defmodule EWalletDB.ValidatorTest do
         attr3: "value3"
       }
 
-      changeset = %SampleStruct{}
+      changeset =
+        %SampleStruct{}
         |> cast(attrs, [:attr1, :attr2, :attr3])
         |> validate_required_all_or_none(%{attr1: nil, attr2: nil, attr3: nil})
 
       refute changeset.valid?
+
       assert changeset.errors ==
-        [{%{attr1: nil, attr2: nil, attr3: nil}, {"either all or none of them must be present", [validation: "all_or_none"]}}]
+               [
+                 {%{attr1: nil, attr2: nil, attr3: nil},
+                  {"either all or none of them must be present", [validation: "all_or_none"]}}
+               ]
     end
   end
 
@@ -232,10 +253,9 @@ defmodule EWalletDB.ValidatorTest do
 
   describe "validate_password/2" do
     test "returns valid if the password meets the requirements" do
-      struct =
-        %SampleStruct{
-          attr1: "valid_password"
-        }
+      struct = %SampleStruct{
+        attr1: "valid_password"
+      }
 
       changeset =
         struct

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -4,6 +4,7 @@ defmodule EWalletDB.Factory do
   """
   use ExMachina.Ecto, repo: EWalletDB.Repo
   alias ExMachina.Strategy
+
   alias EWalletDB.{
     Account,
     APIKey,
@@ -21,6 +22,7 @@ defmodule EWalletDB.Factory do
     Transfer,
     User
   }
+
   alias EWalletDB.Helpers.Crypto
   alias Ecto.UUID
   alias ExULID.ULID
@@ -32,17 +34,18 @@ defmodule EWalletDB.Factory do
   e.g. when APIKey becomes :a_p_i_key
   """
   def get_factory(APIKey), do: :api_key
+
   def get_factory(schema) when is_atom(schema) do
     schema
     |> struct
-    |> Strategy.name_from_struct
+    |> Strategy.name_from_struct()
   end
 
   def balance_factory do
     %Balance{
       address: sequence("address"),
       name: sequence("name"),
-      identifier: Balance.primary,
+      identifier: Balance.primary(),
       user: insert(:user),
       minted_token: nil,
       metadata: %{}
@@ -84,6 +87,7 @@ defmodule EWalletDB.Factory do
 
   def admin_factory do
     password = sequence("password")
+
     %User{
       email: sequence("johndoe") <> "@example.com",
       password: password,
@@ -151,7 +155,7 @@ defmodule EWalletDB.Factory do
       key: sequence("api_key"),
       owner_app: "some_app_name",
       account: insert(:account),
-      expired: false,
+      expired: false
     }
   end
 
@@ -160,7 +164,7 @@ defmodule EWalletDB.Factory do
       token: sequence("auth_token"),
       owner_app: "some_app_name",
       user: insert(:user),
-      expired: false,
+      expired: false
     }
   end
 
@@ -178,7 +182,7 @@ defmodule EWalletDB.Factory do
 
   def forget_password_request_factory do
     %ForgetPasswordRequest{
-      token: sequence("123"),
+      token: sequence("123")
     }
   end
 

--- a/apps/ewallet_db/test/support/schema_case.ex
+++ b/apps/ewallet_db/test/support/schema_case.ex
@@ -61,9 +61,9 @@ defmodule EWalletDB.SchemaCase do
   end
 
   def insert_user_with_role(role_name) do
-    user        = insert(:user)
-    account     = insert(:account)
-    role        = insert(:role, %{name: role_name})
+    user = insert(:user)
+    account = insert(:account)
+    role = insert(:role, %{name: role_name})
     _membership = insert(:membership, %{user: user, account: account, role: role})
 
     {user, account}
@@ -73,6 +73,7 @@ defmodule EWalletDB.SchemaCase do
     case Account.get_master_account() do
       %{} = account ->
         account
+
       _ ->
         insert(:account, %{parent: nil})
     end
@@ -102,7 +103,7 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_insert_ok(schema, field, value) when is_atom(field) do
     quote do
-      test "inserts #{unquote field} successfully" do
+      test "inserts #{unquote(field)} successfully" do
         schema = unquote(schema)
         field = unquote(field)
         value = unquote(value)
@@ -124,9 +125,9 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_insert_generate_uuid(schema, field) do
     quote do
-      test "generates a UUID for :#{unquote field}" do
+      test "generates a UUID for :#{unquote(field)}" do
         schema = unquote(schema)
-        field  = unquote(field)
+        field = unquote(field)
 
         {res, record} =
           schema
@@ -135,8 +136,7 @@ defmodule EWalletDB.SchemaCase do
           |> schema.insert
 
         assert res == :ok
-        assert String.match?(record.unquote(field),
-          ~r/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
+        assert String.match?(record.unquote(field), ~r/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
       end
     end
   end
@@ -163,6 +163,7 @@ defmodule EWalletDB.SchemaCase do
         case prefix do
           "" ->
             assert String.length(external_id) == 26
+
           _ ->
             assert String.starts_with?(external_id, prefix)
             assert String.length(external_id) == String.length(prefix) + 26
@@ -198,10 +199,10 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_insert_generate_length(schema, field, len) do
     quote do
-      test "generates a string with length #{unquote len} into :#{unquote field}" do
+      test "generates a string with length #{unquote(len)} into :#{unquote(field)}" do
         schema = unquote(schema)
-        field  = unquote(field)
-        len  = unquote(len)
+        field = unquote(field)
+        len = unquote(len)
 
         {res, record} =
           schema
@@ -220,7 +221,7 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_insert_prevent_blank(schema, field) when is_atom(field) do
     quote do
-      test "prevents creation with blank :#{unquote field}" do
+      test "prevents creation with blank :#{unquote(field)}" do
         schema = unquote(schema)
         field = unquote(field)
 
@@ -231,8 +232,7 @@ defmodule EWalletDB.SchemaCase do
           |> schema.insert
 
         assert result == :error
-        assert changeset.errors ==
-          [{field, {"can't be blank", [validation: :required]}}]
+        assert changeset.errors == [{field, {"can't be blank", [validation: :required]}}]
       end
     end
   end
@@ -242,7 +242,7 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_insert_prevent_blank_assoc(schema, field) when is_atom(field) do
     quote do
-      test "prevents creation with missing association :#{unquote field}" do
+      test "prevents creation with missing association :#{unquote(field)}" do
         schema = unquote(schema)
         field = unquote(field)
 
@@ -253,8 +253,7 @@ defmodule EWalletDB.SchemaCase do
           |> schema.insert
 
         assert result == :error
-        assert changeset.errors ==
-          [{:"#{field}_id", {"can't be blank", [validation: :required]}}]
+        assert changeset.errors == [{:"#{field}_id", {"can't be blank", [validation: :required]}}]
       end
     end
   end
@@ -274,7 +273,7 @@ defmodule EWalletDB.SchemaCase do
           |> params_for(Map.new(fields, fn field -> {field, nil} end))
           |> schema.insert
 
-        reason = changeset.errors |> List.first |> elem(1) |> elem(0)
+        reason = changeset.errors |> List.first() |> elem(1) |> elem(0)
 
         assert result == :error
         assert reason == "can't all be blank"
@@ -287,7 +286,7 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_insert_allow_duplicate(schema, field, value \\ "same") do
     quote do
-      test "allows insert with existing :#{unquote field} value" do
+      test "allows insert with existing :#{unquote(field)} value" do
         schema = unquote(schema)
         field = unquote(field)
         value = unquote(value)
@@ -314,7 +313,7 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_insert_prevent_duplicate(schema, field, value \\ "same") do
     quote do
-      test "returns error if same :#{unquote field} already exists" do
+      test "returns error if same :#{unquote(field)} already exists" do
         schema = unquote(schema)
         field = unquote(field)
         value = unquote(value)
@@ -342,7 +341,7 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_update_field_ok(schema, field, old \\ "old", new \\ "new") do
     quote do
-      test "updates #{unquote field} successfully" do
+      test "updates #{unquote(field)} successfully" do
         schema = unquote(schema)
         field = unquote(field)
         old = unquote(old)
@@ -367,7 +366,7 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_update_prevents_changing(schema, field) do
     quote do
-      test "prevents changing of #{unquote field}" do
+      test "prevents changing of #{unquote(field)}" do
         schema = unquote(schema)
         field = unquote(field)
 
@@ -400,8 +399,8 @@ defmodule EWalletDB.SchemaCase do
           |> params_for(metadata: nil, encrypted_metadata: nil)
           |> schema.insert()
 
-        {:ok, results} = SQL.query(EWalletDB.Repo,
-                                   "SELECT metadata, encrypted_metadata FROM \"#{table}\"", [])
+        {:ok, results} =
+          SQL.query(EWalletDB.Repo, "SELECT metadata, encrypted_metadata FROM \"#{table}\"", [])
 
         assert record.metadata == %{}
         assert record.encrypted_metadata == %{}
@@ -414,7 +413,7 @@ defmodule EWalletDB.SchemaCase do
   """
   defmacro test_encrypted_map_field(schema, table, field) do
     quote do
-      test "saves #{unquote field} as encrypted data" do
+      test "saves #{unquote(field)} as encrypted data" do
         schema = unquote(schema)
         table = unquote(table)
         field = unquote(field)

--- a/apps/local_ledger/config/config.exs
+++ b/apps/local_ledger/config/config.exs
@@ -9,4 +9,4 @@ config :local_ledger,
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/apps/local_ledger/config/prod.exs
+++ b/apps/local_ledger/config/prod.exs
@@ -4,7 +4,9 @@ use Mix.Config
 # Daily at 2am: 0 2 * * *
 # Every Friday at 5am: 0 5 * * 5
 case System.get_env("BALANCE_CACHING_FREQUENCY") do
-  nil -> :ok
+  nil ->
+    :ok
+
   frequency ->
     config :local_ledger, LocalLedger.Scheduler,
       global: true,

--- a/apps/local_ledger/lib/local_ledger/balance.ex
+++ b/apps/local_ledger/lib/local_ledger/balance.ex
@@ -33,11 +33,11 @@ defmodule LocalLedger.Balance do
   balances.
   """
   def lock(addresses, fun) do
-    Repo.transaction fn ->
+    Repo.transaction(fn ->
       Balance.lock(addresses)
       res = fun.()
       Balance.touch(addresses)
       res
-    end
+    end)
   end
 end

--- a/apps/local_ledger/lib/local_ledger/entry/validator.ex
+++ b/apps/local_ledger/lib/local_ledger/entry/validator.ex
@@ -12,8 +12,7 @@ defmodule LocalLedger.Entry.Validator do
 
     case length(identical_addresses) do
       0 -> attrs
-      _ -> raise SameAddressError,
-                 message: SameAddressError.error_message(identical_addresses)
+      _ -> raise SameAddressError, message: SameAddressError.error_message(identical_addresses)
     end
   end
 
@@ -31,15 +30,16 @@ defmodule LocalLedger.Entry.Validator do
   end
 
   def validate_positive_amounts({debits, credits} = attrs) do
-    case Enum.any?(debits ++ credits, fn(attrs) -> attrs["amount"] == 0 end) do
-      true  -> raise AmountIsZeroError
+    case Enum.any?(debits ++ credits, fn attrs -> attrs["amount"] == 0 end) do
+      true -> raise AmountIsZeroError
       false -> attrs
     end
   end
 
   defp total(list) do
-    Enum.reduce(list, 0, fn(attrs, acc) -> attrs["amount"] + acc end)
+    Enum.reduce(list, 0, fn attrs, acc -> attrs["amount"] + acc end)
   end
+
   defp extract_addresses(list), do: Enum.map(list, fn e -> e["address"] end)
-  defp intersect(a, b), do: a -- (a -- b)
+  defp intersect(a, b), do: a -- a -- b
 end

--- a/apps/local_ledger/lib/local_ledger/transaction.ex
+++ b/apps/local_ledger/lib/local_ledger/transaction.ex
@@ -11,8 +11,8 @@ defmodule LocalLedger.Transaction do
   """
   def build_all({debits, credits}, minted_token) do
     {:ok, minted_token} = MintedToken.get_or_insert(minted_token)
-    sending = format(minted_token, debits, Transaction.debit_type)
-    receiving = format(minted_token, credits, Transaction.credit_type)
+    sending = format(minted_token, debits, Transaction.debit_type())
+    receiving = format(minted_token, credits, Transaction.credit_type())
 
     sending ++ receiving
   end
@@ -23,23 +23,23 @@ defmodule LocalLedger.Transaction do
   def get_addresses(transactions) do
     transactions
     |> Enum.filter(fn transaction ->
-      transaction[:type] == Transaction.debit_type
+      transaction[:type] == Transaction.debit_type()
     end)
     |> Enum.map(fn transaction -> transaction[:balance_address] end)
   end
 
   # Build a list of balance maps with the required details for DB insert.
   defp format(minted_token, balances, type) do
-    Enum.map balances, fn attrs ->
+    Enum.map(balances, fn attrs ->
       {:ok, balance} = Balance.get_or_insert(attrs)
 
       %{
         type: type,
         amount: attrs["amount"],
         minted_token_id: minted_token.id,
-        balance_address: balance.address,
+        balance_address: balance.address
       }
-    end
+    end)
   end
 
   @doc """
@@ -60,14 +60,14 @@ defmodule LocalLedger.Transaction do
   Check the current balance amount for each DEBIT transaction.
   """
   def check_balance(transactions) do
-    Enum.each transactions, fn transaction ->
-      if transaction[:type] == Transaction.debit_type do
+    Enum.each(transactions, fn transaction ->
+      if transaction[:type] == Transaction.debit_type() do
         Transaction.check_balance(%{
           amount: transaction[:amount],
           minted_token_id: transaction[:minted_token_id],
           address: transaction[:balance_address]
         })
       end
-    end
+    end)
   end
 end

--- a/apps/local_ledger/test/local_ledger/cached_balance_test.exs
+++ b/apps/local_ledger/test/local_ledger/cached_balance_test.exs
@@ -10,155 +10,193 @@ defmodule LocalLedger.CachedBalanceTest do
 
     minted_token_1 = insert(:minted_token, id: "tok_OMG_1234")
     minted_token_2 = insert(:minted_token, id: "tok_BTC_5678")
-    balance        = insert(:balance)
+    balance = insert(:balance)
 
     # Total: +120_000 OMG
-    insert_list(12, :credit, minted_token: minted_token_1,
-                             balance: balance,
-                             amount: 10_000)
+    insert_list(
+      12,
+      :credit,
+      minted_token: minted_token_1,
+      balance: balance,
+      amount: 10_000
+    )
+
     # Total: -61_047 OMG
-    insert_list(9, :debit, minted_token: minted_token_1,
-                           balance: balance,
-                           amount: 6_783)
+    insert_list(
+      9,
+      :debit,
+      minted_token: minted_token_1,
+      balance: balance,
+      amount: 6_783
+    )
 
     # Total: +160_524 BTC
-    insert_list(12, :credit, minted_token: minted_token_2,
-                             balance: balance,
-                             amount: 13_377)
+    insert_list(
+      12,
+      :credit,
+      minted_token: minted_token_2,
+      balance: balance,
+      amount: 13_377
+    )
 
     # Total: -74_961 BTC
-    insert_list(9, :debit, minted_token: minted_token_2,
-                           balance: balance,
-                           amount: 8_329)
+    insert_list(
+      9,
+      :debit,
+      minted_token: minted_token_2,
+      balance: balance,
+      amount: 8_329
+    )
 
     %{minted_token_1: minted_token_1, minted_token_2: minted_token_2, balance: balance}
   end
 
   describe "cache_all/0" do
-    test "caches all the balances",
-      %{minted_token_1: minted_token_1, balance: balance_1}
-    do
+    test "caches all the balances", %{minted_token_1: minted_token_1, balance: balance_1} do
       balance_2 = insert(:balance, address: "1232")
 
       # Total: +39_924 OMG
-      insert_list(12, :credit, minted_token: minted_token_1,
-                               balance: balance_2,
-                               amount: 3_327)
+      insert_list(
+        12,
+        :credit,
+        minted_token: minted_token_1,
+        balance: balance_2,
+        amount: 3_327
+      )
+
       # Total: -35_028 OMG
-      insert_list(9, :debit, minted_token: minted_token_1,
-                             balance: balance_2,
-                             amount: 3_892)
+      insert_list(
+        9,
+        :debit,
+        minted_token: minted_token_1,
+        balance: balance_2,
+        amount: 3_892
+      )
 
       CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 2
+
       assert LocalLedgerDB.CachedBalance.get(balance_1.address).amounts == %{
-        "tok_OMG_1234" => 120_000 - 61_047,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 120_000 - 61_047,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
+
       assert LocalLedgerDB.CachedBalance.get(balance_2.address).amounts == %{
-        "tok_OMG_1234" => 39_924 - 35_028
-      }
+               "tok_OMG_1234" => 39_924 - 35_028
+             }
     end
 
     test "reuses the previous cached balance to calculate the new one when
-          strategy = 'since_last_cached'",
-      %{minted_token_1: minted_token_1, balance: balance}
-    do
+          strategy = 'since_last_cached'", %{minted_token_1: minted_token_1, balance: balance} do
       Application.put_env(:local_ledger, :balance_caching_strategy, "since_last_cached")
 
       CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 1
 
       assert LocalLedgerDB.CachedBalance.get(balance.address).amounts == %{
-        "tok_OMG_1234" => 120_000 - 61_047,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 120_000 - 61_047,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
 
       # Then we manually add one to hijack the process - this value should be used to
       # calculate the next cached balance (even if it's incorrect in that case...)
       LocalLedgerDB.CachedBalance.insert(%{
-        amounts:         %{"tok_OMG_1234" => 3_000},
+        amounts: %{"tok_OMG_1234" => 3_000},
         balance_address: balance.address,
-        computed_at:     NaiveDateTime.utc_now()
+        computed_at: NaiveDateTime.utc_now()
       })
 
       # Total: +1_000 OMG
-      insert_list(2, :credit, minted_token: minted_token_1,
-                              balance: balance,
-                              amount: 500)
+      insert_list(
+        2,
+        :credit,
+        minted_token: minted_token_1,
+        balance: balance,
+        amount: 500
+      )
 
       CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 3
+
       assert LocalLedgerDB.CachedBalance.get(balance.address).amounts == %{
-        "tok_OMG_1234" => 3_000 + 1_000
-      }
+               "tok_OMG_1234" => 3_000 + 1_000
+             }
     end
 
     test "reuses the previous cached balance to calculate the new one when
-          strategy = 'since_beginning'",
-      %{minted_token_1: minted_token_1, balance: balance}
-    do
+          strategy = 'since_beginning'", %{minted_token_1: minted_token_1, balance: balance} do
       Application.put_env(:local_ledger, :balance_caching_strategy, "since_beginning")
 
       CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 1
 
       assert LocalLedgerDB.CachedBalance.get(balance.address).amounts == %{
-        "tok_OMG_1234" => 120_000 - 61_047,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 120_000 - 61_047,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
 
       # Then we manually add one to hijack the process - this value should NOT be used.
       LocalLedgerDB.CachedBalance.insert(%{
-        amounts:         %{"tok_OMG_1234" => 3_000},
+        amounts: %{"tok_OMG_1234" => 3_000},
         balance_address: balance.address,
-        computed_at:     NaiveDateTime.utc_now()
+        computed_at: NaiveDateTime.utc_now()
       })
 
       # Total: +1_000 OMG
-      insert_list(2, :credit, minted_token: minted_token_1,
-                              balance: balance,
-                              amount: 500)
+      insert_list(
+        2,
+        :credit,
+        minted_token: minted_token_1,
+        balance: balance,
+        amount: 500
+      )
 
       CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 3
+
       assert LocalLedgerDB.CachedBalance.get(balance.address).amounts == %{
-        "tok_OMG_1234" => 58_953 + 1_000,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 58_953 + 1_000,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
     end
 
-    test "reuses the previous cached balance to calculate the new one if no strategy is given",
-      %{minted_token_1: minted_token_1, balance: balance}
-    do
+    test "reuses the previous cached balance to calculate the new one if no strategy is given", %{
+      minted_token_1: minted_token_1,
+      balance: balance
+    } do
       Application.put_env(:local_ledger, :balance_caching_strategy, nil)
 
       CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 1
 
       assert LocalLedgerDB.CachedBalance.get(balance.address).amounts == %{
-        "tok_OMG_1234" => 120_000 - 61_047,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 120_000 - 61_047,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
 
       # Then we manually add one to hijack the process - this value should NOT be used.
       LocalLedgerDB.CachedBalance.insert(%{
-        amounts:         %{"tok_OMG_1234" => 3_000},
+        amounts: %{"tok_OMG_1234" => 3_000},
         balance_address: balance.address,
-        computed_at:     NaiveDateTime.utc_now()
+        computed_at: NaiveDateTime.utc_now()
       })
 
       # Total: +1_000 OMG
-      insert_list(2, :credit, minted_token: minted_token_1,
-                              balance: balance,
-                              amount: 500)
+      insert_list(
+        2,
+        :credit,
+        minted_token: minted_token_1,
+        balance: balance,
+        amount: 500
+      )
 
       CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 3
+
       assert LocalLedgerDB.CachedBalance.get(balance.address).amounts == %{
-        "tok_OMG_1234" => 58_953 + 1_000,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 58_953 + 1_000,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
     end
 
     test "does not store a cached balance if all the amounts are equal to 0" do
@@ -170,27 +208,31 @@ defmodule LocalLedger.CachedBalanceTest do
   end
 
   describe "all/1" do
-    test "calculates the balance and inserts a new cached balance if not existing",
-      %{balance: balance}
-    do
+    test "calculates the balance and inserts a new cached balance if not existing", %{
+      balance: balance
+    } do
       {res, amounts} = CachedBalance.all(balance)
       assert res == :ok
+
       assert amounts == %{
-        "tok_OMG_1234" => 120_000 - 61_047,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 120_000 - 61_047,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
 
       cached_balance = LocalLedgerDB.CachedBalance.get(balance.address)
       assert cached_balance != nil
+
       assert cached_balance.amounts == %{
-        "tok_OMG_1234" => 120_000 - 61_047,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 120_000 - 61_047,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
     end
 
-    test "uses the cached balance and adds the transactions that happened after",
-      %{minted_token_1: minted_token_1, minted_token_2: minted_token_2, balance: balance}
-    do
+    test "uses the cached balance and adds the transactions that happened after", %{
+      minted_token_1: minted_token_1,
+      minted_token_2: minted_token_2,
+      balance: balance
+    } do
       {:ok, _amounts} = CachedBalance.all(balance)
 
       insert_list(1, :credit, minted_token: minted_token_1, balance: balance, amount: 1_337)
@@ -200,36 +242,38 @@ defmodule LocalLedger.CachedBalanceTest do
 
       {:ok, amounts} = CachedBalance.all(balance)
 
-      cached_count   = LocalLedgerDB.CachedBalance |> Repo.all() |> length()
+      cached_count = LocalLedgerDB.CachedBalance |> Repo.all() |> length()
       cached_balance = LocalLedgerDB.CachedBalance.get(balance.address)
 
       assert cached_count == 1
+
       assert cached_balance.amounts == %{
-        "tok_OMG_1234" => 120_000 - 61_047,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 120_000 - 61_047,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
 
       assert amounts == %{
-        "tok_OMG_1234" => 58_953 + 1_337 - 789,
-        "tok_BTC_5678" => 160_524 - 74_961 + 1_232 - 234
-      }
+               "tok_OMG_1234" => 58_953 + 1_337 - 789,
+               "tok_BTC_5678" => 160_524 - 74_961 + 1_232 - 234
+             }
     end
   end
 
   describe "get/2" do
-    test "calculates the balance and inserts a new cached balance if not existing",
-      %{balance: balance}
-    do
+    test "calculates the balance and inserts a new cached balance if not existing", %{
+      balance: balance
+    } do
       {res, amounts} = CachedBalance.get(balance, "tok_OMG_1234")
       assert res == :ok
       assert amounts == %{"tok_OMG_1234" => 120_000 - 61_047}
 
       cached_balance = LocalLedgerDB.CachedBalance.get(balance.address)
       assert cached_balance != nil
+
       assert cached_balance.amounts == %{
-        "tok_OMG_1234" => 120_000 - 61_047,
-        "tok_BTC_5678" => 160_524 - 74_961
-      }
+               "tok_OMG_1234" => 120_000 - 61_047,
+               "tok_BTC_5678" => 160_524 - 74_961
+             }
     end
   end
 end

--- a/apps/local_ledger/test/local_ledger/entry_test.exs
+++ b/apps/local_ledger/test/local_ledger/entry_test.exs
@@ -12,12 +12,14 @@ defmodule LocalLedger.EntryTest do
 
   describe "#all" do
     test "returns all entries" do
-      {:ok, inserted_entry} = :entry |> build |> Repo.insert
-      {:ok, transaction} = :transaction
-                           |> build(entry_uuid: inserted_entry.uuid)
-                           |> Repo.insert
+      {:ok, inserted_entry} = :entry |> build |> Repo.insert()
 
-      {:ok, entries} = Entry.all
+      {:ok, transaction} =
+        :transaction
+        |> build(entry_uuid: inserted_entry.uuid)
+        |> Repo.insert()
+
+      {:ok, entries} = Entry.all()
       entry = Enum.at(entries, 0)
       assert entry.uuid == inserted_entry.uuid
       assert entry.transactions == [transaction]
@@ -26,10 +28,12 @@ defmodule LocalLedger.EntryTest do
 
   describe "#get" do
     test "returns the specified entry" do
-      {:ok, inserted_entry} = :entry |> build |> Repo.insert
-      {:ok, transaction} = :transaction
-                           |> build(entry_uuid: inserted_entry.uuid)
-                           |> Repo.insert
+      {:ok, inserted_entry} = :entry |> build |> Repo.insert()
+
+      {:ok, transaction} =
+        :transaction
+        |> build(entry_uuid: inserted_entry.uuid)
+        |> Repo.insert()
 
       {:ok, entry} = Entry.get(inserted_entry.uuid)
       assert entry.uuid == inserted_entry.uuid
@@ -39,37 +43,47 @@ defmodule LocalLedger.EntryTest do
 
   describe "#insert" do
     defp debits do
-      [%{
-        "address" => "o",
-        "metadata" => %{},
-        "amount" => 100
-      }, %{
-        "address" => "sirn",
-        "metadata" => %{},
-        "amount" => 200
-      }]
+      [
+        %{
+          "address" => "o",
+          "metadata" => %{},
+          "amount" => 100
+        },
+        %{
+          "address" => "sirn",
+          "metadata" => %{},
+          "amount" => 200
+        }
+      ]
     end
 
     def credits do
-      [%{
-        "address" => "thibault",
-        "metadata" => %{},
-        "amount" => 150
-      }, %{
-        "address" => "mederic",
-        "metadata" => %{},
-        "amount" => 150
-      }]
+      [
+        %{
+          "address" => "thibault",
+          "metadata" => %{},
+          "amount" => 150
+        },
+        %{
+          "address" => "mederic",
+          "metadata" => %{},
+          "amount" => 150
+        }
+      ]
     end
 
     def genesis do
-      {:ok, entry} = Entry.insert(%{
-        "metadata" => %{},
-        "debits" => debits(),
-        "credits" => credits(),
-        "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-        "correlation_id" => UUID.generate
-      }, %{genesis: true})
+      {:ok, entry} =
+        Entry.insert(
+          %{
+            "metadata" => %{},
+            "debits" => debits(),
+            "credits" => credits(),
+            "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
+            "correlation_id" => UUID.generate()
+          },
+          %{genesis: true}
+        )
 
       entry
     end
@@ -93,21 +107,29 @@ defmodule LocalLedger.EntryTest do
           enough funds" do
       genesis()
 
-      {:ok, entry} = Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{
-          "address" => "mederic",
-          "metadata" => %{},
-          "amount" => 100
-        }],
-        "credits" => [%{
-          "address" => "thibault",
-          "metadata" => %{},
-          "amount" => 100
-        }],
-        "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-        "correlation_id" => UUID.generate
-      }, %{genesis: false})
+      {:ok, entry} =
+        Entry.insert(
+          %{
+            "metadata" => %{},
+            "debits" => [
+              %{
+                "address" => "mederic",
+                "metadata" => %{},
+                "amount" => 100
+              }
+            ],
+            "credits" => [
+              %{
+                "address" => "thibault",
+                "metadata" => %{},
+                "amount" => 100
+              }
+            ],
+            "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
+            "correlation_id" => UUID.generate()
+          },
+          %{genesis: false}
+        )
 
       assert entry != nil
       assert length(entry.transactions) == 2
@@ -118,21 +140,29 @@ defmodule LocalLedger.EntryTest do
     test "fails when the correlation_id is already in the database" do
       genesis_entry = genesis()
 
-      {status, error} = Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{
-          "address" => "mederic",
-          "metadata" => %{},
-          "amount" => 100
-        }],
-        "credits" => [%{
-          "address" => "thibault",
-          "metadata" => %{},
-          "amount" => 100
-        }],
-        "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-        "correlation_id" => genesis_entry.correlation_id
-      }, %{genesis: false})
+      {status, error} =
+        Entry.insert(
+          %{
+            "metadata" => %{},
+            "debits" => [
+              %{
+                "address" => "mederic",
+                "metadata" => %{},
+                "amount" => 100
+              }
+            ],
+            "credits" => [
+              %{
+                "address" => "thibault",
+                "metadata" => %{},
+                "amount" => 100
+              }
+            ],
+            "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
+            "correlation_id" => genesis_entry.correlation_id
+          },
+          %{genesis: false}
+        )
 
       assert status == :error
       assert error.errors == [correlation_id: {"has already been taken", []}]
@@ -141,96 +171,128 @@ defmodule LocalLedger.EntryTest do
     test "returns a 'same address' error when the from/to addresses are identical" do
       genesis()
 
-      res = Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{
-          "address" => "mederic",
-          "metadata" => %{},
-          "amount" => 200
-        }],
-        "credits" => [%{
-          "address" => "mederic",
-          "metadata" => %{},
-          "amount" => 200
-        }],
-        "minted_token" => %{
-          "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-          "metadata" => %{}
-        },
-        "correlation_id" => UUID.generate
-      }, %{genesis: false})
+      res =
+        Entry.insert(
+          %{
+            "metadata" => %{},
+            "debits" => [
+              %{
+                "address" => "mederic",
+                "metadata" => %{},
+                "amount" => 200
+              }
+            ],
+            "credits" => [
+              %{
+                "address" => "mederic",
+                "metadata" => %{},
+                "amount" => 200
+              }
+            ],
+            "minted_token" => %{
+              "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
+              "metadata" => %{}
+            },
+            "correlation_id" => UUID.generate()
+          },
+          %{genesis: false}
+        )
 
       assert res == {
-        :error,
-        :same_address,
-        "Found identical addresses in senders and receivers: mederic."
-      }
+               :error,
+               :same_address,
+               "Found identical addresses in senders and receivers: mederic."
+             }
     end
 
     test "returns an 'insufficient_funds' error when the debit balances don't have enough funds" do
       genesis()
 
-      {:error, :insufficient_funds, _} = Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{
-          "address" => "mederic",
-          "metadata" => %{},
-          "amount" => 200
-        }],
-        "credits" => [%{
-          "address" => "thibault",
-          "metadata" => %{},
-          "amount" => 200
-        }],
-        "minted_token" => %{
-          "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-          "metadata" => %{}
-        },
-        "correlation_id" => UUID.generate
-      }, %{genesis: false})
+      {:error, :insufficient_funds, _} =
+        Entry.insert(
+          %{
+            "metadata" => %{},
+            "debits" => [
+              %{
+                "address" => "mederic",
+                "metadata" => %{},
+                "amount" => 200
+              }
+            ],
+            "credits" => [
+              %{
+                "address" => "thibault",
+                "metadata" => %{},
+                "amount" => 200
+              }
+            ],
+            "minted_token" => %{
+              "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
+              "metadata" => %{}
+            },
+            "correlation_id" => UUID.generate()
+          },
+          %{genesis: false}
+        )
     end
 
     test "returns an 'invalid_amount' error when amount is invalid (debit != credit)" do
       genesis()
 
-      {:error, :invalid_amount, _} = Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{
-          "address" => "mederic",
-          "metadata" => %{},
-          "amount" => 200
-        }],
-        "credits" => [%{
-          "address" => "thibault",
-          "metadata" => %{},
-          "amount" => 100
-        }],
-        "minted_token" => %{
-          "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-          "metadata" => %{}
-        },
-        "correlation_id" => UUID.generate
-      }, %{genesis: false})
+      {:error, :invalid_amount, _} =
+        Entry.insert(
+          %{
+            "metadata" => %{},
+            "debits" => [
+              %{
+                "address" => "mederic",
+                "metadata" => %{},
+                "amount" => 200
+              }
+            ],
+            "credits" => [
+              %{
+                "address" => "thibault",
+                "metadata" => %{},
+                "amount" => 100
+              }
+            ],
+            "minted_token" => %{
+              "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
+              "metadata" => %{}
+            },
+            "correlation_id" => UUID.generate()
+          },
+          %{genesis: false}
+        )
     end
 
     test "returns an 'amount_is_zero' error when amount is 0" do
       genesis()
 
-      {:error, :amount_is_zero, _} = Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{
-          "address" => "mederic",
-          "metadata" => %{},
-          "amount" => 0
-        }],
-        "credits" => [%{
-          "address" => "thibault",
-          "metadata" => %{},
-          "amount" => 0
-        }],
-        "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-        "correlation_id" => UUID.generate
-        }, %{genesis: false})
+      {:error, :amount_is_zero, _} =
+        Entry.insert(
+          %{
+            "metadata" => %{},
+            "debits" => [
+              %{
+                "address" => "mederic",
+                "metadata" => %{},
+                "amount" => 0
+              }
+            ],
+            "credits" => [
+              %{
+                "address" => "thibault",
+                "metadata" => %{},
+                "amount" => 0
+              }
+            ],
+            "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
+            "correlation_id" => UUID.generate()
+          },
+          %{genesis: false}
+        )
     end
 
     test "updates the balances one after the other with two inserts happening
@@ -242,35 +304,43 @@ defmodule LocalLedger.EntryTest do
       assert get_current_balance("thibault") == 150
       assert get_current_balance("sirn") == -200
 
-      {:ok, new_pid} = Task.start_link fn ->
-        Sandbox.allow(Repo, pid, self())
-        assert_receive :select_for_update, 5000
+      {:ok, new_pid} =
+        Task.start_link(fn ->
+          Sandbox.allow(Repo, pid, self())
+          assert_receive :select_for_update, 5000
 
-        assert get_current_balance("mederic") == 50
-        assert get_current_balance("thibault") == 250
-        assert get_current_balance("sirn") == -200
+          assert get_current_balance("mederic") == 50
+          assert get_current_balance("thibault") == 250
+          assert get_current_balance("sirn") == -200
 
-        # this should block until the other transaction commit
-        Entry.insert(%{
+          # this should block until the other transaction commit
+          Entry.insert(
+            %{
+              "metadata" => %{},
+              "debits" => [%{"address" => "mederic", "metadata" => %{}, "amount" => 50}],
+              "credits" => [%{"address" => "sirn", "metadata" => %{}, "amount" => 50}],
+              "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
+              "correlation_id" => UUID.generate()
+            },
+            %{genesis: false}
+          )
+
+          send(pid, :updated)
+        end)
+
+      Entry.insert(
+        %{
           "metadata" => %{},
-          "debits" => [%{"address" => "mederic", "metadata" => %{}, "amount" => 50}],
-          "credits" => [%{"address" => "sirn", "metadata" => %{}, "amount" => 50}],
+          "debits" => [%{"address" => "mederic", "metadata" => %{}, "amount" => 100}],
+          "credits" => [%{"address" => "thibault", "metadata" => %{}, "amount" => 100}],
           "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-          "correlation_id" => UUID.generate
-        }, %{genesis: false})
-
-        send pid, :updated
-      end
-
-      Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{"address" => "mederic", "metadata" => %{}, "amount" => 100}],
-        "credits" => [%{"address" => "thibault", "metadata" => %{}, "amount" => 100}],
-        "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-        "correlation_id" => UUID.generate
-      }, %{genesis: false}, fn ->
-        send new_pid, :select_for_update
-      end)
+          "correlation_id" => UUID.generate()
+        },
+        %{genesis: false},
+        fn ->
+          send(new_pid, :select_for_update)
+        end
+      )
 
       assert_receive :updated, 5000
       assert get_current_balance("mederic") == 0
@@ -287,48 +357,68 @@ defmodule LocalLedger.EntryTest do
       assert get_current_balance("thibault") == 150
       assert get_current_balance("sirn") == -200
 
-      {:ok, new_pid} = Task.start_link fn ->
-        Sandbox.allow(Repo, pid, self())
-        assert_receive :select_for_update, 5000
+      {:ok, new_pid} =
+        Task.start_link(fn ->
+          Sandbox.allow(Repo, pid, self())
+          assert_receive :select_for_update, 5000
 
-        # this should block until the other transaction commit
-        {res, error, _} = Entry.insert(%{
+          # this should block until the other transaction commit
+          {res, error, _} =
+            Entry.insert(
+              %{
+                "metadata" => %{},
+                "debits" => [
+                  %{
+                    "address" => "mederic",
+                    "metadata" => %{},
+                    "amount" => 100
+                  }
+                ],
+                "credits" => [
+                  %{
+                    "address" => "sirn",
+                    "metadata" => %{},
+                    "amount" => 100
+                  }
+                ],
+                "minted_token" => %{
+                  "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
+                  "metadata" => %{}
+                },
+                "correlation_id" => UUID.generate()
+              },
+              %{genesis: false}
+            )
+
+          assert res == :error
+          assert error == :insufficient_funds
+          send(pid, :updated)
+        end)
+
+      send(new_pid, :select_for_update)
+
+      Entry.insert(
+        %{
           "metadata" => %{},
-          "debits" => [%{
-            "address" => "mederic",
-            "metadata" => %{},
-            "amount" => 100
-          }],
-          "credits" => [%{
-            "address" => "sirn",
-            "metadata" => %{},
-            "amount" => 100
-          }],
+          "debits" => [
+            %{
+              "address" => "mederic",
+              "metadata" => %{},
+              "amount" => 100
+            }
+          ],
+          "credits" => [
+            %{
+              "address" => "thibault",
+              "metadata" => %{},
+              "amount" => 100
+            }
+          ],
           "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-          "correlation_id" => UUID.generate
-        }, %{genesis: false})
-
-        assert res == :error
-        assert error == :insufficient_funds
-        send pid, :updated
-      end
-
-      send new_pid, :select_for_update
-      Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{
-          "address" => "mederic",
-          "metadata" => %{},
-          "amount" => 100
-        }],
-        "credits" => [%{
-          "address" => "thibault",
-          "metadata" => %{},
-          "amount" => 100
-        }],
-        "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-        "correlation_id" => UUID.generate
-      }, %{genesis: false})
+          "correlation_id" => UUID.generate()
+        },
+        %{genesis: false}
+      )
 
       assert_receive :updated, 5000
       assert get_current_balance("mederic") == 50
@@ -337,48 +427,61 @@ defmodule LocalLedger.EntryTest do
     end
 
     test "handles integers up to 1 trillion * 1e18" do
-      {:ok, entry} = Entry.insert(%{
-        "metadata" => %{},
-        "debits" => [%{
-          "address" => "o",
-          "metadata" => %{},
-          "amount" => 1_000_000_000_000_000_000_000_000_000_000
-        }],
-        "credits" => [%{
-          "address" => "thibault",
-          "metadata" => %{},
-          "amount" => 1_000_000_000_000_000_000_000_000_000_000
-        }],
-        "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-        "correlation_id" => UUID.generate
-      }, %{genesis: true})
+      {:ok, entry} =
+        Entry.insert(
+          %{
+            "metadata" => %{},
+            "debits" => [
+              %{
+                "address" => "o",
+                "metadata" => %{},
+                "amount" => 1_000_000_000_000_000_000_000_000_000_000
+              }
+            ],
+            "credits" => [
+              %{
+                "address" => "thibault",
+                "metadata" => %{},
+                "amount" => 1_000_000_000_000_000_000_000_000_000_000
+              }
+            ],
+            "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
+            "correlation_id" => UUID.generate()
+          },
+          %{genesis: true}
+        )
 
       assert entry != nil
       assert length(entry.transactions) == 2
-      assert get_current_balance("o") ==
-        -1_000_000_000_000_000_000_000_000_000_000
-      assert get_current_balance("thibault") ==
-        1_000_000_000_000_000_000_000_000_000_000
+      assert get_current_balance("o") == -1_000_000_000_000_000_000_000_000_000_000
+      assert get_current_balance("thibault") == 1_000_000_000_000_000_000_000_000_000_000
     end
 
     test "fails for integers above 1 trillion * 1e81" do
-
       assert_raise Postgrex.Error, fn ->
-        {:ok, _} = Entry.insert(%{
-          "metadata" => %{},
-          "debits" => [%{
-            "address" => "o",
-            "metadata" => %{},
-            "amount" => round(1_000_000_000_000.0e82)
-          }],
-          "credits" => [%{
-            "address" => "thibault",
-            "metadata" => %{},
-            "amount" => round(1_000_000_000_000.0e82)
-          }],
-          "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-          "correlation_id" => UUID.generate
-        }, %{genesis: true})
+        {:ok, _} =
+          Entry.insert(
+            %{
+              "metadata" => %{},
+              "debits" => [
+                %{
+                  "address" => "o",
+                  "metadata" => %{},
+                  "amount" => round(1_000_000_000_000.0e82)
+                }
+              ],
+              "credits" => [
+                %{
+                  "address" => "thibault",
+                  "metadata" => %{},
+                  "amount" => round(1_000_000_000_000.0e82)
+                }
+              ],
+              "minted_token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
+              "correlation_id" => UUID.generate()
+            },
+            %{genesis: true}
+          )
       end
     end
   end

--- a/apps/local_ledger/test/local_ledger/transaction_test.exs
+++ b/apps/local_ledger/test/local_ledger/transaction_test.exs
@@ -12,34 +12,41 @@ defmodule LocalLedger.TransactionTest do
 
   describe "#build_all" do
     test "builds and formats the transactions" do
-      debits = [%{
-        "address" => "omisego.test.sender1",
-        "metadata" => %{},
-        "amount" => 100
-      }]
-      credits = [%{
-        "address" => "omisego.test.receiver1",
-        "metadata" => %{},
-        "amount" => 100
-      }]
+      debits = [
+        %{
+          "address" => "omisego.test.sender1",
+          "metadata" => %{},
+          "amount" => 100
+        }
+      ]
+
+      credits = [
+        %{
+          "address" => "omisego.test.receiver1",
+          "metadata" => %{},
+          "amount" => 100
+        }
+      ]
+
       token = %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
       incoming_transactions = {debits, credits}
 
-      formatted_transactions = Transaction.build_all(incoming_transactions,
-                                                     token)
-       assert formatted_transactions == [
-         %{
-           type: LocalLedgerDB.Transaction.debit_type,
-           amount: 100,
-           minted_token_id: "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-           balance_address: "omisego.test.sender1",
-         }, %{
-           type: LocalLedgerDB.Transaction.credit_type,
-           amount: 100,
-           minted_token_id: "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-           balance_address: "omisego.test.receiver1",
-         }
-       ]
+      formatted_transactions = Transaction.build_all(incoming_transactions, token)
+
+      assert formatted_transactions == [
+               %{
+                 type: LocalLedgerDB.Transaction.debit_type(),
+                 amount: 100,
+                 minted_token_id: "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
+                 balance_address: "omisego.test.sender1"
+               },
+               %{
+                 type: LocalLedgerDB.Transaction.credit_type(),
+                 amount: 100,
+                 minted_token_id: "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
+                 balance_address: "omisego.test.receiver1"
+               }
+             ]
     end
   end
 
@@ -47,15 +54,16 @@ defmodule LocalLedger.TransactionTest do
     test "returns the list of debit addresses" do
       transactions = [
         %{
-          type: LocalLedgerDB.Transaction.debit_type,
+          type: LocalLedgerDB.Transaction.debit_type(),
           amount: 100,
           minted_token_id: "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-          balance_address: "omisego.test.sender1",
-        }, %{
-          type: LocalLedgerDB.Transaction.credit_type,
+          balance_address: "omisego.test.sender1"
+        },
+        %{
+          type: LocalLedgerDB.Transaction.credit_type(),
           amount: 100,
           minted_token_id: "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-          balance_address: "omisego.test.receiver1",
+          balance_address: "omisego.test.receiver1"
         }
       ]
 
@@ -66,22 +74,23 @@ defmodule LocalLedger.TransactionTest do
 
   describe "#check_funds" do
     defp init_debit_balances(amount_1, amount_2) do
-      {:ok, token} = :minted_token |> build |> Repo.insert
-      {:ok, balance_1} = :balance |> build(address: "test1") |> Repo.insert
-      {:ok, balance_2} = :balance |> build(address: "test2") |> Repo.insert
-      {:ok, balance_3} = :balance |> build(address: "test3") |> Repo.insert
+      {:ok, token} = :minted_token |> build |> Repo.insert()
+      {:ok, balance_1} = :balance |> build(address: "test1") |> Repo.insert()
+      {:ok, balance_2} = :balance |> build(address: "test2") |> Repo.insert()
+      {:ok, balance_3} = :balance |> build(address: "test3") |> Repo.insert()
 
       Entry.insert(%{
         metadata: %{},
-        correlation_id: UUID.generate,
+        correlation_id: UUID.generate(),
         transactions: [
           %{
-            type: LocalLedgerDB.Transaction.credit_type,
+            type: LocalLedgerDB.Transaction.credit_type(),
             amount: amount_1,
             minted_token_id: token.id,
             balance_address: balance_1.address
-          }, %{
-            type: LocalLedgerDB.Transaction.credit_type,
+          },
+          %{
+            type: LocalLedgerDB.Transaction.credit_type(),
             amount: amount_2,
             minted_token_id: token.id,
             balance_address: balance_2.address
@@ -96,22 +105,26 @@ defmodule LocalLedger.TransactionTest do
           not have enough funds" do
       {token, balance_1, balance_2, balance_3} = init_debit_balances(80, 100)
 
-      transactions = [%{
-        type: LocalLedgerDB.Transaction.debit_type,
-        amount: 100,
-        minted_token_id: token.id,
-        balance_address: balance_1.address,
-      }, %{
-        type: LocalLedgerDB.Transaction.debit_type,
-        amount: 100,
-        minted_token_id: token.id,
-        balance_address: balance_2.address,
-      }, %{
-        type: LocalLedgerDB.Transaction.credit_type,
-        amount: 200,
-        minted_token_id: token.id,
-        balance_address: balance_3.address,
-      }]
+      transactions = [
+        %{
+          type: LocalLedgerDB.Transaction.debit_type(),
+          amount: 100,
+          minted_token_id: token.id,
+          balance_address: balance_1.address
+        },
+        %{
+          type: LocalLedgerDB.Transaction.debit_type(),
+          amount: 100,
+          minted_token_id: token.id,
+          balance_address: balance_2.address
+        },
+        %{
+          type: LocalLedgerDB.Transaction.credit_type(),
+          amount: 200,
+          minted_token_id: token.id,
+          balance_address: balance_3.address
+        }
+      ]
 
       assert_raise InsufficientFundsError, fn ->
         Transaction.check_balance(transactions)
@@ -121,22 +134,26 @@ defmodule LocalLedger.TransactionTest do
     test "returns :ok when all the debit balances have enough funds" do
       {token, balance_1, balance_2, balance_3} = init_debit_balances(200, 100)
 
-      transactions = [%{
-        type: LocalLedgerDB.Transaction.debit_type,
-        amount: 100,
-        minted_token_id: token.id,
-        balance_address: balance_1.address,
-      }, %{
-        type: LocalLedgerDB.Transaction.debit_type,
-        amount: 100,
-        minted_token_id: token.id,
-        balance_address: balance_2.address,
-      }, %{
-        type: LocalLedgerDB.Transaction.credit_type,
-        amount: 100,
-        minted_token_id: token.id,
-        balance_address: balance_3.address,
-      }]
+      transactions = [
+        %{
+          type: LocalLedgerDB.Transaction.debit_type(),
+          amount: 100,
+          minted_token_id: token.id,
+          balance_address: balance_1.address
+        },
+        %{
+          type: LocalLedgerDB.Transaction.debit_type(),
+          amount: 100,
+          minted_token_id: token.id,
+          balance_address: balance_2.address
+        },
+        %{
+          type: LocalLedgerDB.Transaction.credit_type(),
+          amount: 100,
+          minted_token_id: token.id,
+          balance_address: balance_3.address
+        }
+      ]
 
       res = Transaction.check_balance(transactions)
       assert res == :ok

--- a/apps/local_ledger_db/config/config.exs
+++ b/apps/local_ledger_db/config/config.exs
@@ -6,7 +6,7 @@ config :local_ledger_db, ecto_repos: [LocalLedgerDB.Repo]
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/apps/local_ledger_db/config/dev.exs
+++ b/apps/local_ledger_db/config/dev.exs
@@ -7,6 +7,6 @@ config :local_ledger_db, LocalLedgerDB.Repo,
 key = "j6fy7rZP9ASvf1bmywWGRjrmh8gKANrg40yWZ-rSKpI"
 
 config :cloak, Salty.SecretBox.Cloak,
-       tag: "SBX",
-       default: true,
-       keys: [%{tag: <<1>>, key: key, default: true}]
+  tag: "SBX",
+  default: true,
+  keys: [%{tag: <<1>>, key: key, default: true}]

--- a/apps/local_ledger_db/config/prod.exs
+++ b/apps/local_ledger_db/config/prod.exs
@@ -7,6 +7,6 @@ config :local_ledger_db, LocalLedgerDB.Repo,
 key = System.get_env("CAISHEN_SECRET_KEY") || System.get_env("LOCAL_LEDGER_SECRET_KEY")
 
 config :cloak, Salty.SecretBox.Cloak,
-       tag: "SBX",
-       default: true,
-       keys: [%{tag: <<1>>, key: key, default: true}]
+  tag: "SBX",
+  default: true,
+  keys: [%{tag: <<1>>, key: key, default: true}]

--- a/apps/local_ledger_db/config/test.exs
+++ b/apps/local_ledger_db/config/test.exs
@@ -8,6 +8,6 @@ config :local_ledger_db, LocalLedgerDB.Repo,
 key = "j6fy7rZP9ASvf1bmywWGRjrmh8gKANrg40yWZ-rSKpI"
 
 config :cloak, Salty.SecretBox.Cloak,
-       tag: "SBX",
-       default: true,
-       keys: [%{tag: <<1>>, key: key, default: true}]
+  tag: "SBX",
+  default: true,
+  keys: [%{tag: <<1>>, key: key, default: true}]

--- a/apps/local_ledger_db/lib/local_ledger_db/cached_balance.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/cached_balance.ex
@@ -9,11 +9,17 @@ defmodule LocalLedgerDB.CachedBalance do
   @primary_key {:uuid, Ecto.UUID, autogenerate: true}
 
   schema "cached_balance" do
-    field :amounts, :map
-    field :computed_at, :naive_datetime
-    belongs_to :balance, Balance, foreign_key: :balance_address,
-                                  references: :address,
-                                  type: :string
+    field(:amounts, :map)
+    field(:computed_at, :naive_datetime)
+
+    belongs_to(
+      :balance,
+      Balance,
+      foreign_key: :balance_address,
+      references: :address,
+      type: :string
+    )
+
     timestamps()
   end
 

--- a/apps/local_ledger_db/lib/local_ledger_db/ecto_batch_stream.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/ecto_batch_stream.ex
@@ -13,16 +13,19 @@ defmodule LocalLedger.EctoBatchStream do
   #     stream = EctoBatchStream.stream(MyApp.Repo, query)
   #     stream |> Stream.take(3) |> Enum.to_list # => […]
   def stream(repo, query, batch_size \\ @batch_size) do
-    batches_stream = Stream.unfold(0, fn
-      :done -> nil
-      offset ->
-        results = repo.all(from _ in query, offset: ^offset, limit: ^batch_size)
+    batches_stream =
+      Stream.unfold(0, fn
+        :done ->
+          nil
 
-        if length(results) < batch_size,
-          do: {results, :done},
-          else: {results, offset + batch_size}
-    end)
+        offset ->
+          results = repo.all(from(_ in query, offset: ^offset, limit: ^batch_size))
 
-    batches_stream |> Stream.concat
+          if length(results) < batch_size,
+            do: {results, :done},
+            else: {results, offset + batch_size}
+      end)
+
+    batches_stream |> Stream.concat()
   end
 end

--- a/apps/local_ledger_db/lib/local_ledger_db/errors/insufficient_funds_error.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/errors/insufficient_funds_error.ex
@@ -3,10 +3,10 @@ defmodule LocalLedgerDB.Errors.InsufficientFundsError do
                          for this transaction."
 
   def error_message(current_amount, %{
-    amount: amount_to_debit,
-    minted_token_id: minted_token_id,
-    address: address
-  }) do
+        amount: amount_to_debit,
+        minted_token_id: minted_token_id,
+        address: address
+      }) do
     %{
       address: address,
       current_amount: current_amount,

--- a/apps/local_ledger_db/lib/local_ledger_db/minted_token.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/minted_token.ex
@@ -11,12 +11,18 @@ defmodule LocalLedgerDB.MintedToken do
   @primary_key {:uuid, UUID, autogenerate: true}
 
   schema "minted_token" do
-    field :id, :string
-    field :metadata, :map, default: %{}
-    field :encrypted_metadata, Cloak.EncryptedMapField, default: %{}
-    field :encryption_version, :binary
-    has_many :transactions, Transaction, foreign_key: :minted_token_id,
-                                         references: :id
+    field(:id, :string)
+    field(:metadata, :map, default: %{})
+    field(:encrypted_metadata, Cloak.EncryptedMapField, default: %{})
+    field(:encryption_version, :binary)
+
+    has_many(
+      :transactions,
+      Transaction,
+      foreign_key: :minted_token_id,
+      references: :id
+    )
+
     timestamps()
   end
 
@@ -28,7 +34,7 @@ defmodule LocalLedgerDB.MintedToken do
     |> cast(attrs, [:id, :metadata, :encrypted_metadata, :encryption_version])
     |> validate_required([:id, :metadata, :encrypted_metadata])
     |> unique_constraint(:id)
-    |> put_change(:encryption_version, Cloak.version)
+    |> put_change(:encryption_version, Cloak.version())
   end
 
   @doc """
@@ -39,6 +45,7 @@ defmodule LocalLedgerDB.MintedToken do
     case get(id) do
       nil ->
         insert(attrs)
+
       minted_token ->
         {:ok, minted_token}
     end
@@ -64,6 +71,7 @@ defmodule LocalLedgerDB.MintedToken do
     case Repo.insert(changeset, opts) do
       {:ok, _minted_token} ->
         {:ok, get(id)}
+
       {:error, changeset} ->
         {:error, changeset}
     end

--- a/apps/local_ledger_db/test/local_ledger_db/balance_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/balance_test.exs
@@ -12,15 +12,14 @@ defmodule LocalLedgerDB.BalanceTest do
 
   describe "initialization" do
     test "generates a UUID" do
-      {res, balance} = :balance |> build |> Repo.insert
+      {res, balance} = :balance |> build |> Repo.insert()
 
       assert res == :ok
-      assert String.match?(balance.uuid,
-                           ~r/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
+      assert String.match?(balance.uuid, ~r/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
     end
 
     test "generates the inserted_at and updated_at values" do
-      {res, balance} = :balance |> build |> Repo.insert
+      {res, balance} = :balance |> build |> Repo.insert()
 
       assert res == :ok
       assert balance.inserted_at != nil
@@ -28,7 +27,7 @@ defmodule LocalLedgerDB.BalanceTest do
     end
 
     test "saves the encrypted metadata" do
-      :balance |> build(%{metadata: %{e_id: "123"}}) |> Repo.insert
+      :balance |> build(%{metadata: %{e_id: "123"}}) |> Repo.insert()
 
       {:ok, results} = SQL.query(Repo, "SELECT encrypted_metadata FROM balance", [])
 
@@ -39,8 +38,7 @@ defmodule LocalLedgerDB.BalanceTest do
 
   describe "validations" do
     test "has a valid factory" do
-      changeset = Balance.changeset(%Balance{},
-                                    string_params_for(:balance))
+      changeset = Balance.changeset(%Balance{}, string_params_for(:balance))
       assert changeset.valid?
     end
 
@@ -48,24 +46,25 @@ defmodule LocalLedgerDB.BalanceTest do
       params = string_params_for(:balance, %{address: nil})
       changeset = Balance.changeset(%Balance{}, params)
       refute changeset.valid?
-      assert changeset.errors == [address: {"can't be blank",
-                                            [validation: :required]}]
+      assert changeset.errors == [address: {"can't be blank", [validation: :required]}]
     end
 
     test "prevents creation of a balance with an address already in DB" do
-      {:ok, _} = :balance |> build |> Repo.insert
+      {:ok, _} = :balance |> build |> Repo.insert()
 
-      {:error, balance} = %Balance{}
-                          |> Balance.changeset(string_params_for(:balance))
-                          |> Repo.insert
+      {:error, balance} =
+        %Balance{}
+        |> Balance.changeset(string_params_for(:balance))
+        |> Repo.insert()
 
       assert balance.errors == [address: {"has already been taken", []}]
     end
 
     test "allows creation of a balance with metadata" do
-      {res, balance} = :balance
-                       |> build(%{metadata: %{e_id: "123"}})
-                       |> Repo.insert
+      {res, balance} =
+        :balance
+        |> build(%{metadata: %{e_id: "123"}})
+        |> Repo.insert()
 
       assert res == :ok
       assert balance.metadata == %{e_id: "123"}
@@ -74,9 +73,10 @@ defmodule LocalLedgerDB.BalanceTest do
 
   describe "#touch" do
     test "touches the balance" do
-      {_, inserted_balance} = :balance
-                              |> build
-                              |> Repo.insert
+      {_, inserted_balance} =
+        :balance
+        |> build
+        |> Repo.insert()
 
       Balance.touch([inserted_balance.address])
       updated_balance = Balance.get(inserted_balance.address)
@@ -89,36 +89,42 @@ defmodule LocalLedgerDB.BalanceTest do
       balances = Repo.all(Balance)
       assert balances == []
 
-      {:ok, balance} = Balance.get_or_insert(%{
-        "address" => "123",
-        "metadata" => %{}
-      })
+      {:ok, balance} =
+        Balance.get_or_insert(%{
+          "address" => "123",
+          "metadata" => %{}
+        })
 
       balances = Repo.all(Balance)
       assert balances == [balance]
     end
 
     test "returns an existing balance when it is already in the database" do
-      {_, inserted_balance} = :balance
-                              |> build(%{address: "456"})
-                              |> Repo.insert
+      {_, inserted_balance} =
+        :balance
+        |> build(%{address: "456"})
+        |> Repo.insert()
 
       assert Enum.at(Repo.all(Balance), 0).uuid == inserted_balance.uuid
-      {:ok, balance} = Balance.get_or_insert(%{
-        "address" => "456",
-        "metadata" => %{}
-      })
+
+      {:ok, balance} =
+        Balance.get_or_insert(%{
+          "address" => "456",
+          "metadata" => %{}
+        })
+
       assert inserted_balance.uuid == balance.uuid
     end
 
     defp start_task(pid, callback) do
-      {:ok, pid} = Task.start_link fn ->
-        Sandbox.allow(Repo, pid, self())
-        assert_receive :select_for_update, 5000
-        balance = callback.()
-        assert balance.address == "123"
-        send pid, :updated
-      end
+      {:ok, pid} =
+        Task.start_link(fn ->
+          Sandbox.allow(Repo, pid, self())
+          assert_receive :select_for_update, 5000
+          balance = callback.()
+          assert balance.address == "123"
+          send(pid, :updated)
+        end)
 
       pid
     end
@@ -127,19 +133,22 @@ defmodule LocalLedgerDB.BalanceTest do
       pid = self()
 
       callback = fn ->
-        {:ok, balance} = Balance.get_or_insert(%{
-          "address" => "123",
-          "metadata" => %{}
-        })
+        {:ok, balance} =
+          Balance.get_or_insert(%{
+            "address" => "123",
+            "metadata" => %{}
+          })
+
         balance
       end
 
       for _ <- 0..10, do: send(start_task(pid, callback), :select_for_update)
 
-      {:ok, balance} = Balance.get_or_insert(%{
-        "address" => "123",
-        "metadata" => %{}
-      })
+      {:ok, balance} =
+        Balance.get_or_insert(%{
+          "address" => "123",
+          "metadata" => %{}
+        })
 
       assert_receive :updated, 5000
       assert length(Repo.all(Balance)) == 1
@@ -149,9 +158,11 @@ defmodule LocalLedgerDB.BalanceTest do
 
   describe "#get" do
     test "returns the existing balance" do
-      {_, inserted_balance} = :balance
-                              |> build(%{address: "456"})
-                              |> Repo.insert
+      {_, inserted_balance} =
+        :balance
+        |> build(%{address: "456"})
+        |> Repo.insert()
+
       balance = Balance.get("456")
       assert balance.uuid == inserted_balance.uuid
     end
@@ -165,61 +176,63 @@ defmodule LocalLedgerDB.BalanceTest do
   describe "#insert" do
     test "inserts a balance if it does not existing" do
       assert Repo.all(Balance) == []
-      {:ok, balance} = :balance |> string_params_for |> Balance.insert
+      {:ok, balance} = :balance |> string_params_for |> Balance.insert()
       assert Repo.all(Balance) == [balance]
     end
 
     test "returns the existing balance without error if already existing" do
       assert Repo.all(Balance) == []
-      inserted_balance = :balance |> string_params_for |> Balance.insert
-      balance = :balance |> string_params_for |> Balance.insert
+      inserted_balance = :balance |> string_params_for |> Balance.insert()
+      balance = :balance |> string_params_for |> Balance.insert()
 
       assert inserted_balance == balance
     end
 
     test "returns an error when passing invalid arguments" do
       assert Repo.all(Balance) == []
-      {res, changeset} = %{"address" => nil, "metadata" => %{}}
-                         |> Balance.insert
+
+      {res, changeset} =
+        %{"address" => nil, "metadata" => %{}}
+        |> Balance.insert()
+
       assert res == :error
-      assert changeset.errors == [address: {"can't be blank",
-                                            [validation: :required]}]
+      assert changeset.errors == [address: {"can't be blank", [validation: :required]}]
     end
   end
 
   describe "#lock" do
     test "locks the balances associated with the given addresses get locked" do
-      {_, balance_1} = :balance |> build(%{address: "123"}) |> Repo.insert
-      {_, balance_2} = :balance |> build(%{address: "345"}) |> Repo.insert
+      {_, balance_1} = :balance |> build(%{address: "123"}) |> Repo.insert()
+      {_, balance_2} = :balance |> build(%{address: "345"}) |> Repo.insert()
       pid = self()
 
       {:ok, new_pid} =
-        Task.start_link fn ->
+        Task.start_link(fn ->
           Sandbox.allow(Repo, pid, self())
           assert_receive :select_for_update, 5000
 
           Repo.transaction(fn ->
             # this should block until the other transaction commit
             balance = Balance.get(balance_1.address)
-            changeset = Balance.changeset(balance,
-                                          %{metadata: %{desc: "Blocked"}})
+            changeset = Balance.changeset(balance, %{metadata: %{desc: "Blocked"}})
             Repo.update!(changeset)
           end)
 
-        send pid, :updated
-      end
+          send(pid, :updated)
+        end)
 
-      {:ok, updated_balance} = Repo.transaction fn ->
-        Balance.lock([balance_1.address, balance_2.address])
-        send new_pid, :select_for_update
+      {:ok, updated_balance} =
+        Repo.transaction(fn ->
+          Balance.lock([balance_1.address, balance_2.address])
+          send(new_pid, :select_for_update)
 
-        balance_1.address
-        |> Balance.get
-        |> Balance.changeset(%{metadata: %{desc: "Free"}})
-        |> Repo.update!
+          balance_1.address
+          |> Balance.get()
+          |> Balance.changeset(%{metadata: %{desc: "Free"}})
+          |> Repo.update!()
 
-        Balance.get(balance_1.address)
-      end
+          Balance.get(balance_1.address)
+        end)
 
       assert updated_balance.metadata == %{"desc" => "Free"}
       assert_receive :updated, 5000

--- a/apps/local_ledger_db/test/local_ledger_db/entry_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/entry_test.exs
@@ -11,15 +11,14 @@ defmodule LocalLedgerDB.EntryTest do
   end
 
   test "generates a UUID" do
-    {res, entry} = :entry |> build |> Repo.insert
+    {res, entry} = :entry |> build |> Repo.insert()
 
     assert res == :ok
-    assert String.match?(entry.uuid,
-                         ~r/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
+    assert String.match?(entry.uuid, ~r/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
   end
 
   test "generates the inserted_at and updated_at values" do
-    {res, entry} = :entry |> build |> Repo.insert
+    {res, entry} = :entry |> build |> Repo.insert()
 
     assert res == :ok
     assert entry.inserted_at != nil
@@ -34,7 +33,7 @@ defmodule LocalLedgerDB.EntryTest do
   end
 
   test "allows creation of an entry with metadata" do
-    {res, entry} = :entry |> build(%{metadata: %{e_id: "123"}}) |> Repo.insert
+    {res, entry} = :entry |> build(%{metadata: %{e_id: "123"}}) |> Repo.insert()
 
     assert res == :ok
     assert entry.metadata == %{e_id: "123"}
@@ -49,7 +48,7 @@ defmodule LocalLedgerDB.EntryTest do
   end
 
   test "saves the encrypted metadata" do
-    :entry |> build(%{metadata: %{e_id: "123"}}) |> Repo.insert
+    :entry |> build(%{metadata: %{e_id: "123"}}) |> Repo.insert()
 
     {:ok, results} = SQL.query(Repo, "SELECT encrypted_metadata FROM entry", [])
 

--- a/apps/local_ledger_db/test/local_ledger_db/minted_token_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/minted_token_test.exs
@@ -11,15 +11,14 @@ defmodule LocalLedgerDB.MintedTokenTest do
   end
 
   test "generates a UUID" do
-    {res, minted_token} = :minted_token |> build |> Repo.insert
+    {res, minted_token} = :minted_token |> build |> Repo.insert()
 
     assert res == :ok
-    assert String.match?(minted_token.uuid,
-                         ~r/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
+    assert String.match?(minted_token.uuid, ~r/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/)
   end
 
   test "generates the inserted_at and updated_at values" do
-    {res, minted_token} = :minted_token |> build |> Repo.insert
+    {res, minted_token} = :minted_token |> build |> Repo.insert()
 
     assert res == :ok
     assert minted_token.inserted_at != nil
@@ -27,8 +26,7 @@ defmodule LocalLedgerDB.MintedTokenTest do
   end
 
   test "has a valid factory" do
-    changeset = MintedToken.changeset(%MintedToken{},
-                                      string_params_for(:minted_token))
+    changeset = MintedToken.changeset(%MintedToken{}, string_params_for(:minted_token))
     assert changeset.valid?
   end
 
@@ -36,25 +34,27 @@ defmodule LocalLedgerDB.MintedTokenTest do
     params = string_params_for(:minted_token, %{id: nil})
     changeset = MintedToken.changeset(%MintedToken{}, params)
     refute changeset.valid?
-    assert changeset.errors == [id: {"can't be blank",
-                                        [validation: :required]}]
+    assert changeset.errors == [id: {"can't be blank", [validation: :required]}]
   end
 
   test "prevents creation of a minted_token with an id already in DB" do
-    {:ok, _} = :minted_token |> build |> Repo.insert
+    {:ok, _} = :minted_token |> build |> Repo.insert()
 
     params = string_params_for(:minted_token)
-    {:error, minted_token} = %MintedToken{}
-                             |> MintedToken.changeset(params)
-                             |> Repo.insert
+
+    {:error, minted_token} =
+      %MintedToken{}
+      |> MintedToken.changeset(params)
+      |> Repo.insert()
 
     assert minted_token.errors == [id: {"has already been taken", []}]
   end
 
   test "allows creation of a minted_token with metadata" do
-    {res, minted_token} = :minted_token
-                          |> build(%{metadata: %{e_id: "123"}})
-                          |> Repo.insert
+    {res, minted_token} =
+      :minted_token
+      |> build(%{metadata: %{e_id: "123"}})
+      |> Repo.insert()
 
     assert res == :ok
     assert minted_token.metadata == %{e_id: "123"}
@@ -63,7 +63,7 @@ defmodule LocalLedgerDB.MintedTokenTest do
   test "saves the encrypted metadata" do
     :minted_token
     |> build(%{metadata: %{e_id: "123"}})
-    |> Repo.insert
+    |> Repo.insert()
 
     {:ok, results} = SQL.query(Repo, "SELECT encrypted_metadata FROM minted_token", [])
 
@@ -76,33 +76,42 @@ defmodule LocalLedgerDB.MintedTokenTest do
       minted_tokens = Repo.all(MintedToken)
       assert minted_tokens == []
 
-      {:ok, minted_token} = MintedToken.get_or_insert(%{"id" => "tok_OMG_01cbepz8h0xp9c5dvexefez2f1",
-                                                        "metadata" => %{}})
+      {:ok, minted_token} =
+        MintedToken.get_or_insert(%{
+          "id" => "tok_OMG_01cbepz8h0xp9c5dvexefez2f1",
+          "metadata" => %{}
+        })
 
       minted_tokens = Repo.all(MintedToken)
       assert minted_tokens == [minted_token]
     end
 
-    test "returns an existing minted_token when it is already in the database"
-      do
-      {_, inserted_minted_token} = :minted_token
-                              |> build(%{id: "tok_BTC_01cbepxbxqg0z8nqm3eb23qec2"})
-                              |> Repo.insert
+    test "returns an existing minted_token when it is already in the database" do
+      {_, inserted_minted_token} =
+        :minted_token
+        |> build(%{id: "tok_BTC_01cbepxbxqg0z8nqm3eb23qec2"})
+        |> Repo.insert()
 
       assert Enum.at(Repo.all(MintedToken), 0).id == inserted_minted_token.id
-      {:ok, minted_token} = MintedToken.get_or_insert(%{"id" => "tok_BTC_01cbepxbxqg0z8nqm3eb23qec2",
-                                                        "metadata" => %{}})
+
+      {:ok, minted_token} =
+        MintedToken.get_or_insert(%{
+          "id" => "tok_BTC_01cbepxbxqg0z8nqm3eb23qec2",
+          "metadata" => %{}
+        })
+
       assert inserted_minted_token.id == minted_token.id
     end
 
     defp start_task(pid, callback) do
-      {:ok, pid} = Task.start_link fn ->
-        Sandbox.allow(Repo, pid, self())
-        assert_receive :select_for_update, 5000
-        minted_token = callback.()
-        assert minted_token.id == "tok_OMG_01cbepz8h0xp9c5dvexefez2f1"
-        send pid, :updated
-      end
+      {:ok, pid} =
+        Task.start_link(fn ->
+          Sandbox.allow(Repo, pid, self())
+          assert_receive :select_for_update, 5000
+          minted_token = callback.()
+          assert minted_token.id == "tok_OMG_01cbepz8h0xp9c5dvexefez2f1"
+          send(pid, :updated)
+        end)
 
       pid
     end
@@ -111,15 +120,22 @@ defmodule LocalLedgerDB.MintedTokenTest do
       pid = self()
 
       callback = fn ->
-        {:ok, minted_token} = MintedToken.get_or_insert(%{"id" => "tok_OMG_01cbepz8h0xp9c5dvexefez2f1",
-                                                          "metadata" => %{}})
+        {:ok, minted_token} =
+          MintedToken.get_or_insert(%{
+            "id" => "tok_OMG_01cbepz8h0xp9c5dvexefez2f1",
+            "metadata" => %{}
+          })
+
         minted_token
       end
 
       for _ <- 0..10, do: send(start_task(pid, callback), :select_for_update)
 
-      {:ok, minted_token} = MintedToken.get_or_insert(%{"id" => "tok_OMG_01cbepz8h0xp9c5dvexefez2f1",
-                                                        "metadata" => %{}})
+      {:ok, minted_token} =
+        MintedToken.get_or_insert(%{
+          "id" => "tok_OMG_01cbepz8h0xp9c5dvexefez2f1",
+          "metadata" => %{}
+        })
 
       assert_receive :updated, 5000
       assert length(Repo.all(MintedToken)) == 1
@@ -129,9 +145,11 @@ defmodule LocalLedgerDB.MintedTokenTest do
 
   describe "#get" do
     test "returns the existing minted_token" do
-      {_, inserted_minted_token} = :minted_token
-                              |> build(%{id: "tok_BTC_01cbepxbxqg0z8nqm3eb23qec2"})
-                              |> Repo.insert
+      {_, inserted_minted_token} =
+        :minted_token
+        |> build(%{id: "tok_BTC_01cbepxbxqg0z8nqm3eb23qec2"})
+        |> Repo.insert()
+
       minted_token = MintedToken.get("tok_BTC_01cbepxbxqg0z8nqm3eb23qec2")
       assert minted_token.id == inserted_minted_token.id
     end
@@ -145,31 +163,37 @@ defmodule LocalLedgerDB.MintedTokenTest do
   describe "#insert" do
     test "inserts a minted_token if it does not existing" do
       assert Repo.all(MintedToken) == []
+
       {:ok, minted_token} =
         :minted_token
         |> string_params_for
-        |> MintedToken.insert
+        |> MintedToken.insert()
+
       assert Repo.all(MintedToken) == [minted_token]
     end
 
     test "returns the existing token without error if already existing" do
       assert Repo.all(MintedToken) == []
+
       inserted_minted_token =
         :minted_token
         |> string_params_for
-        |> MintedToken.insert
-      minted_token = :minted_token |> string_params_for |> MintedToken.insert
+        |> MintedToken.insert()
+
+      minted_token = :minted_token |> string_params_for |> MintedToken.insert()
 
       assert inserted_minted_token == minted_token
     end
 
     test "returns an error when passing invalid arguments" do
       assert Repo.all(MintedToken) == []
-      {res, changeset} = %{"id" => nil, "metadata" => %{}}
-                         |> MintedToken.insert
+
+      {res, changeset} =
+        %{"id" => nil, "metadata" => %{}}
+        |> MintedToken.insert()
+
       assert res == :error
-      assert changeset.errors == [id: {"can't be blank",
-                                            [validation: :required]}]
+      assert changeset.errors == [id: {"can't be blank", [validation: :required]}]
     end
   end
 end

--- a/apps/local_ledger_db/test/support/factory.ex
+++ b/apps/local_ledger_db/test/support/factory.ex
@@ -42,14 +42,14 @@ defmodule LocalLedgerDB.Factory do
   def empty_transaction_factory do
     %{
       amount: 150,
-      type: Transaction.credit_type
+      type: Transaction.credit_type()
     }
   end
 
   def credit_factory do
     %Transaction{
       amount: 150,
-      type: Transaction.credit_type,
+      type: Transaction.credit_type(),
       entry_uuid: insert(:entry).uuid
     }
   end
@@ -57,7 +57,7 @@ defmodule LocalLedgerDB.Factory do
   def debit_factory do
     %Transaction{
       amount: 150,
-      type: Transaction.debit_type,
+      type: Transaction.debit_type(),
       entry_uuid: insert(:entry).uuid
     }
   end
@@ -65,7 +65,7 @@ defmodule LocalLedgerDB.Factory do
   def transaction_factory do
     %Transaction{
       amount: 10_000,
-      type: Transaction.credit_type,
+      type: Transaction.credit_type(),
       minted_token_id: insert(:minted_token).id,
       balance_address: insert(:balance).address,
       entry_uuid: insert(:entry).uuid

--- a/apps/url_dispatcher/lib/mix/tasks/omg.server.ex
+++ b/apps/url_dispatcher/lib/mix/tasks/omg.server.ex
@@ -58,13 +58,15 @@ defmodule Mix.Tasks.Omg.Server do
   # so that it can prepare the endpoints to be served.
   defp configure_endpoints(args) do
     Application.put_env(:url_dispatcher, :serve_endpoints, true)
-    args # Doesn't touch the arguments, so send it back for further processing
+    # Doesn't touch the arguments, so send it back for further processing
+    args
   end
 
   defp configure_no_watch(args) do
-    {parsed, args, _invalids} = OptionParser.parse(args, [no_watch: :boolean])
+    {parsed, args, _invalids} = OptionParser.parse(args, no_watch: :boolean)
     if parsed[:no_watch], do: Application.put_env(:admin_panel, :start_with_no_watch, true)
-    args # This is the arguments with `--no-watch` flag removed by `OptionParser.parse/2` above
+    # This is the arguments with `--no-watch` flag removed by `OptionParser.parse/2` above
+    args
   end
 
   defp configure_no_halt(args) do
@@ -72,6 +74,6 @@ defmodule Mix.Tasks.Omg.Server do
   end
 
   defp iex_running? do
-    Code.ensure_loaded?(IEx) and IEx.started?
+    Code.ensure_loaded?(IEx) and IEx.started?()
   end
 end

--- a/apps/url_dispatcher/lib/url_dispatcher/application.ex
+++ b/apps/url_dispatcher/lib/url_dispatcher/application.ex
@@ -9,14 +9,15 @@ defmodule UrlDispatcher.Application do
     import Supervisor.Spec, warn: false
 
     # List all child processes to be supervised
-    children = prepare_children([
-      {
-        :http,
-        UrlDispatcher.Plug,
-        port_for(:url_dispatcher),
-        websockets_dispatcher() ++ [http_dispatcher()]
-      }
-    ])
+    children =
+      prepare_children([
+        {
+          :http,
+          UrlDispatcher.Plug,
+          port_for(:url_dispatcher),
+          websockets_dispatcher() ++ [http_dispatcher()]
+        }
+      ])
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -45,13 +46,17 @@ defmodule UrlDispatcher.Application do
   defp prepare_children(children) when is_list(children) do
     if server?(), do: Enum.map(children, &prepare_children/1), else: []
   end
-  defp prepare_children({scheme, plug, port, dispatchers}) do
-    Logger.info "Running #{inspect plug} with Cowboy #{scheme} on port #{port}"
 
-    Cowboy.child_spec(scheme, plug, [], [
+  defp prepare_children({scheme, plug, port, dispatchers}) do
+    Logger.info("Running #{inspect(plug)} with Cowboy #{scheme} on port #{port}")
+
+    Cowboy.child_spec(
+      scheme,
+      plug,
+      [],
       port: port,
       dispatch: [{:_, dispatchers}]
-    ])
+    )
   end
 
   defp server? do

--- a/apps/url_dispatcher/lib/url_dispatcher/plug.ex
+++ b/apps/url_dispatcher/lib/url_dispatcher/plug.ex
@@ -18,16 +18,19 @@ defmodule UrlDispatcher.Plug do
   defp handle_request("/api" <> _, conn), do: EWalletAPI.Endpoint.call(conn, [])
   defp handle_request("/admin/api" <> _, conn), do: AdminAPI.Endpoint.call(conn, [])
   defp handle_request("/admin" <> _, conn), do: AdminPanel.Endpoint.call(conn, [])
+
   defp handle_request("/public" <> _, conn) do
-    opts = Static.init([
-      at: "/public",
-      from: Path.join(Application.get_env(:ewallet, :root), "public"),
-      only: @public_folders
-    ])
+    opts =
+      Static.init(
+        at: "/public",
+        from: Path.join(Application.get_env(:ewallet, :root), "public"),
+        only: @public_folders
+      )
 
     case Static.call(conn, opts) do
       %{halted: true} = conn ->
         conn
+
       _ ->
         conn
         |> resp(404, "The url could not be resolved.")

--- a/apps/url_dispatcher/lib/url_dispatcher/socket_dispatcher.ex
+++ b/apps/url_dispatcher/lib/url_dispatcher/socket_dispatcher.ex
@@ -10,7 +10,7 @@ defmodule UrlDispatcher.SocketDispatcher do
   end
 
   def ewallet_api do
-    Endpoint.__sockets__
+    Endpoint.__sockets__()
     |> Enum.map(fn {path, socket} ->
       {path, Endpoint, socket} |> build_websocket_config("/api")
     end)
@@ -21,11 +21,10 @@ defmodule UrlDispatcher.SocketDispatcher do
   end
 
   defp build_websocket_config({path, endpoint, socket}, prefix) do
-    {"#{prefix}#{path}",
-       CowboyWebSocket,
-       {
-         WebSocket, {endpoint, socket, :websocket}
-      }
-     }
+    {"#{prefix}#{path}", CowboyWebSocket,
+     {
+       WebSocket,
+       {endpoint, socket, :websocket}
+     }}
   end
 end

--- a/apps/url_dispatcher/test/url_dispatcher/plug_test.exs
+++ b/apps/url_dispatcher/test/url_dispatcher/plug_test.exs
@@ -41,7 +41,8 @@ defmodule UrlDispatcher.PlugTest do
     test "returns a 200 response when requesting a file in /public folder" do
       conn = request("/public/uploads/test.txt")
 
-      assert conn.halted # Plug.Static returns `%Plug.Conn{halted: true}` on success
+      # Plug.Static returns `%Plug.Conn{halted: true}` on success
+      assert conn.halted
       assert conn.status == 200
     end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ use Mix.Config
 # back to each application for organization purposes.
 import_config "../apps/*/config/config.exs"
 
-config :ewallet, root: File.cwd!
+config :ewallet, root: File.cwd!()
 
 # Configures Elixir's Logger
 config :logger, :console,
@@ -18,4 +18,4 @@ config :logger, :console,
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -3,10 +3,9 @@ use Mix.Config
 level =
   case System.get_env("LOGGER_LEVEL") do
     "DEBUG" -> :debug
-    "WARN"  -> :warn
+    "WARN" -> :warn
     "ERROR" -> :error
-    _       -> :info
+    _ -> :info
   end
 
-config :logger,
-  level: level
+config :logger, level: level

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule EWallet.Umbrella.Mixfile do
   def project do
     [
       apps_path: "apps",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test
@@ -19,21 +19,21 @@ defmodule EWallet.Umbrella.Mixfile do
         extra_section: "Guides",
         extras: [
           {"README.md", [filename: "introduction", title: "Introduction"]},
-          "docs/balances.md",
+          "docs/balances.md"
         ],
         groups_for_extras: [
           "Getting Started": ["README.md"],
-          "Entities": ["docs/balances.md"],
+          Entities: ["docs/balances.md"]
         ],
         groups_for_modules: [
-          "EWallet": ~r/EWallet(\..+)*$/,
+          EWallet: ~r/EWallet(\..+)*$/,
           "EWallet API": ~r/EWalletAPI(?!\.V\d+)(\..+)*$/,
           "EWallet API V1": ~r/EWalletAPI.V1(\..+)*$/,
           "EWallet DB": ~r/EWalletDB(\..+)*$/,
           "Admin API": ~r/AdminAPI(?!\.V\d+)(\..+)*$/,
-          "Admin API V1": ~r/AdminAPI.V1(\..+)*$/,
-        ],
-      ],
+          "Admin API V1": ~r/AdminAPI.V1(\..+)*$/
+        ]
+      ]
     ]
   end
 
@@ -56,7 +56,7 @@ defmodule EWallet.Umbrella.Mixfile do
       init: [
         "ecto.create",
         "ecto.migrate",
-        "seed",
+        "seed"
       ],
       reset: [
         "ecto.drop",

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule EWallet.Umbrella.Mixfile do
   # Run "mix help deps" for examples and options.
   defp deps do
     [
-      {:credo, github: "rrrene/credo", only: [:dev, :test], runtime: false},
+      {:credo, "~> 0.9.2", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:excoveralls, "~> 0.8", only: :test, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -16,7 +16,7 @@
   "cors_plug": {:hex, :cors_plug, "1.5.1", "5acf5f41ae238b074aa9cb5e2da1360bd66a5f7b8ffeabe49e9a37a176728755", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
-  "credo": {:git, "https://github.com/rrrene/credo.git", "f0d14eaa770f321aa629a5494a5e1db4e556e4cf", []},
+  "credo": {:hex, :credo, "0.9.2", "841d316612f568beb22ba310d816353dddf31c2d94aa488ae5a27bb53760d0bf", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "crontab": {:hex, :crontab, "1.1.2", "4784a50987b4a19af07a908f98e8a308b00f9c93efc5a7892155dc10cd8fc7d9", [:mix], [{:ecto, "~> 1.0 or ~> 2.0 or ~> 2.1", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm"},
   "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},


### PR DESCRIPTION
Issue/Task Number: T119, T175

# Overview

This PR runs `mix format` on the entire repo, and enforces formatting during the CI build process.

# Changes

- Added config for the formatter
- Ran `mix format` on the entire repo
- Updated `Jenkinfile` to enforce formatting
- Upgraded credo version since it's related to formatting lint

# Implementation Details

N/A

# Usage

Run `mix format`.

After this PR merge onwards. All PRs need to be `mix format` and commit the formatted change before submission. Otherwise the build will fail.

# Impact

Deploy as usual
