### PR TITLE
Preload minted token in transactions

### DIFF
--- a/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
@@ -19,6 +19,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
             object: "transaction_source",
             address: transaction.from,
             amount: transaction.amount,
+            minted_token_id: minted_token.id,
             minted_token: %{
               object: "minted_token",
               id: minted_token.id,
@@ -35,6 +36,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
             object: "transaction_source",
             address: transaction.to,
             amount: transaction.amount,
+            minted_token_id: minted_token.id,
             minted_token: %{
               object: "minted_token",
               id: minted_token.id,
@@ -92,6 +94,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                 object: "transaction_source",
                 address: transaction1.from,
                 amount: transaction1.amount,
+                minted_token_id: minted_token1.id,
                 minted_token: %{
                   object: "minted_token",
                   id: minted_token1.id,
@@ -108,6 +111,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                 object: "transaction_source",
                 address: transaction1.to,
                 amount: transaction1.amount,
+                minted_token_id: minted_token1.id,
                 minted_token: %{
                   object: "minted_token",
                   id: minted_token1.id,
@@ -138,6 +142,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                 object: "transaction_source",
                 address: transaction2.from,
                 amount: transaction2.amount,
+                minted_token_id: minted_token2.id,
                 minted_token: %{
                   object: "minted_token",
                   id: minted_token2.id,
@@ -154,6 +159,7 @@ defmodule AdminAPI.V1.TransactionViewTest do
                 object: "transaction_source",
                 address: transaction2.to,
                 amount: transaction2.amount,
+                minted_token_id: minted_token2.id,
                 minted_token: %{
                   object: "minted_token",
                   id: minted_token2.id,

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
@@ -3,11 +3,12 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
   alias Ecto.Association.NotLoaded
   alias EWallet.Web.V1.{TransactionSerializer, MintedTokenSerializer}
   alias EWallet.Web.Date
-  alias EWalletDB.Repo
+  alias EWalletDB.{Repo, MintedToken}
 
   describe "serialize/1 for single transaction" do
     test "serializes into correct V1 transaction format" do
-      transaction = :transfer |> insert() |> Repo.preload(:minted_token)
+      transaction = insert(:transfer)
+      minted_token = MintedToken.get_by(uuid: transaction.minted_token_uuid)
 
       expected = %{
         object: "transaction",
@@ -17,13 +18,15 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
           object: "transaction_source",
           address: transaction.from,
           amount: transaction.amount,
-          minted_token: MintedTokenSerializer.serialize(transaction.minted_token)
+          minted_token_id: minted_token.id,
+          minted_token: MintedTokenSerializer.serialize(minted_token)
         },
         to: %{
           object: "transaction_source",
           address: transaction.to,
           amount: transaction.amount,
-          minted_token: MintedTokenSerializer.serialize(transaction.minted_token)
+          minted_token_id: minted_token.id,
+          minted_token: MintedTokenSerializer.serialize(minted_token)
         },
         exchange: %{
           object: "exchange",
@@ -39,7 +42,7 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
       assert TransactionSerializer.serialize(transaction) == expected
     end
 
-    test "serializes to nil if the tranasction is not loaded" do
+    test "serializes to nil if the transaction is not loaded" do
       assert TransactionSerializer.serialize(%NotLoaded{}) == nil
     end
   end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
@@ -2,11 +2,11 @@ defmodule EWalletAPI.V1.TransactionViewTest do
   use EWalletAPI.ViewCase, :v1
   alias EWalletAPI.V1.TransactionView
   alias EWallet.Web.{Date, V1.MintedTokenSerializer}
-  alias EWalletDB.Repo
 
   describe "EWalletAPI.V1.TransactionView.render/2" do
     test "renders transaction.json with correct structure" do
-      transaction = :transfer |> insert() |> Repo.preload(:minted_token)
+      transaction = insert(:transfer)
+      minted_token = transaction.minted_token
 
       expected = %{
         version: @expected_version,
@@ -19,12 +19,14 @@ defmodule EWalletAPI.V1.TransactionViewTest do
             object: "transaction_source",
             address: transaction.from,
             amount: transaction.amount,
-            minted_token: MintedTokenSerializer.serialize(transaction.minted_token)
+            minted_token_id: minted_token.id,
+            minted_token: MintedTokenSerializer.serialize(minted_token)
           },
           to: %{
             object: "transaction_source",
             address: transaction.to,
             amount: transaction.amount,
+            minted_token_id: minted_token.id,
             minted_token: MintedTokenSerializer.serialize(transaction.minted_token)
           },
           exchange: %{


### PR DESCRIPTION
Issue/Task Number: T247

# Overview

Minted tokens in the transaction serializer was sometimes `nil` because no preloaded. This PR fixes that and adds the `minted_token_id` to be consistent with the new approach to serializer (`id` + `object` if preloaded).

# Changes

- Update the `TransactionSerializer` module
- Fix the tests

# Impact

How can this change be deployed? Any special requirement?
