### PR TITLE
Add "Support" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,11 @@ In this section, we will be sharing some of the next features the OmiseGO team w
 
 # Support
 
-- Want to chat? Find us on [Rocket Chat](http://chat.omisego.network/). Questions regarding the eWallet SDK should go in `#eWallet SDK` channel.
-- Getting stuck on programming issues? Browse or create new questions on StackOverflow with tag [omisego](https://stackoverflow.com/questions/tagged/omisego)
-- Found a bug? File us a [GitHub issue](https://github.com/omisego/ewallet/issues)
+- Got an idea to improve the SDKs? Talk to us in our [Rocket Chat](https://chat.omisego.network/)'s `#eWallet SDK` channel
+
+- Found a bug? File an issue with [GitHub Issues](https://github.com/omisego/ewallet/issues).
+
+- Stuck at integrating or building on top of the SDKs? Search or create a question on StackOverflow using the tag [omisego](https://stackoverflow.com/questions/tagged/omisego).
 
 # F.A.Q
 


### PR DESCRIPTION
Issue/Task Number: T217

# Overview

This adds a Support section to the readme following the [first omisego-tagged question](https://stackoverflow.com/questions/49992831/no-function-clause-matching-in-base-url-decode64-2-when-making-request-to-adm) on StackOverflow.

# Changes

- Textual change to README only

# Implementation Details

Note that product-based Q&A, and self-answer on those questions on StackOverflow are [welcomed](https://meta.stackexchange.com/questions/133522/encyclopedia-stack-exchange-vs-commercial-products).

> This is absolutely welcome on Stack Overflow.
>
> I would say that the answer should disclose the affiliation of the poster if only because that affiliation is evidence of the authority of the answer and therefore makes the answer better.
>
> At the point at which these questions start being spam and or advertisements ("How can I find people I went to high school with?" "Try classmates!") then you can shut it down.
>
> This question and answer are so obviously non-promotional that it's practically a case study of how vendors, tool creators, API writers, etc. should be using Stack Overflow.
>
> Please remember the big picture.
>
> This question and answer belongs on Stack Overflow, where the public at large can find it, edit it, improve it, and vote on it. Having this kind of technical information here is so much better than having it buried on a vendor's website in a knowledge base article that rapidly gets out of date and has no possibility of public involvement.

But also note that there are sensitivities to Q&A of commercial nature on StackOverflow. As discussed in:

- [Encyclopedia Stack Exchange vs. commercial products](https://meta.stackexchange.com/questions/133522/encyclopedia-stack-exchange-vs-commercial-products)
- [Limits for self-promotion in answers](https://meta.stackexchange.com/questions/57497/limits-for-self-promotion-in-answers)
- [Use Stack Overflow as the official support site of an open-source project](https://meta.stackexchange.com/questions/19852/use-stack-overflow-as-the-official-support-site-of-an-open-source-project)
- [Is it okay to use Stack Overflow as the support forum for a product or project?](https://meta.stackexchange.com/questions/3966/is-it-okay-to-use-stack-overflow-as-the-support-forum-for-a-product-or-project/13282#13282)

The general rule (in my own interpretation) is that, we should be fine as long as we:

- Limit to programming Q&A, whether it be integrating into or extending OmiseGO's offerings.
- Answer to questions that are directed at OmiseGO's code/tools/etc.
- Not promoting/recommending OmiseGO to questions that are not originally targeted at OmiseGO's offerings.

# Usage

N/A

# Impact

N/A