### PR TITLE
Add account to auth tokens in Admin API

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -28,6 +28,10 @@ defmodule AdminAPI.V1.ErrorHandler do
       code: "forget_password:token_not_found",
       description: "There are no password reset requests corresponding to the provided token"
     },
+    auth_token_not_found: %{
+      code: "auth_token:not_found",
+      description: "There is no auth token corresponding to the provided token"
+    },
     user_email_not_found: %{
       code: "user:email_not_found",
       description: "There is no user corresponding to the provided email"

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -21,6 +21,8 @@ defmodule AdminAPI.V1.Router do
   scope "/", AdminAPI.V1 do
     pipe_through([:api, :user_api])
 
+    post("/auth_token.switch_account", AuthController, :switch_account)
+
     # Minted Token endpoints
     post("/minted_token.all", MintedTokenController, :all)
     post("/minted_token.get", MintedTokenController, :get)

--- a/apps/admin_api/lib/admin_api/v1/serializers/auth_token_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/auth_token_serializer.ex
@@ -2,11 +2,19 @@ defmodule AdminAPI.V1.AuthTokenSerializer do
   @moduledoc """
   Serializes authentication token data into V1 response format.
   """
-  def serialize(%{auth_token: _, user: _} = attrs) do
+  alias EWallet.Web.V1.{UserSerializer, AccountSerializer}
+  alias EWalletDB.Helpers.{Assoc, Preloader}
+
+  def serialize(auth_token) do
+    auth_token = Preloader.preload(auth_token, [:user, :account])
+
     %{
       object: "authentication_token",
-      authentication_token: attrs.auth_token,
-      user_id: attrs.user.id
+      authentication_token: auth_token.token,
+      user_id: Assoc.get(auth_token, [:user, :id]),
+      user: UserSerializer.serialize(auth_token.user),
+      account_id: Assoc.get(auth_token, [:account, :id]),
+      account: AccountSerializer.serialize(auth_token.account)
     }
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/serializers/auth_token_serializer.ex
+++ b/apps/admin_api/lib/admin_api/v1/serializers/auth_token_serializer.ex
@@ -2,11 +2,15 @@ defmodule AdminAPI.V1.AuthTokenSerializer do
   @moduledoc """
   Serializes authentication token data into V1 response format.
   """
+  alias EWallet.AccountPolicy
   alias EWallet.Web.V1.{UserSerializer, AccountSerializer}
+  alias EWalletDB.Account
   alias EWalletDB.Helpers.{Assoc, Preloader}
 
   def serialize(auth_token) do
     auth_token = Preloader.preload(auth_token, [:user, :account])
+    master_account = Account.get_master_account()
+    master_admin = AccountPolicy.authorize(:godmode, auth_token.user.id, master_account.id)
 
     %{
       object: "authentication_token",
@@ -14,7 +18,8 @@ defmodule AdminAPI.V1.AuthTokenSerializer do
       user_id: Assoc.get(auth_token, [:user, :id]),
       user: UserSerializer.serialize(auth_token.user),
       account_id: Assoc.get(auth_token, [:account, :id]),
-      account: AccountSerializer.serialize(auth_token.account)
+      account: AccountSerializer.serialize(auth_token.account),
+      master_admin: master_admin
     }
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/views/auth_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/auth_view.ex
@@ -3,8 +3,8 @@ defmodule AdminAPI.V1.AuthView do
   alias AdminAPI.V1.AuthTokenSerializer
   alias EWallet.Web.V1.ResponseSerializer
 
-  def render("auth_token.json", attrs) do
-    attrs
+  def render("auth_token.json", %{auth_token: auth_token}) do
+    auth_token
     |> AuthTokenSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -73,6 +73,7 @@ paths:
           $ref: "#/components/responses/AuthenticationTokenResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
+
   /logout:
     post:
       tags:
@@ -84,6 +85,22 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/EmptyResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+
+  /auth_token.switch_account:
+    post:
+      tags:
+        - Session
+      summary: Switch the current account associated with the auth token.
+      operationId: switch_account
+      security:
+        - UserAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/SwitchAccountBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/AuthenticationTokenResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
 
@@ -705,11 +722,19 @@ components:
           type: string
         user_id:
           type: string
-          format: uuid
+        user:
+          type: object
+        account_id:
+          type: string
+        account:
+          type: object
       required:
         - object
         - authentication_token
         - user_id
+        - user
+        - account_id
+        - account
     AuthenticationTokenResponseSchema:
       description: "The response schema for an authentication token"
       allOf:
@@ -725,7 +750,30 @@ components:
           data:
             object: "authentication_token"
             authentication_token: "azJRj09l7jvR8KhTqUs3"
-            user_id: "12345678-1234-1234-1234-123456789012"
+            user_id: "cec34607-0761-4a59-8357-18963e42a1aa"
+            user:
+              object: "user"
+              id: "cec34607-0761-4a59-8357-18963e42a1aa"
+              provider_user_id: "wijf-fbancomw-dqwjudb"
+              username: "johndoe"
+              email: "johndoe@omise.co"
+              metadata: {"first_name": "John", "last_name": "Doe"}
+              encrypted_metadata: {"something": "secret"}
+              created_at: "2018-01-01T00:00:00Z"
+              updated_at: "2018-01-01T10:00:00Z"
+            account_id: "acc_01CA2P8JQANS5ATY5GJ5ETMJCF"
+            account:
+              object: "account"
+              id: "acc_01CA2P8JQANS5ATY5GJ5ETMJCF"
+              parent_id: "acc_01CA26PKGE49AABZD6K6MSHN0Y"
+              name: "Account Name"
+              description: "The account description"
+              master: true
+              metadata: {}
+              encrypted_metadata: {}
+              avatar: {"original": "file_url"}
+              created_at: "2018-01-01T00:00:00Z"
+              updated_at: "2018-01-01T10:00:00Z"
 
     ######################################
     #         MINTED TOKEN SCHEMAS       #
@@ -1501,6 +1549,19 @@ components:
             example:
               email: "test@example.com"
               password: "the_password"
+    SwitchAccountBody:
+      description: The parameters to use for switching the current account
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              account_id:
+                type: string
+            required:
+              - account_id
+            example:
+              accound_id: "the_account_id"
     ResetPasswordBody:
       description: The parameters to use for requesting a reset password
       required: true

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -724,10 +724,12 @@ components:
           type: string
         user:
           type: object
+          $ref: '#/components/schemas/UserSchema'
         account_id:
           type: string
         account:
           type: object
+          $ref: '#/components/schemas/AccountSchema'
       required:
         - object
         - authentication_token
@@ -750,10 +752,10 @@ components:
           data:
             object: "authentication_token"
             authentication_token: "azJRj09l7jvR8KhTqUs3"
-            user_id: "cec34607-0761-4a59-8357-18963e42a1aa"
+            user_id: "usr_01cc02x0v98qcctvycfx4vsk8x"
             user:
               object: "user"
-              id: "cec34607-0761-4a59-8357-18963e42a1aa"
+              id: "usr_01cc02x0v98qcctvycfx4vsk8x"
               provider_user_id: "wijf-fbancomw-dqwjudb"
               username: "johndoe"
               email: "johndoe@omise.co"

--- a/apps/admin_api/test/admin_api/v1/controllers/auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/auth_controller_test.exs
@@ -142,7 +142,7 @@ defmodule AdminAPI.V1.AuthControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
     end
 
-    test "returns : when unauthenticated" do
+    test "returns :invalid_api_key when unauthenticated" do
       response =
         client_request("/auth_token.switch_account", %{
           "account_id" => "123"

--- a/apps/admin_api/test/admin_api/v1/controllers/auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/auth_controller_test.exs
@@ -1,11 +1,12 @@
 defmodule AdminAPI.V1.AuthControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWalletDB.AuthToken
+  alias EWallet.Web.V1.{UserSerializer, AccountSerializer}
+  alias EWalletDB.{Repo, AuthToken, Membership}
 
   describe "/login" do
     test "responds with a new auth token if the given email and password are valid" do
       response = client_request("/login", %{email: @user_email, password: @password})
-      auth_token = get_last_inserted(AuthToken)
+      auth_token = AuthToken |> get_last_inserted() |> Repo.preload([:user, :account])
 
       expected = %{
         "version" => @expected_version,
@@ -13,7 +14,10 @@ defmodule AdminAPI.V1.AuthControllerTest do
         "data" => %{
           "object" => "authentication_token",
           "authentication_token" => auth_token.token,
-          "user_id" => @user_id
+          "user_id" => auth_token.user.id,
+          "user" => auth_token.user |> UserSerializer.serialize() |> stringify_keys(),
+          "account_id" => auth_token.account.id,
+          "account" => auth_token.account |> AccountSerializer.serialize() |> stringify_keys()
         }
       }
 
@@ -84,6 +88,68 @@ defmodule AdminAPI.V1.AuthControllerTest do
       refute response["success"]
       refute response["success"]
       assert response["data"]["code"] == "client:invalid_parameter"
+    end
+  end
+
+  describe "/auth_token.switch_account" do
+    test "switches the account" do
+      user = get_test_user()
+      account = insert(:account)
+
+      # User belongs to the master account and has access to the sub account
+      # just created
+      response =
+        user_request("/auth_token.switch_account", %{
+          "account_id" => account.id
+        })
+
+      assert response["success"]
+      assert response["data"]["user"]["id"] == user.id
+      assert response["data"]["account"]["id"] == account.id
+    end
+
+    test "returns a permission error when trying to switch to an invalid account" do
+      user = get_test_user() |> Repo.preload([:accounts])
+      {:ok, _} = Membership.unassign(user, Enum.at(user.accounts, 0))
+      account = insert(:account)
+
+      response =
+        user_request("/auth_token.switch_account", %{
+          "account_id" => account.id
+        })
+
+      refute response["success"]
+      assert response["data"]["code"] == "user:unauthorized"
+    end
+
+    test "returns :account_not_found when the account does not exist" do
+      response =
+        user_request("/auth_token.switch_account", %{
+          "account_id" => "123"
+        })
+
+      refute response["success"]
+      assert response["data"]["code"] == "account:not_found"
+    end
+
+    test "returns :invalid_parameter when account_id is not sent" do
+      response =
+        user_request("/auth_token.switch_account", %{
+          "fake" => "123"
+        })
+
+      refute response["success"]
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
+    test "returns : when unauthenticated" do
+      response =
+        client_request("/auth_token.switch_account", %{
+          "account_id" => "123"
+        })
+
+      refute response["success"]
+      assert response["data"]["code"] == "client:invalid_api_key"
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/serializers/auth_token_serializer_test.exs
+++ b/apps/admin_api/test/admin_api/v1/serializers/auth_token_serializer_test.exs
@@ -4,12 +4,12 @@ defmodule AdminAPI.V1.AuthTokenSerializerTest do
 
   describe "AuthTokenSerializer.serialize/1" do
     test "data contains the session token" do
-      attrs = %{auth_token: "the_auth_token", user: %{id: "the_user_id"}}
-      serialized = AuthTokenSerializer.serialize(attrs)
+      auth_token = insert(:auth_token)
+      serialized = AuthTokenSerializer.serialize(auth_token)
 
       assert serialized.object == "authentication_token"
-      assert serialized.authentication_token == "the_auth_token"
-      assert serialized.user_id == "the_user_id"
+      assert serialized.authentication_token == auth_token.token
+      assert serialized.user_id == auth_token.user.id
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/views/auth_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/auth_view_test.exs
@@ -1,22 +1,20 @@
 defmodule AdminAPI.V1.AuthViewTest do
   use AdminAPI.ViewCase, :v1
-  alias AdminAPI.V1.AuthView
+  alias AdminAPI.V1.{AuthTokenSerializer, AuthView}
 
   describe "AdminAPI.V1.AuthView.render/2" do
     # Potential candidate to be moved to a shared library
     # credo:disable-for-next-line Credo.Check.Design.DuplicatedCode
     test "renders auth_token.json with correct structure" do
+      auth_token = insert(:auth_token)
+
       expected = %{
         version: @expected_version,
         success: true,
-        data: %{
-          object: "authentication_token",
-          authentication_token: "the_auth_token",
-          user_id: "the_user_id"
-        }
+        data: AuthTokenSerializer.serialize(auth_token)
       }
 
-      attrs = %{auth_token: "the_auth_token", user: %{id: "the_user_id"}}
+      attrs = %{auth_token: auth_token}
       assert AuthView.render("auth_token.json", attrs) == expected
     end
 

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -90,8 +90,15 @@ defmodule AdminAPI.ConnCase do
     {:ok, account} = :account |> params_for(parent: nil) |> Account.insert()
     role = insert(:role, %{name: "admin"})
     _api_key = insert(:api_key, %{id: @api_key_id, key: @api_key, owner_app: "admin_api"})
-    _auth_token = insert(:auth_token, %{user: user, token: @auth_token, owner_app: "admin_api"})
     _membership = insert(:membership, %{user: user, role: role, account: account})
+
+    _auth_token =
+      insert(:auth_token, %{
+        user: user,
+        account: account,
+        token: @auth_token,
+        owner_app: "admin_api"
+      })
 
     # Setup could return all the inserted credentials using ExUnit context
     # by returning {:ok, context_map}. But it would make the code
@@ -99,6 +106,14 @@ defmodule AdminAPI.ConnCase do
     # and access using `context[:attribute]`.
     :ok
   end
+
+  def stringify_keys(map) when is_map(map) do
+    for {key, val} <- map, into: %{}, do: {convert_key(key), stringify_keys(val)}
+  end
+
+  def stringify_keys(value), do: value
+  def convert_key(key) when is_atom(key), do: Atom.to_string(key)
+  def convert_key(key), do: key
 
   @doc """
   Returns the user that has just been created from the test setup.

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -37,9 +37,13 @@ defmodule EWallet.Web.V1.ErrorHandler do
       code: "server:unknown_error",
       description: "An unknown error occured on the server"
     },
+    account_not_found: %{
+      code: "account:not_found",
+      description: "There is no user corresponding to the provided account id"
+    },
     access_token_not_found: %{
       code: "user:access_token_not_found",
-      description: "There is no user corresponding to the provided access_token"
+      description: "There is no account corresponding to the provided access_token"
     },
     access_token_expired: %{
       code: "user:access_token_expired",

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
@@ -42,8 +42,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
       account_id: Assoc.get(consumption, [:account, :id]),
       account: AccountSerializer.serialize(consumption.account),
       transaction_request_id: consumption.transaction_request.id,
-      transaction_request:
-        TransactionRequestSerializer.serialize(consumption.transaction_request),
+      transaction_request: TransactionRequestSerializer.serialize(consumption.transaction_request),
       address: consumption.balance_address,
       metadata: consumption.metadata || %{},
       encrypted_metadata: consumption.encrypted_metadata || %{},

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
@@ -42,7 +42,8 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
       account_id: Assoc.get(consumption, [:account, :id]),
       account: AccountSerializer.serialize(consumption.account),
       transaction_request_id: consumption.transaction_request.id,
-      transaction_request: TransactionRequestSerializer.serialize(consumption.transaction_request),
+      transaction_request:
+        TransactionRequestSerializer.serialize(consumption.transaction_request),
       address: consumption.balance_address,
       metadata: consumption.metadata || %{},
       encrypted_metadata: consumption.encrypted_metadata || %{},

--- a/apps/ewallet_api/lib/ewallet_api/v1/serializers/auth_token_serializer.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/serializers/auth_token_serializer.ex
@@ -6,7 +6,7 @@ defmodule EWalletAPI.V1.AuthTokenSerializer do
   def serialize(auth_token) do
     %{
       object: "authentication_token",
-      authentication_token: auth_token
+      authentication_token: auth_token.token
     }
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/serializers/auth_token_serializer_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/serializers/auth_token_serializer_test.exs
@@ -4,10 +4,11 @@ defmodule EWalletAPI.V1.AuthTokenSerializerTest do
 
   describe "V1.AuthTokenSerializer" do
     test "data contains the authentication token" do
-      serialized = AuthTokenSerializer.serialize("the_auth_token")
+      auth_token = insert(:auth_token)
+      serialized = AuthTokenSerializer.serialize(auth_token)
 
       assert serialized.object == "authentication_token"
-      assert serialized.authentication_token == "the_auth_token"
+      assert serialized.authentication_token == auth_token.token
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/auth_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/auth_view_test.exs
@@ -6,16 +6,18 @@ defmodule EWalletAPI.V1.AuthViewTest do
     # Potential candidate to be moved to a shared library
     # credo:disable-for-next-line Credo.Check.Design.DuplicatedCode
     test "renders auth_token.json with correct structure" do
+      auth_token = insert(:auth_token)
+
       expected = %{
         version: @expected_version,
         success: true,
         data: %{
           object: "authentication_token",
-          authentication_token: "the_auth_token"
+          authentication_token: auth_token.token
         }
       }
 
-      attrs = %{auth_token: "the_auth_token"}
+      attrs = %{auth_token: auth_token}
       assert AuthView.render("auth_token.json", attrs) == expected
     end
 

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -386,7 +386,7 @@ defmodule EWalletDB.User do
     query =
       from(
         [q, child] in query_accounts(user),
-        order_by: [asc: child.depth],
+        order_by: [asc: child.depth, desc: child.inserted_at],
         limit: 1
       )
 

--- a/apps/ewallet_db/priv/repo/migrations/20180425050633_add_account_uuid_to_auth_token.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180425050633_add_account_uuid_to_auth_token.exs
@@ -1,0 +1,9 @@
+defmodule EWalletDB.Repo.Migrations.AddAccountUUIDToAuthToken do
+  use Ecto.Migration
+
+  def change do
+    alter table(:auth_token) do
+      add :account_uuid, references(:account, type: :uuid, column: :uuid)
+    end
+  end
+end

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -164,6 +164,7 @@ defmodule EWalletDB.Factory do
       token: sequence("auth_token"),
       owner_app: "some_app_name",
       user: insert(:user),
+      account: insert(:account),
       expired: false
     }
   end


### PR DESCRIPTION
Issue/Task Number: T248

# Overview

Based on a request from the Admin Panel implementer @jarindr, we've decided to add the `current_account` in the `AuthToken` returned when logging in. This PR does just that, as well as offering a way to update the current account with `auth_token.switch_account`.

# Changes

- Add `/auth_token.switch_account`
- Refactor serializers and views to allow the `AuthToken` to contain the whole `user` and `account` objects
