### PR TITLE
Improvements to ClientAuthPlug and UserAuthPlug

### DIFF
--- a/apps/admin_api/config/test.exs
+++ b/apps/admin_api/config/test.exs
@@ -1,12 +1,13 @@
 use Mix.Config
 
+# General application configuration
+config :admin_api, enable_client_auth: true
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :admin_api, AdminAPI.Endpoint,
   secret_key_base: "G1DLBdjjJSoSiQRa5Gf8YrWUx5yrX+JFmZx+UBk829W1+e0oJ9TYrW/GkIgrAdfm",
   server: false
-
-config :admin_api, enable_client_auth: "true"
 
 # Configs for Bamboo emailing library
 config :admin_api, AdminAPI.Mailer, adapter: Bamboo.TestAdapter

--- a/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
@@ -2,8 +2,24 @@ defmodule AdminAPI.V1.ClientAuthPlug do
   @moduledoc """
   This plug checks if valid `api_key_id` and `api_key` are provided.
 
-  If `api_key_id` and `api_key` matches the database record, the plug assigns
-  the `api_key_id` and `account` to the connection along with `authenticated: true`.
+  On success, the plug assigns the following `conn.assigns`:
+
+    - `authenticated`: Set to `:client` to indicate that the request has been authenticated
+                       at the client level.
+    - `api_key_id`: The API key used to authenticate the request.
+    - `auth_account`: The account that is associated with the API key.
+
+  If client auth is disabled, the plug assigns the following `conn.assigns`:
+
+    - `authenticated`: Set to `:client`.
+    - `api_key_id`: Not assigned.
+    - `auth_account`: Not assigned.
+
+  On failure, the plug halts, then assigns the following `conn.assigns`:
+
+    - `authenticated`: Set to `false`.
+    - `api_key_id`: Not assigned.
+    - `auth_account`: Not assigned.
   """
   import Plug.Conn
   import AdminAPI.V1.ErrorHandler

--- a/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
@@ -25,19 +25,30 @@ defmodule AdminAPI.V1.ClientAuthPlug do
   import AdminAPI.V1.ErrorHandler
   alias EWalletDB.{Account, APIKey}
 
-  def init(opts), do: opts
+  @doc """
+  API used by Plug to start client authentication.
+  """
+  @spec init(keyword()) :: keyword()
+  def init(opts) do
+    Keyword.put_new(
+      opts,
+      :enable_client_auth,
+      Application.get_env(:admin_api, :enable_client_auth)
+    )
+  end
 
+  @doc """
+  API used by Plug to authenticate the client.
+  """
+  @spec call(Conn.t(), keyword()) :: Conn.t()
   def call(conn, opts) do
-    auth =
-      Keyword.get(opts, :enable_client_auth, Application.get_env(:admin_api, :enable_client_auth))
-
-    case auth do
+    case opts[:enable_client_auth] do
       true ->
         conn
         |> parse_header()
         |> authenticate()
 
-      _ ->
+      false ->
         assign(conn, :authenticated, :client)
     end
   end

--- a/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
@@ -16,7 +16,7 @@ defmodule AdminAPI.V1.ClientAuthPlug do
       Keyword.get(opts, :enable_client_auth, Application.get_env(:admin_api, :enable_client_auth))
 
     case auth do
-      "true" ->
+      true ->
         conn
         |> parse_header()
         |> authenticate()

--- a/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/client_auth_plug.ex
@@ -62,7 +62,7 @@ defmodule AdminAPI.V1.ClientAuthPlug do
         conn
         |> assign(:authenticated, :client)
         |> assign(:api_key_id, api_key_id)
-        |> assign(:account, account)
+        |> assign(:auth_account, account)
 
       false ->
         conn

--- a/apps/admin_api/lib/admin_api/v1/plugs/user_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/user_auth_plug.ex
@@ -26,7 +26,7 @@ defmodule AdminAPI.V1.UserAuthPlug do
 
   def call(conn, opts) do
     case Keyword.get(opts, :enable_client_auth) do
-      "true" ->
+      true ->
         conn
         |> parse_header()
         |> ClientAuthPlug.authenticate()

--- a/apps/admin_api/lib/admin_api/v1/plugs/user_auth_plug.ex
+++ b/apps/admin_api/lib/admin_api/v1/plugs/user_auth_plug.ex
@@ -1,14 +1,20 @@
 defmodule AdminAPI.V1.UserAuthPlug do
   @moduledoc """
-  This plug checks if valid api key and token were provided.
+  This plug checks if a pair of valid user ID and authentication token were provided.
 
-  If api key and token are valid, the plug assigns the user
-  associated with the token to the connection so that downstream
-  consumers know which user this request belongs to.
+  On success, the plug assigns the following to `conn.assigns`:
 
-  The credentials in this plug may need to be stored on client's side,
-  i.e. in the browser. Therefore high privilege credentials like
-  EWalletDB.Key's `access_key` and `secret_key` should not be used.
+    - `authenticated`: Set to `:user` to indicate that the request has been authenticated
+                       at the user level.
+    - `api_key_id`: The API key used to authenticate the request
+                    (set if enable_client_auth == true, otherwise not assigned).
+    - `user`: The user that is associated with the authentication token.
+
+  On failure, the plug assigns the following to `conn.assigns`:
+
+    - `authenticated`: Set to `false`.
+    - `api_key_id`: Not assigned.
+    - `user`: Not assigned.
   """
   import Plug.Conn
   import AdminAPI.V1.ErrorHandler

