### PR TITLE
Fix seed's argument error

### DIFF
--- a/apps/ewallet/priv/repo/report_minimum.exs
+++ b/apps/ewallet/priv/repo/report_minimum.exs
@@ -84,7 +84,7 @@ CLI.print("""
 
       ```
       OMGAdmin #{Base.encode64(api_key_id <> ":" <> api_key
-        <> ":" <> admin.id <> ":" <> admin_auth_token)}
+        <> ":" <> admin.id <> ":" <> admin_auth_token.token)}
       ```
 
       The above header is for you to get started quickly. To integrate the eWallet SDK

--- a/apps/ewallet/priv/repo/report_sample.exs
+++ b/apps/ewallet/priv/repo/report_sample.exs
@@ -44,7 +44,7 @@ CLI.print("""
   3. Use the value below for `ClientAuth`:
 
   ```
-  OMGClient #{Base.encode64(ewallet_api_key.key <> ":" <> ewallet_auth_token)}
+  OMGClient #{Base.encode64(ewallet_api_key.key <> ":" <> ewallet_auth_token.token)}
   ```
 
   4. Try out Client endpoints such as /me.get, /me.list_transactions, /logout, etc.
@@ -69,7 +69,7 @@ CLI.print("""
 
   ```
   OMGAdmin #{Base.encode64(admin_api_key.id <> ":" <> admin_api_key.key <> ":" <> admin_user.id
-    <> ":" <> admin_auth_token)}
+    <> ":" <> admin_auth_token.token)}
   ```
 
   4. Try out User endpoints such as /account.create, /account.assign_user, /access_key.create, etc.

--- a/apps/ewallet/priv/repo/seeders/auth_token.exs
+++ b/apps/ewallet/priv/repo/seeders/auth_token.exs
@@ -36,7 +36,7 @@ Enum.each(seeds, fn(data) ->
         User ID          : #{data.user.id}
         Provider user ID : #{data.user.provider_user_id || '<nil>'}
         User email       : #{data.user.email || '<nil>'}
-        Auth token       : #{token}
+        Auth token       : #{token.token}
       """)
     {:error, changeset} ->
       CLI.error("""


### PR DESCRIPTION
Issue/Task Number: T270

# Overview

Fixes seed error due to the way `AuthToken.generate/2` is returned since #166. Also reported by #173.

# Changes

- Update seed reports to expect the auth_token as struct, not string

# Implementation Details

Simple fix of accessing a struct vs. string

# Usage

Run `mix do reset, mix seed --sample` should output the seed report successfully without any errors.

# Impact

No extra steps required during deploy.
