### PR TITLE
Add symbol to existing minted token's IDs

### DIFF
--- a/apps/ewallet_db/priv/repo/migrations/20180424131331_add_symbol_to_minted_token_id.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180424131331_add_symbol_to_minted_token_id.exs
@@ -38,7 +38,7 @@ defmodule EWalletDB.Repo.Migrations.AddSymbolToMintedTokenId do
   defp remove_symbol(id) do
     # Remove the symbol only if the pattern is strictly
     # `<non_underscores>_<non_underscores>_<non_underscores>`
-    String.replace(id, ~r/([^_]+)_([^_]+)_([^_]+)/, "\\1_\\3")
+    String.replace(id, ~r/^([^_]+)_([^_]+)_([^_]+)$/, "\\1_\\3")
   end
 
   defp update_id(id, table_name, uuid) do

--- a/apps/ewallet_db/priv/repo/migrations/20180424131331_add_symbol_to_minted_token_id.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180424131331_add_symbol_to_minted_token_id.exs
@@ -1,0 +1,51 @@
+defmodule EWalletDB.Repo.Migrations.AddSymbolToMintedTokenId do
+  use Ecto.Migration
+  import Ecto.Query
+  alias EWalletDB.Repo
+
+  @table_name "minted_token"
+
+  def up do
+    for [uuid, id, symbol] <- get_all(@table_name) do
+      id
+      |> add_symbol(symbol)
+      |> update_id(@table_name, uuid)
+    end
+  end
+
+  def down do
+    for [uuid, id, _symbol] <- get_all(@table_name) do
+      id
+      |> remove_symbol()
+      |> update_id(@table_name, uuid)
+    end
+  end
+
+  defp get_all(table_name) do
+    query = from(t in table_name,
+                 select: [t.uuid, t.id, t.symbol],
+                 lock: "FOR UPDATE")
+
+    Repo.all(query)
+  end
+
+  defp add_symbol(id, symbol) do
+    # Add the symbol only if the pattern is strictly:
+    # `<non_underscores>_<non_underscores>`
+    String.replace(id, ~r/^([^_]+)_([^_]+)$/, "\\1_#{symbol}_\\2")
+  end
+
+  defp remove_symbol(id) do
+    # Remove the symbol only if the pattern is strictly
+    # `<non_underscores>_<non_underscores>_<non_underscores>`
+    String.replace(id, ~r/([^_]+)_([^_]+)_([^_]+)/, "\\1_\\3")
+  end
+
+  defp update_id(id, table_name, uuid) do
+    query = from(t in table_name,
+                 where: t.uuid == ^uuid,
+                 update: [set: [id: ^id]])
+
+    Repo.update_all(query, [])
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T245

# Overview

This PR adds the minted token 's symbol to its ID, which was missing in #149's migrations.

# Changes

- Add a new migration that adds the minted token's symbol to its IDs.

# Implementation Details

A simple DB migration that checks for `<non_underscores>_<non_underscores>` and add the symbol accordingly. Otherwise no changes is made.

# Usage

Run `mix ecto.migrate`.

If your minted tokens already have the IDs containing the symbol, you can follow these steps to verify this PR:

1. Run `mix ecto.migrate`. This brings the database to the latest migration.
2. Run `mix ecto.rollback --step 1` This triggers the PR's down() function and minted tokens are reverted back to their IDs without symbols. Verify manually in database that minted token IDs do not contain symbols.
3. Run `mix ecto.migrate` again. This should trigger this PR's migration script again. Verify manually in database that minted token IDs now contain symbols.

# Impact

Deploy as usual.