--- a/apps/admin_api/test/admin_api/v1/controllers/auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/auth_controller_test.exs
@@ -170,14 +170,32 @@ defmodule AdminAPI.V1.AuthControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
     end
 
-    test "returns :invalid_api_key when unauthenticated" do
+    test "returns :invalid_api_key if client credentials are invalid" do
       response =
-        client_request("/auth_token.switch_account", %{
-          "account_id" => "123"
-        })
+        user_request(
+          "/auth_token.switch_account",
+          %{
+            "account_id" => "123"
+          },
+          api_key: "bad_api_key"
+        )
 
       refute response["success"]
       assert response["data"]["code"] == "client:invalid_api_key"
+    end
+
+    test "returns :access_token_not_found if user credentials are invalid" do
+      response =
+        user_request(
+          "/auth_token.switch_account",
+          %{
+            "account_id" => "123"
+          },
+          auth_token: "bad_auth_token"
+        )
+
+      refute response["success"]
+      assert response["data"]["code"] == "user:access_token_not_found"
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/plugs/client_auth_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/client_auth_plug_test.exs
@@ -3,13 +3,7 @@ defmodule AdminAPI.V1.ClientAuthPlugTest do
   alias AdminAPI.V1.ClientAuthPlug
   alias Ecto.UUID
 
-  describe "ClientAuthPlug.call/2" do
-    test "assigns authenticated conn info when auth is not enabled" do
-      conn = test_with_no_auth()
-      refute conn.halted
-      assert conn.assigns.authenticated == :client
-    end
-
+  describe "ClientAuthPlug.call/2 with enable_client_auth == true" do
     test "assigns authenticated conn info if the api_key_id and api_key match the db record" do
       conn = test_with("OMGAdmin", @api_key_id, @api_key)
       assert_success(conn)
@@ -50,17 +44,18 @@ defmodule AdminAPI.V1.ClientAuthPlugTest do
     end
   end
 
-  defp test_with(type, api_key_id, api_key), do: test_with(type, [api_key_id, api_key])
-
-  defp test_with(type, data) when is_list(data) do
-    build_conn()
-    |> put_auth_header(type, data)
-    |> ClientAuthPlug.call([])
+  describe "ClientAuthPlug.call/2 with enable_client_auth == false" do
+    test "assigns authenticated == :client" do
+      conn = test_with("OMGAdmin", "", "", false)
+      refute conn.halted
+      assert conn.assigns.authenticated == :client
+    end
   end
 
-  defp test_with_no_auth do
+  defp test_with(type, api_key_id, api_key, client_auth? \\ true) do
     build_conn()
-    |> ClientAuthPlug.call(enable_client_auth: false)
+    |> put_auth_header(type, [api_key_id, api_key])
+    |> ClientAuthPlug.call(enable_client_auth: client_auth?)
   end
 
   defp assert_success(conn) do

--- a/apps/admin_api/test/admin_api/v1/plugs/user_auth_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/user_auth_plug_test.exs
@@ -3,14 +3,7 @@ defmodule AdminAPI.V1.UserAuthPlugTest do
   alias AdminAPI.V1.UserAuthPlug
   alias Ecto.UUID
 
-  describe "UserAuthPlug.call/2" do
-    test "assigns authenticated conn info if the token is correct without admin " do
-      conn = test_with("OMGAdmin", @user_id, @auth_token)
-
-      refute conn.halted
-      assert_success(conn)
-    end
-
+  describe "UserAuthPlug.call/2 with enable_client_auth == true" do
     test "assigns authenticated conn info if the token is correct" do
       conn = test_with("OMGAdmin", @api_key_id, @api_key, @user_id, @auth_token)
 
@@ -27,6 +20,43 @@ defmodule AdminAPI.V1.UserAuthPlugTest do
 
     test "assigns unauthenticated conn info if the token doesn't belong to the user_id" do
       conn = test_with("OMGAdmin", @api_key_id, @api_key, UUID.generate(), @auth_token)
