### PR TITLE
Fix inconsistent minted token IDs between local ledger and ewallet

### DIFF
--- a/apps/ewallet_db/priv/repo/migrations/20180430105218_update_predictable_minted_token_id.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180430105218_update_predictable_minted_token_id.exs
@@ -1,0 +1,86 @@
+defmodule EWalletDB.Repo.Migrations.UpdatePredictableMintedTokenId do
+  use Ecto.Migration
+  import Ecto.Query
+  alias EWalletDB.Repo
+  alias ExULID.ULID
+  alias Ecto.UUID
+
+  @table "minted_token"
+  @prefix "tok_"
+  @ulid_timestamp "01ccmny8yn"
+
+  # Migrate up
+  #
+  # Because minted token's IDs need to be sync'ed between `ewallet_db` and `local_ledger_db`,
+  # we need some way for the two databases to update to new ID format with consistent ID,
+  # at the same time not coupling the two database's migrations together.
+  #
+  # This is achieved by knowing that there are two moving factors in the new ID format,
+  # the ULID's timestamp (first 10 characters) and randomness (16 following characters).
+  # We can construct a predictable minted token ID by fixing the timestamp part to a specific value,
+  # and use the leading part of existing uuid (the shared value between the two database)
+  # for the 16-character randomness.
+  def up do
+    query = from(t in @table,
+                 select: [t.id, t.uuid, t.symbol, t.metadata],
+                 lock: "FOR UPDATE")
+
+    for [id, uuid, symbol, metadata] <- Repo.all(query) do
+      new_id = compute_id(@prefix, symbol, @ulid_timestamp, uuid)
+
+      # Let's also keep the original ID in metadata otherwise it'll be irrecoverable for rollback.
+      metadata = Map.put(metadata, :migration_original_id, id)
+
+      query = from(t in @table,
+                   where: t.uuid == ^uuid,
+                   update: [set: [id: ^new_id, metadata: ^metadata]])
+
+      Repo.update_all(query, [])
+    end
+  end
+
+  # We'll prepare the new ID using <prefix><symbol>_<ulid_timestamp><uuid_first_16_chars> format.
+  # Since uuid characters are a subset of Crockford's base32, we can use parts of the existing uuid
+  # as the randomness of the new sync'ed id. They don't represent the same decoded data but we are
+  # not concerned about that, we just need a consistent ID value.
+  defp compute_id(prefix, symbol, ulid_timestamp, uuid) do
+    # UUID's format is "756412b1-4a79-4963-9017-4eb49845c740" so we'll need the first 3 parts
+    {:ok, uuid} = UUID.cast(uuid)
+    [first, second, third, _discard] = String.split(uuid, "-", parts: 4)
+
+    prefix <> symbol <> "_" <> ulid_timestamp <> first <> second <> third
+  end
+
+  # Rollback
+  def down do
+    query = from(t in @table,
+                 select: [t.uuid, t.metadata, t.symbol, t.inserted_at],
+                 lock: "FOR UPDATE")
+
+    for [uuid, metadata, symbol, inserted_at] <- Repo.all(query) do
+      {id, metadata} = revert(metadata, @prefix, symbol, inserted_at)
+
+      query = from(t in @table,
+                   where: t.uuid == ^uuid,
+                   update: [set: [id: ^id, metadata: ^metadata]])
+
+      Repo.update_all(query, [])
+    end
+  end
+
+  # Revert back the ID and metadata if possible, otherwise re-generate the ID.
+  defp revert(%{"migration_original_id" => original_id} = metadata, _prefix, _symbol, _inserted_at) do
+    {original_id, Map.delete(metadata, "migration_original_id")}
+  end
+  defp revert(metadata, prefix, symbol, inserted_at) do
+    with {date, {hours, minutes, seconds, microseconds}} <- inserted_at,
+         erlang_time <- {date, {hours, minutes, seconds}},
+         {:ok, naive} <- NaiveDateTime.from_erl(erlang_time, {microseconds, 6}),
+         {:ok, datetime} <- DateTime.from_naive(naive, "Etc/UTC"),
+         unix_time <- DateTime.to_unix(datetime, :millisecond),
+         ulid <- prefix <> symbol <> "_" <> ULID.generate(unix_time)
+    do
+      {ulid, metadata}
+    end
+  end
+end

