### PR TITLE
Fix error 500 when consuming request with a different minted token

### DIFF
--- a/apps/ewallet/lib/ewallet/gates/transaction_consumption_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_consumption_gate.ex
@@ -161,7 +161,7 @@ defmodule EWallet.TransactionConsumptionGate do
   end
 
   defp validate_minted_token(request, minted_token) do
-    case request.minted_token_id == minted_token.id do
+    case request.minted_token_uuid == minted_token.uuid do
       true -> {:ok, minted_token}
       false -> {:error, :invalid_minted_token_provided}
     end

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_gate_test.exs
@@ -793,6 +793,25 @@ defmodule EWallet.TransactionConsumptionGateTest do
       assert error == :unauthorized_amount_override
     end
 
+    test "returns an error if the minted tokens are different", meta do
+      initialize_balance(meta.sender_balance, 200_000, meta.minted_token)
+      different_minted_token = insert(:minted_token)
+
+      {res, error} =
+        TransactionConsumptionGate.consume(meta.sender, %{
+          "transaction_request_id" => meta.request.id,
+          "correlation_id" => "123",
+          "amount" => 0,
+          "address" => meta.sender_balance.address,
+          "metadata" => %{},
+          "idempotency_token" => "123",
+          "token_id" => different_minted_token.id
+        })
+
+      assert res == :error
+      assert error == :invalid_minted_token_provided
+    end
+
     test "returns an error if the consumption tries to set an amount equal to 0", meta do
       initialize_balance(meta.sender_balance, 200_000, meta.minted_token)
 

--- a/apps/ewallet/test/ewallet/gates/transaction_request_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_request_gate_test.exs
@@ -614,7 +614,7 @@ defmodule EWallet.TransactionRequestTest do
       assert res == :ok
       assert %TransactionRequest{} = updated_request
       assert TransactionRequest.valid?(updated_request) == true
-      assert updated_request.updated_at > request.updated_at
+      assert NaiveDateTime.compare(updated_request.updated_at, request.updated_at) == :gt
     end
 
     test "touches the request if max_consumptions is equal to 0" do
@@ -623,7 +623,7 @@ defmodule EWallet.TransactionRequestTest do
       assert res == :ok
       assert %TransactionRequest{} = updated_request
       assert TransactionRequest.valid?(updated_request) == true
-      assert updated_request.updated_at > request.updated_at
+      assert NaiveDateTime.compare(updated_request.updated_at, request.updated_at) == :gt
     end
 
     test "touches the request if max_consumptions has not been reached" do
@@ -632,7 +632,7 @@ defmodule EWallet.TransactionRequestTest do
       assert res == :ok
       assert %TransactionRequest{} = updated_request
       assert TransactionRequest.valid?(updated_request) == true
-      assert updated_request.updated_at > request.updated_at
+      assert NaiveDateTime.compare(updated_request.updated_at, request.updated_at) == :gt
     end
 
     test "expires the request if max_consumptions has been reached" do

--- a/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
@@ -88,7 +88,7 @@ defmodule EWalletDB.TransactionRequestTest do
     test "updates the updated_at field" do
       request = insert(:transaction_request)
       {:ok, updated} = TransactionRequest.touch(request)
-      assert updated.updated_at > request.updated_at
+      assert NaiveDateTime.compare(updated.updated_at, request.updated_at) == :gt
     end
   end
 
@@ -254,7 +254,7 @@ defmodule EWalletDB.TransactionRequestTest do
       assert %TransactionRequest{} = updated_request
       assert TransactionRequest.valid?(updated_request) == true
       assert TransactionRequest.expired?(updated_request) == false
-      assert updated_request.updated_at > request.updated_at
+      assert NaiveDateTime.compare(updated_request.updated_at, request.updated_at) == :gt
     end
 
     test "touches the request if max_consumptions is equal to 0" do
@@ -263,7 +263,7 @@ defmodule EWalletDB.TransactionRequestTest do
       assert res == :ok
       assert %TransactionRequest{} = updated_request
       assert TransactionRequest.valid?(updated_request) == true
-      assert updated_request.updated_at > request.updated_at
+      assert NaiveDateTime.compare(updated_request.updated_at, request.updated_at) == :gt
     end
 
     test "touches the request if max_consumptions has not been reached" do
@@ -272,7 +272,7 @@ defmodule EWalletDB.TransactionRequestTest do
       assert res == :ok
       assert %TransactionRequest{} = updated_request
       assert TransactionRequest.valid?(updated_request) == true
-      assert updated_request.updated_at > request.updated_at
+      assert NaiveDateTime.compare(updated_request.updated_at, request.updated_at) == :gt
     end
 
     test "expires the request if max_consumptions has been reached" do


### PR DESCRIPTION
Issue/Task Number: T258

# Overview

This fixes the issue:

```ex
Request: POST /api/me.consume_transaction_request
** (exit) an exception was raised:
    ** (KeyError) key :minted_token_id not found in: %EWalletDB.TransactionRequest{<manually_redacted>}
        (ewallet) lib/ewallet/gates/transaction_consumption_gate.ex:164: EWallet.TransactionConsumptionGate.validate_minted_token/2
        (ewallet) lib/ewallet/gates/transaction_consumption_gate.ex:132: EWallet.TransactionConsumptionGate.do_consume/2
        (ecto) lib/ecto/adapters/sql.ex:620: anonymous fn/3 in Ecto.Adapters.SQL.do_transaction/3
        (db_connection) lib/db_connection.ex:1283: DBConnection.transaction_run/4
        (db_connection) lib/db_connection.ex:1207: DBConnection.run_begin/3
        (db_connection) lib/db_connection.ex:798: DBConnection.transaction/3
        (ewallet) lib/ewallet/gates/transaction_consumption_gate.ex:112: EWallet.TransactionConsumptionGate.consume/2
        (ewallet_api) lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex:27: EWalletAPI.V1.TransactionConsumptionController.consume_for_user/2
```

# Changes

- Added a new test to cover consuming a request with a different minted token.
- Fix more random tests failing due to operator comparison on NaiveDateTime

# Implementation Details

N/A

# Usage

Perform a consumption by providing a different minted token from the original transaction request.

# Impact

Deploy as usual