### PR TITLE
Fix minted token's association with master account

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/minted_token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/minted_token_controller.ex
@@ -8,6 +8,7 @@ defmodule AdminAPI.V1.MintedTokenController do
   alias EWallet.Web.{SearchParser, SortParser, Paginator}
   alias EWalletDB.{Account, MintedToken}
   alias Ecto.UUID
+  alias Plug.Conn
 
   # The field names to be mapped into DB column names.
   # The keys and values must be strings as this is mapped early before
@@ -31,6 +32,7 @@ defmodule AdminAPI.V1.MintedTokenController do
   @doc """
   Retrieves a list of minted tokens.
   """
+  @spec all(Conn.t(), map() | nil) :: map()
   def all(conn, attrs) do
     MintedToken
     |> SearchParser.to_query(attrs, @search_fields)
@@ -42,6 +44,7 @@ defmodule AdminAPI.V1.MintedTokenController do
   @doc """
   Retrieves a specific minted token by its id.
   """
+  @spec get(Conn.t(), map()) :: map()
   def get(conn, %{"id" => id}) do
     id
     |> MintedToken.get()
@@ -53,6 +56,7 @@ defmodule AdminAPI.V1.MintedTokenController do
   @doc """
   Creates a new Minted Token.
   """
+  @spec create(Conn.t(), map()) :: map()
   def create(conn, attrs) do
     inserted_minted_token =
       attrs
@@ -73,6 +77,7 @@ defmodule AdminAPI.V1.MintedTokenController do
   @doc """
   Mint a minted token.
   """
+  @spec mint(Conn.t(), map()) :: map()
   def mint(
         conn,
         %{

--- a/apps/admin_api/lib/admin_api/v1/controllers/minted_token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/minted_token_controller.ex
@@ -6,7 +6,7 @@ defmodule AdminAPI.V1.MintedTokenController do
   import AdminAPI.V1.ErrorHandler
   alias EWallet.MintGate
   alias EWallet.Web.{SearchParser, SortParser, Paginator}
-  alias EWalletDB.MintedToken
+  alias EWalletDB.{Account, MintedToken}
   alias Ecto.UUID
 
   # The field names to be mapped into DB column names.
@@ -53,10 +53,10 @@ defmodule AdminAPI.V1.MintedTokenController do
   @doc """
   Creates a new Minted Token.
   """
-  def create(%{assigns: %{account: account}} = conn, attrs) do
+  def create(conn, attrs) do
     inserted_minted_token =
       attrs
-      |> Map.put("account_uuid", account.uuid)
+      |> Map.put("account_uuid", Account.get_master_account().uuid)
       |> MintedToken.insert()
 
     case attrs["amount"] do
@@ -69,8 +69,6 @@ defmodule AdminAPI.V1.MintedTokenController do
         respond_single(inserted_minted_token, conn)
     end
   end
-
-  def create(conn, _), do: handle_error(conn, :invalid_parameter)
 
   @doc """
   Mint a minted token.


### PR DESCRIPTION
Issue/Task Number: T271

# Overview

Fixes `"client:invalid_parameter"` error when trying to create a minted token with `/admin/api/minted_token.create`. Fixes #177.

Depends on #179 otherwise the test with `enable_client_auth: false` is not possible.

# Changes

- Fix  `/minted_token.create`'s account association to the master account

# Implementation Details

This bug follows #151 that the client authentication (using API ID and API key) in AdminAPI can now be optional. This means `conn.assigns.account` assigned during `ClientAuthPlug` may not always be available, but `/minted_token.create` still relies on it.

Since we have no use case for minted token in non-master accounts, it's best to fix it to master account until we have a solid reason not to.

# Usage

Requesting `/minted_token.create` with valid parameters should now be successful.

# Impact

Deploy as usual.