--- a/apps/local_ledger_db/priv/repo/migrations/20180430105449_update_predictable_minted_token_id.exs
+++ b/apps/local_ledger_db/priv/repo/migrations/20180430105449_update_predictable_minted_token_id.exs
@@ -1,0 +1,130 @@
+defmodule LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId do
+  use Ecto.Migration
+  import Ecto.Query
+  alias Ecto.Adapters.SQL
+  alias Ecto.UUID
+  alias ExULID.ULID
+  alias LocalLedgerDB.Repo
+
+  @prefix "tok_"
+  @ulid_timestamp "01ccmny8yn"
+
+  # Migrate up
+  #
+  # Because minted token's IDs need to be sync'ed between `ewallet_db` and `local_ledger_db`,
+  # we need some way for the two databases to update to new ID format with consistent ID,
+  # at the same time not coupling the two database's migrations together.
+  #
+  # This is achieved by knowing that there are two moving factors in the new ID format,
+  # the ULID's timestamp (first 10 characters) and randomness (16 following characters).
+  # We can construct a predictable minted token ID by fixing the timestamp part to a specific value,
+  # and use the leading part of existing uuid (the shared value between the two database)
+  # for the 16-character randomness.
+  def up do
+    query = from(t in "minted_token",
+                 select: [t.id, t.uuid, t.metadata],
+                 lock: "FOR UPDATE")
+
+    SQL.query(Repo, "ALTER TABLE minted_token DISABLE TRIGGER ALL")
+
+    for [id, uuid, metadata] <- Repo.all(query) do
+      # The id's format is "OMG:756412b1-4a79-4963-9017-4eb49845c740", split to get symbol and uuid.
+      [symbol, ewallet_uuid] = String.split(id, ":")
+      new_id = compute_id(@prefix, symbol, @ulid_timestamp, ewallet_uuid)
+
+      # Let's also keep the original ID in metadata otherwise it'll be irrecoverable for rollback.
+      metadata = Map.put(metadata, :migration_original_id, id)
+
+      query = from(t in "minted_token",
+                   where: t.uuid == ^uuid,
+                   update: [set: [id: ^new_id, metadata: ^metadata]])
+
+      Repo.update_all(query, [])
+
+      query = from(t in "transaction",
+                   where: t.minted_token_id == ^id,
+                   update: [set: [minted_token_id: ^new_id]])
+
+      Repo.update_all(query, [])
+
+      query = from(t in "cached_balance",
+                   where: fragment("amounts \\? ?", ^id),
+                   update: [set: [amounts: fragment("amounts - ? || jsonb_build_object(?, amounts->?)",
+                                                    type(^id, :string),
+                                                    type(^new_id, :string),
+                                                    type(^id, :string))]])
+
+      Repo.update_all(query, [])
+    end
+
+    SQL.query(Repo, "ALTER TABLE minted_token ENABLE TRIGGER ALL")
+  end
+
+  # We'll prepare the new ID using <prefix><symbol>_<ulid_timestamp><uuid_first_16_chars> format.
+  # Since uuid characters are a subset of Crockford's base32, we can use parts of the existing uuid
+  # as the randomness of the new sync'ed id. They don't represent the same decoded data but we are
+  # not concerned about that, we just need a consistent ID value.
+  defp compute_id(prefix, symbol, ulid_timestamp, uuid) do
+    # UUID's format is "756412b1-4a79-4963-9017-4eb49845c740" so we'll need the first 3 parts
+    {:ok, uuid} = UUID.cast(uuid)
+    [first, second, third, _remaining] = String.split(uuid, "-", parts: 4)
+
+    prefix <> symbol <> "_" <> ulid_timestamp <> first <> second <> third
+  end
+
+  # Rollback
+  def down do
+    query = from(t in "minted_token",
+                 select: [t.id, t.uuid, t.metadata, t.inserted_at],
+                 lock: "FOR UPDATE")
+
+    SQL.query(Repo, "ALTER TABLE minted_token DISABLE TRIGGER ALL")
+
+    for [id, uuid, metadata, inserted_at] <- Repo.all(query) do
+      {new_id, metadata} = revert(metadata, @prefix, id, inserted_at)
+
+      query = from(t in "minted_token",
+                   where: t.uuid == ^uuid,
+                   update: [set: [id: ^new_id, metadata: ^metadata]])
+
+      Repo.update_all(query, [])
+
+      query = from(t in "transaction",
+                   where: t.minted_token_id == ^id,
+                   update: [set: [minted_token_id: ^new_id]])
+
+      Repo.update_all(query, [])
+
+      query = from(t in "cached_balance",
+                   where: fragment("amounts \\? ?", ^id),
+                   update: [set: [amounts: fragment("amounts - ? || jsonb_build_object(?, amounts->?)",
+                                                    type(^id, :string),
+                                                    type(^new_id, :string),
+                                                    type(^id, :string))]])
+
+      Repo.update_all(query, [])
+    end
+
+    SQL.query(Repo, "ALTER TABLE minted_token ENABLE TRIGGER ALL")
+  end
+
+  # Revert back the ID and metadata if possible, otherwise re-generate the ID.
+  defp revert(%{"migration_original_id" => original_id} = metadata, _prefix, _id, _inserted_at) do
+    {original_id, Map.delete(metadata, "migration_original_id")}
+  end
+  defp revert(metadata, prefix, id, inserted_at) do
+    with [_prefix, symbol, _remaining_id] <- String.split(id),
+         {date, {hours, minutes, seconds, microseconds}} <- inserted_at,
+         erlang_time <- {date, {hours, minutes, seconds}},
+         {:ok, naive} <- NaiveDateTime.from_erl(erlang_time, {microseconds, 6}),
+         {:ok, datetime} <- DateTime.from_naive(naive, "Etc/UTC"),
+         unix_time <- DateTime.to_unix(datetime, :millisecond),
+         ulid <- prefix <> symbol <> "_" <> ULID.generate(unix_time)
+    do
+      {ulid, metadata}
+    else
+      _ ->
+        {id, metadata}
+    end
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T263

