### PR TITLE
Fix seeds failing due to id/uuid misreference

### DIFF
--- a/apps/ewallet/lib/ewallet/web/preloader.ex
+++ b/apps/ewallet/lib/ewallet/web/preloader.ex
@@ -19,9 +19,9 @@ defmodule EWallet.Web.Preloader do
   @doc """
   Preloads associations into the given record(s).
   """
-  @spec preload(Ecto.Schema.t() | Ecto.Schema.t(), list(atom)) ::
+  @spec preload(Ecto.Schema.t() | Ecto.Schema.t(), atom() | [atom()]) ::
           Ecto.Schema.t() | [Ecto.Schema.t()]
   def preload(record, preloads) do
-    Repo.preload(record, preloads)
+    Repo.preload(record, List.wrap(preloads))
   end
 end

--- a/apps/ewallet/priv/repo/seeders/api_key.exs
+++ b/apps/ewallet/priv/repo/seeders/api_key.exs
@@ -2,10 +2,11 @@
 alias EWalletDB.{Account, APIKey}
 alias EWallet.Seeder
 alias EWallet.Seeder.CLI
+alias EWallet.Web.Preloader
 
 seeds = [
   # Auth tokens for ewallet_api
-  %{account_name: "master_account", owner_app: "ewallet_api"},
+  %{account: Account.get_by(name: "master_account"), owner_app: "ewallet_api"},
 
   # Auth tokens for admin_api
   # Not inserting for master account as it is already seeded in `initial_api_key.exs`
@@ -15,26 +16,27 @@ CLI.subheading("Seeding API Keys:\n")
 
 Enum.each(seeds, fn(data) ->
   insert_data = %{
-    account_id: Account.get_by(name: data.account_name).id,
+    account_uuid: data.account.uuid,
     owner_app:  data.owner_app
   }
 
   case APIKey.insert(insert_data) do
     {:ok, api_key} ->
-      if data.account_name == "master_account" && data.owner_app == "ewallet_api" do
+      api_key = Preloader.preload(api_key, :account)
+      if data.account.name == "master_account" && data.owner_app == "ewallet_api" do
         Application.put_env(:ewallet, :seed_ewallet_api_key, api_key)
       end
       CLI.success("""
           Owner app  : #{api_key.owner_app}
-          Account    : #{data.account_name} (#{api_key.account_id})
+          Account    : #{api_key.account.name} (#{api_key.account.id})
           API key ID : #{api_key.id}
           API key    : #{api_key.key}
         """)
     {:error, changeset} ->
       CLI.error("""
           API key could not be inserted:
-          Owner app  : #{insert_data.owner_app}
-          Account   : #{data.account.name} (#{insert_data.account_id})
+          Owner app : #{insert_data.owner_app}
+          Account   : #{data.account.name} (#{data.account.id})
         """)
       Seeder.print_errors(changeset)
     _ ->

--- a/apps/ewallet/priv/repo/seeders/initial_api_key.exs
+++ b/apps/ewallet/priv/repo/seeders/initial_api_key.exs
@@ -2,10 +2,11 @@
 alias EWallet.Seeder
 alias EWallet.Seeder.CLI
 alias EWalletDB.{Account, APIKey}
+alias EWallet.Web.Preloader
 
 master  = Account.get_by(name: "master_account")
 api_key = APIKey.insert(%{
-  account_id: master.id,
+  account_uuid: master.uuid,
   owner_app: "admin_api"
 })
 
@@ -13,9 +14,10 @@ CLI.subheading("Seeding an Admin Panel API key:\n")
 
 case api_key do
   {:ok, api_key} ->
+    api_key = Preloader.preload(api_key, :account)
     Application.put_env(:ewallet, :seed_admin_api_key, api_key)
     CLI.success("""
-      Account ID : #{api_key.account_id}
+      Account ID : #{api_key.account.id}
       API key ID : #{api_key.id}
       API key    : #{api_key.key}
     """)


### PR DESCRIPTION
Issue/Task Number: T218

# Overview

Following #149, @jarindr found out that `mix seed` fails due to id/uuid references. This PR updates all seed scripts to correctly use `id` vs. `uuid` during the seed.

# Changes

- Update seed scripts to use `id` when displaying info, and use `uuid` and `relation_uuid` when doing direct inserts to the database.

# Implementation Details

To follow #149 correctly, the code interacting directly with the schema or the database need to use `uuid` and/or `relation_uuid`. While other code e.g. when displaying inserted data, the `id` should be used.

# Usage

Run `mix seed` and `mix seed --sample` should be successful.

# Impact

Deploy as usual.
