### PR TITLE
Add missing prefix to account ID

### DIFF
--- a/apps/ewallet_db/priv/repo/migrations/20180430045654_add_id_prefix_to_account.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180430045654_add_id_prefix_to_account.exs
@@ -1,0 +1,53 @@
+defmodule EWalletDB.Repo.Migrations.AddIdPrefixToAccount do
+  use Ecto.Migration
+  import Ecto.Query
+  alias EWalletDB.Repo
+
+  @table_name "account"
+  @prefix "acc_"
+
+  def up do
+    for [uuid, id] <- get_all(@table_name) do
+      id
+      |> add_prefix(@prefix)
+      |> update_id(@table_name, uuid)
+    end
+  end
+
+  def down do
+    for [uuid, id] <- get_all(@table_name) do
+      id
+      |> remove_prefix(@prefix)
+      |> update_id(@table_name, uuid)
+    end
+  end
+
+  # Add the prefix only if the ID is 26 characters long (ULID's length).
+  # The previous ID format is UUID which is 36 character in length with hyphens and 32 without.
+  # So it's safe to assume that 26-char IDs are the new format is suffice.
+  defp add_prefix(id, prefix) when byte_size(id) == 26 do
+    prefix <> id
+  end
+  defp add_prefix(id, _prefix), do: id
+
+  # Remove the prefix only if the ID starts with the prefix
+  defp remove_prefix(id, prefix) do
+    String.replace_prefix(id, prefix, "")
+  end
+
+  defp get_all(table_name) do
+    query = from(t in table_name,
+                 select: [t.uuid, t.id],
+                 lock: "FOR UPDATE")
+
+    Repo.all(query)
+  end
+
+  defp update_id(id, table_name, uuid) do
+    query = from(t in table_name,
+                 where: t.uuid == ^uuid,
+                 update: [set: [id: ^id]])
+
+    Repo.update_all(query, [])
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T262

# Overview

This PR adds the prefix "acc_" which was missing from existing accounts.

# Changes

- Add a new migration that adds "acc_" prefix to existing accounts.

# Implementation Details

This is a simple DB migration that adds the prefix if the existing ID length is 26 (the length of new ULID but without prefix).

# Usage

Run `mix ecto.migrate`.

You can follow these steps to verify this PR:

1. Run `mix ecto.migrate`. This brings the database to the latest migration.
2. Run `mix ecto.rollback --step 1` This triggers the PR's down() function and accounts are reverted back to their IDs without the prefix. Verify manually in database that account IDs do not contain the prefix.
3. Run `mix ecto.migrate` again. This should trigger this PR's migration script again. Verify manually in database that account IDs now contain the prefix.

# Impact

Deploy then run `mix ecto.migrate`