# Overview

Fixes the issue that #149 did not completely convert the minted token IDs in local ledger, therefore the minted token IDs in the local ledger and ewallet are inconsistent even though they represent the same minted token.

# Changes

- Fixes some errors when running `mix seed --sample`
- Adds a migration that updates the `minted_token.id` in both the local ledger and ewallet to be consistent.

# Implementation Details

**Cause:** This bug is caused by missing migrations in `local_ledger_db` that should have converted minted token IDs from the previous `SYM:uuid` to `tok_SYM_ulid` format but did not. This causes transactions to fail as it could not retrieve the balance in `local_ledger_db` using the new `tok_SYM_ulid` format.

**Solution:** Since this project is still in beta, it is possible to wipe the database to avoid this fix entirely, but this is a good drill to see how complex data issues can be investigated & fixed. So we tackled the issue as if this is a production issue with live data. See "lessons learnt" below for more detail of the solution.

**Lessons learnt:**

- Migrations in `local_ledger_db` cannot make queries across to `ewallet_db` because `EWalletDB.Repo` is not started during `local_ledger_db` migrations. This means by default, migrations cannot reach another database that does not belong to or configured for the app.
- To workaround above, we could either:
    1. Add `EWalletDB.Repo` to `local_ledger_db/config/*.exs`, or
    2. Run migration with `mix ecto.migrate -r EWalletDB.Repo -r LocalLedgerDB.Repo`
  
  Both of which would permanently add `EWalletDB.Repo` to `local_ledger_db` for a one time issue = not good 🙅‍♂️ 
- Instead, we needed a way that would allow both `ewallet_db` and `local_ledger_db` to:
  - Guarantee that its minted token IDs are the same 
  - Follows the new format `tok_SYM_ulid` where `ulid` consists of a 10-character timestamp and 16-character *randomness*
  - Without querying across the two separate databases
- So in order to generate a consistent ID, we reused existing data that's common between the two databases to build a new `tok_SYM_<timestamp><randomness>`:
  - `tok_` is the known prefix
  - `SYM` exists in `ewallet_db` as `minted_token.symbol`, while in `local_ledger_db` is extractable from from the existing ID's `SYM:uuid` format.
  - `<timestamp>` is fixed to a specific date & time, i.e. "01ccmny8yn". This should be safe because there are a limited number of minted tokens in each system, and the uniqueness & minted token identification can be guaranteed by the randomness, not the timestamp.
  - `<randomness>` instead of randomly generating a new value, we reused the existing minted token's `uuid` by extracting the first 16 characters from the uuid string. This uuid exists in `ewallet_db`. However, the uuids in `local_ledger_db` are of different values. Instead, we can extract it from the existing `SYM:uuid` format in the ID, where the uuid was taken from `ewallet_db`.
- I added `migration_original_id` to the minted token's metadata for a recoverable rollback.

No fancy diagrams like @ripzery because I'm bad at drawing 😢 

# Usage

To properly test this fix, I suggest following this instruction:

1. Checkout the commit before #149 is merged with: `git checkout 64bdb3c`.
2. Seed the database with `mix do ecto.drop, ecto.create, ecto.migrate, seed --sample`. 
  _This is so that we have a database populated with `minted_token.id` that are in the old format, e.g. `OEM:68199c99-7bf6-4f4f-8e09-184a15819cbd`._
3. Checkout the commit right before this branch starts with `git checkout 9cdd60a`.
4. Run the migration: `mix ecto.migrate`.
  _This is where the bug happens. `minted_token.id` in `local_ledger_db` and `ewallet_db` should be inconsistent at this point, e.g. `tok_OEM_01ccmny8ynf96dbf02bbcd489d` in `ewallet_db` and `OEM:68199c99-7bf6-4f4f-8e09-184a15819cbd` in `local_ledger_db`._
3. Checkout this branch with `git checkout t263-local-ledger-ids`, make sure you are on the latest commit.
4. Run the migration: `mix ecto.migrate`.
5. Verify that the `minted_token.id` in `local_ledger_db` and `ewallet_db` are now consistent with the minted token's ID appearing the same everywhere.

# Impact

Run `mix ecto.migrate` after deployment.

Note: For some ewallet instances that have successfully added transactions since #149 is deployed, manual work might be needed to clean up duplicate minted tokens in the local_ledger. For example, if more tokens were minted, `LocalLedger` sees that the minted token does not match any record in its database, so it creates a new `minted_token`. Extra clean up is needed to merge back the new `minted_token` to the existing one.

For new or existing installations that has not deployed b3d3425, no manual actions are needed.