+
+      assert conn.halted
+      assert_error(conn)
+    end
+
+    test "assigns unauthenticated conn info if client auth info is not provided " do
+      conn = test_with("OMGAdmin", @user_id, @auth_token)
+
+      assert conn.halted
+      assert_error(conn)
+    end
+  end
+
+  describe "UserAuthPlug.call/2 with enable_client_auth == false" do
+    test "assigns authenticated conn info if the token is correct " do
+      conn = test_with("OMGAdmin", @user_id, @auth_token, false)
+
+      refute conn.halted
+      assert_success(conn)
+    end
+
+    test "assigns authenticated conn info even if client auth info is provided" do
+      conn = test_with("OMGAdmin", @api_key_id, @api_key, @user_id, @auth_token, false)
+
+      refute conn.halted
+      assert_success(conn)
+    end
+
+    test "assigns authenticated conn info even if invalid client auth info is provided" do
+      conn = test_with("OMGAdmin", @api_key_id, "bad_api_key", @user_id, @auth_token, false)
+
+      refute conn.halted
+      assert_success(conn)
+    end
+
+    test "assigns unauthenticated conn info if the token is invalid " do
+      conn = test_with("OMGAdmin", @user_id, "bad_token", false)
 
       assert conn.halted
       assert_error(conn)
@@ -70,16 +100,16 @@ defmodule AdminAPI.V1.UserAuthPlugTest do
     end
   end
 
-  defp test_with(type, api_key_id, api_key, user_id, auth_token) do
+  defp test_with(type, api_key_id, api_key, user_id, auth_token, client_auth? \\ true) do
     build_conn()
     |> put_auth_header(type, [api_key_id, api_key, user_id, auth_token])
-    |> UserAuthPlug.call([])
+    |> UserAuthPlug.call(enable_client_auth: client_auth?)
   end
 
-  defp test_with(type, user_id, auth_token) do
+  defp test_with(type, user_id, auth_token, client_auth? \\ true) do
     build_conn()
     |> put_auth_header(type, [user_id, auth_token])
-    |> UserAuthPlug.call(enable_client_auth: false)
+    |> UserAuthPlug.call(enable_client_auth: client_auth?)
   end
 
   defp assert_success(conn) do

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -146,15 +146,19 @@ defmodule AdminAPI.ConnCase do
   A helper function that generates a valid user request (user-authenticated)
   with given path and data, and return the parsed JSON response.
   """
-  def user_request(path, data \\ %{}, status \\ :ok)
+  def user_request(path, data \\ %{}, status \\ :ok, include_client_auth \\ true)
       when is_binary(path) and byte_size(path) > 0 do
     # Make the authenticated request after login
     build_conn()
     |> put_req_header("accept", @header_accept)
-    |> put_auth_header("OMGAdmin", [@api_key_id, @api_key, @user_id, @auth_token])
+    |> put_auth_header("OMGAdmin", user_auth_header(include_client_auth))
     |> post(@base_dir <> path, data)
     |> json_response(status)
   end
+
+  defp user_auth_header(include_client_auth?)
+  defp user_auth_header(true), do: [@api_key_id, @api_key, @user_id, @auth_token]
+  defp user_auth_header(false), do: [@user_id, @auth_token]
 
   @doc """
   Helper functions that puts an Authorization header to the connection.


### PR DESCRIPTION
Issue/Task Number: T271

# Overview

Small refactors and improvements of `ClientAuthPlug` and `UserAuthPlug` and its tests to cover all `:enable_client_auth` cases.

# Changes

- ~Move `:enable_client_auth` check from `init/1` to `call/2` to support runtime config change~ No need to. I was coupling #178 and #179 together when I was doing that.
- Add tests to `ClientAuthPlugTest` and `UserAuthPlugTest` to cover all `:enable_client_auth` combinations
- Update moduledoc for `ClientAuthPlug` & `UserAuthPlug`
- Refined `UserAuthPlug.call/2` to be more specific when handling different kinds of auth headers:

# Implementation Details

- Added more `ClientAuthPlugTest` and `UserAuthPlugTest` tests. This should cover all combinations of `enable_client_auth: true` v.s. `false` and 4-part v.s. 2-part Authorization header.
- The refined `UserAuthPlug.call/2` can handle different kinds of auth headers more accurately:
  - When `enable_client_auth: true`
    - Attempts to authenticate `api_key_id:api_key:user_id:auth_token` header
    - Other header formats will not be authenticated
  - When `enable_client_auth: false`
    - Attempts to authenticate `user_id:auth_token` header
    - If `api_key_id:api_key:user_id:auth_token` header is provided, it authenticates both `api_key_id:api_key` and `user_id:auth_token`. Providing incorrect `api_key_id:api_key` will result in `client:invalid_api_key` error.
- ☝️ This refined plug also allows for more accurate error codes. Before this PR an invalid `user_id:auth_token` would return `client:invalid_api_key` error. With this PR it would return `client:invalid_api_key` and `user:access_token_not_found` accurately.

# Usage

Run `mix test`

# Impact

Deploy as usual.