### PR TITLE
Expired consumption event

### DIFF
--- a/apps/ewallet/config/dev.exs
+++ b/apps/ewallet/config/dev.exs
@@ -4,3 +4,21 @@ config :ewallet,
   websocket_endpoints: [
     EWalletAPI.V1.Endpoint
   ]
+
+config :logger,
+  level: :debug
+
+config :ewallet, EWallet.Scheduler,
+  global: true,
+  jobs: [
+    expire_requests: [
+      schedule: "* * * * *",
+      task: {EWalletDB.TransactionRequest, :expire_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
+    ],
+    expire_consumptions: [
+      schedule: "* * * * *",
+      task: {EWalletDB.TransactionConsumption, :expire_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
+    ]
+  ]

--- a/apps/ewallet/config/dev.exs
+++ b/apps/ewallet/config/dev.exs
@@ -5,8 +5,7 @@ config :ewallet,
     EWalletAPI.V1.Endpoint
   ]
 
-config :logger,
-  level: :debug
+config :logger, level: :debug
 
 config :ewallet, EWallet.Scheduler,
   global: true,

--- a/apps/ewallet/config/prod.exs
+++ b/apps/ewallet/config/prod.exs
@@ -4,3 +4,18 @@ config :ewallet,
   websocket_endpoints: [
     EWalletAPI.V1.Endpoint
   ]
+
+config :ewallet, EWallet.Scheduler,
+  global: true,
+  jobs: [
+    expire_requests: [
+      schedule: "* * * * *",
+      task: {EWalletDB.TransactionRequest, :expire_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
+    ],
+    expire_consumptions: [
+      schedule: "* * * * *",
+      task: {EWalletDB.TransactionConsumption, :expire_all, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster}
+    ]
+  ]

--- a/apps/ewallet/lib/ewallet/application.ex
+++ b/apps/ewallet/lib/ewallet/application.ex
@@ -1,0 +1,18 @@
+defmodule EWallet.Application do
+  @moduledoc false
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    # List all child processes to be supervised
+    children = [
+      worker(EWallet.Scheduler, [])
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: EWallet.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/apps/ewallet/lib/ewallet/scheduler.ex
+++ b/apps/ewallet/lib/ewallet/scheduler.ex
@@ -1,0 +1,4 @@
+defmodule EWallet.Scheduler do
+  @moduledoc false
+  use Quantum.Scheduler, otp_app: :ewallet
+end

--- a/apps/ewallet/lib/ewallet/schedulers/transaction_consumption_scheduler.ex
+++ b/apps/ewallet/lib/ewallet/schedulers/transaction_consumption_scheduler.ex
@@ -1,0 +1,21 @@
+defmodule EWallet.TransactionConsumptionScheduler do
+  @moduledoc """
+  Scheduler containing logic for CRON tasks related to
+  transaction consumptions.
+  """
+  alias EWallet.Web.V1.Event
+  alias EWalletDB.TransactionConsumption
+
+  @doc """
+  Expires all transaction consumptions which are
+  past their expiration dates and send a failed
+  "transaction_consumption_finalized" event.
+  """
+  def expire_all do
+    {_count, consumptions} = TransactionConsumption.expire_all()
+
+    Enum.each(consumptions, fn consumption ->
+      Event.dispatch(:transaction_consumption_finalized, %{consumption: consumption})
+    end)
+  end
+end

--- a/apps/ewallet/lib/ewallet/schedulers/transaction_request_scheduler.ex
+++ b/apps/ewallet/lib/ewallet/schedulers/transaction_request_scheduler.ex
@@ -1,0 +1,15 @@
+defmodule EWallet.TransactionRequestScheduler do
+  @moduledoc """
+  Scheduler containing logic for CRON tasks related to
+  transaction requests.
+  """
+  alias EWalletDB.TransactionRequest
+
+  @doc """
+  Expires all transaction request which are
+  past their expiration dates.
+  """
+  def expire_all do
+    TransactionRequest.expire_all()
+  end
+end

--- a/apps/ewallet/mix.exs
+++ b/apps/ewallet/mix.exs
@@ -27,6 +27,7 @@ defmodule EWallet.Mixfile do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      mod: {EWallet.Application, []},
       extra_applications: [:logger]
     ]
   end
@@ -40,6 +41,8 @@ defmodule EWallet.Mixfile do
     [
       {:phoenix, "~> 1.3.0"},
       {:phoenix_html, "~> 2.11.0"},
+      {:quantum, "~> 2.2.6"},
+      {:timex, "~> 3.0"},
       {:ewallet_db, in_umbrella: true},
       {:local_ledger, in_umbrella: true},
       {:local_ledger_db, in_umbrella: true, only: :test}

--- a/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
+++ b/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
@@ -52,6 +52,8 @@ defmodule EWallet.TransactionConsumptionSchedulerTest do
         assert decoded["success"] == false
         assert decoded["event"] == "transaction_consumption_finalized"
         assert decoded["error"]["code"] == "transaction_consumption:expired"
+        assert decoded["data"]["object"] == "transaction_consumption"
+        assert decoded["data"]["status"] == "expired"
       end)
 
       # Reload all the records

--- a/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
+++ b/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
@@ -1,0 +1,80 @@
+defmodule EWallet.TransactionConsumptionSchedulerTest do
+  use EWallet.LocalLedgerCase, async: true
+  alias EWallet.Web.V1.WebsocketResponseSerializer
+  alias EWallet.{TestEndpoint, TransactionConsumptionScheduler}
+  alias EWalletDB.TransactionConsumption
+  alias Phoenix.Socket.Broadcast
+
+  setup do
+    {:ok, _} = TestEndpoint.start_link()
+    :ok
+  end
+
+  describe "expire_all/0" do
+    test "expires all requests past their expiration date and send event" do
+      now = NaiveDateTime.utc_now()
+
+      # t1 and t2 have expiration dates in the past
+      t1 =
+        insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, -60, :seconds))
+
+      t2 =
+        insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, -600, :seconds))
+
+      t3 =
+        insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, 600, :seconds))
+
+      t4 =
+        insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, 160, :seconds))
+
+      # They are still valid since we haven't made them expired yet
+      assert TransactionConsumption.expired?(t1) == false
+      assert TransactionConsumption.expired?(t2) == false
+      assert TransactionConsumption.expired?(t3) == false
+      assert TransactionConsumption.expired?(t4) == false
+
+      TransactionConsumptionScheduler.expire_all()
+
+      events = TestEndpoint.get_events()
+
+      # 2 expired consumptions times 5 channels = 10 events
+      assert length(events) == 10
+
+      Enum.each(events, fn event ->
+        {:socket_push, :text, encoded} =
+          WebsocketResponseSerializer.fastlane!(%Broadcast{
+            topic: event.topic,
+            event: event.event,
+            payload: event.payload
+          })
+
+        decoded = Poison.decode!(encoded)
+        assert decoded["success"] == false
+        assert decoded["event"] == "transaction_consumption_finalized"
+        assert decoded["error"]["code"] == "transaction_consumption:expired"
+      end)
+
+      # Reload all the records
+      t1 = TransactionConsumption.get(t1.id)
+      t2 = TransactionConsumption.get(t2.id)
+      t3 = TransactionConsumption.get(t3.id)
+      t4 = TransactionConsumption.get(t4.id)
+
+      # Now t1 and t2 are expired
+      assert TransactionConsumption.expired?(t1) == true
+      assert TransactionConsumption.expired?(t2) == true
+      assert TransactionConsumption.expired?(t3) == false
+      assert TransactionConsumption.expired?(t4) == false
+    end
+
+    test "sets the expired_at field" do
+      now = NaiveDateTime.utc_now()
+      t = insert(:transaction_consumption, expiration_date: NaiveDateTime.add(now, -60, :seconds))
+      TransactionConsumptionScheduler.expire_all()
+      t = TransactionConsumption.get(t.id)
+
+      assert TransactionConsumption.expired?(t) == true
+      assert t.expired_at != nil
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/schedulers/transaction_request_scheduler_test.exs
+++ b/apps/ewallet/test/ewallet/schedulers/transaction_request_scheduler_test.exs
@@ -1,0 +1,48 @@
+defmodule EWallet.TransactionRequestSchedulerTest do
+  use EWallet.LocalLedgerCase, async: true
+  alias EWallet.TransactionRequestScheduler
+  alias EWalletDB.TransactionRequest
+
+  describe "expire_all/0" do
+    test "expires all requests past their expiration date" do
+      now = NaiveDateTime.utc_now()
+
+      # t1 and t2 have expiration dates in the past
+      t1 = insert(:transaction_request, expiration_date: NaiveDateTime.add(now, -60, :seconds))
+      t2 = insert(:transaction_request, expiration_date: NaiveDateTime.add(now, -600, :seconds))
+      t3 = insert(:transaction_request, expiration_date: NaiveDateTime.add(now, 600, :seconds))
+      t4 = insert(:transaction_request, expiration_date: NaiveDateTime.add(now, 160, :seconds))
+
+      # They are still valid since we haven't made them expired yet
+      assert TransactionRequest.expired?(t1) == false
+      assert TransactionRequest.expired?(t2) == false
+      assert TransactionRequest.expired?(t3) == false
+      assert TransactionRequest.expired?(t4) == false
+
+      TransactionRequestScheduler.expire_all()
+
+      # Reload all the records
+      t1 = TransactionRequest.get(t1.id)
+      t2 = TransactionRequest.get(t2.id)
+      t3 = TransactionRequest.get(t3.id)
+      t4 = TransactionRequest.get(t4.id)
+
+      # Now t1 and t2 are expired
+      assert TransactionRequest.expired?(t1) == true
+      assert TransactionRequest.expired?(t2) == true
+      assert TransactionRequest.expired?(t3) == false
+      assert TransactionRequest.expired?(t4) == false
+    end
+
+    test "sets the expiration reason" do
+      now = NaiveDateTime.utc_now()
+      t = insert(:transaction_request, expiration_date: NaiveDateTime.add(now, -60, :seconds))
+      TransactionRequestScheduler.expire_all()
+      t = TransactionRequest.get(t.id)
+
+      assert TransactionRequest.expired?(t) == true
+      assert t.expired_at != nil
+      assert t.expiration_reason == "expired_transaction_request"
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/v1/event_handlers/transaction_consumption_confirmation_event_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/event_handlers/transaction_consumption_confirmation_event_test.exs
@@ -4,10 +4,13 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandlerTest do
   alias EWallet.TestEndpoint
   alias EWalletDB.Repo
 
+  setup do
+    {:ok, _} = TestEndpoint.start_link()
+    :ok
+  end
+
   describe "broadcast/1" do
     test "broadcasts the 'transaction_consumption_finalized' event" do
-      {:ok, _} = TestEndpoint.start_link()
-
       consumption =
         :transaction_consumption
         |> insert()
@@ -35,13 +38,9 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandlerTest do
       |> Enum.each(fn topic ->
         assert Enum.member?(mapped, {"transaction_consumption_finalized", topic})
       end)
-
-      :ok = TestEndpoint.stop()
     end
 
     test "broadcasts the 'transaction_consumption_request' event" do
-      {:ok, _} = TestEndpoint.start_link()
-
       consumption =
         :transaction_consumption
         |> insert()
@@ -69,8 +68,6 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandlerTest do
       |> Enum.each(fn topic ->
         assert Enum.member?(mapped, {"transaction_consumption_request", topic})
       end)
-
-      :ok = TestEndpoint.stop()
     end
   end
 end

--- a/apps/ewallet_db/config/dev.exs
+++ b/apps/ewallet_db/config/dev.exs
@@ -10,18 +10,3 @@ config :cloak, Salty.SecretBox.Cloak,
   tag: "SBX",
   default: true,
   keys: [%{tag: <<1>>, key: key, default: true}]
-
-config :ewallet_db, EWalletDB.Scheduler,
-  global: true,
-  jobs: [
-    expire_requests: [
-      schedule: "* * * * *",
-      task: {EWalletDB.TransactionRequest, :expire_all, []},
-      run_strategy: {Quantum.RunStrategy.Random, :cluster}
-    ],
-    expire_consumptions: [
-      schedule: "* * * * *",
-      task: {EWalletDB.TransactionConsumption, :expire_all, []},
-      run_strategy: {Quantum.RunStrategy.Random, :cluster}
-    ]
-  ]

--- a/apps/ewallet_db/config/prod.exs
+++ b/apps/ewallet_db/config/prod.exs
@@ -12,18 +12,3 @@ config :cloak, Salty.SecretBox.Cloak,
   tag: "SBX",
   default: true,
   keys: [%{tag: <<1>>, key: key, default: true}]
-
-config :ewallet_db, EWalletDB.Scheduler,
-  global: true,
-  jobs: [
-    expire_requests: [
-      schedule: "* * * * *",
-      task: {EWalletDB.TransactionRequest, :expire_all, []},
-      run_strategy: {Quantum.RunStrategy.Random, :cluster}
-    ],
-    expire_consumptions: [
-      schedule: "* * * * *",
-      task: {EWalletDB.TransactionConsumption, :expire_all, []},
-      run_strategy: {Quantum.RunStrategy.Random, :cluster}
-    ]
-  ]

--- a/apps/ewallet_db/lib/ewallet_db/application.ex
+++ b/apps/ewallet_db/lib/ewallet_db/application.ex
@@ -11,8 +11,7 @@ defmodule EWalletDB.Application do
 
     # List all child processes to be supervised
     children = [
-      supervisor(EWalletDB.Repo, []),
-      worker(EWalletDB.Scheduler, [])
+      supervisor(EWalletDB.Repo, [])
     ]
 
     children =

--- a/apps/ewallet_db/lib/ewallet_db/scheduler.ex
+++ b/apps/ewallet_db/lib/ewallet_db/scheduler.ex
@@ -1,4 +1,0 @@
-defmodule EWalletDB.Scheduler do
-  @moduledoc false
-  use Quantum.Scheduler, otp_app: :ewallet_db
-end

--- a/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
@@ -199,10 +199,13 @@ defmodule EWalletDB.TransactionConsumption do
     |> where([t], not is_nil(t.expiration_date))
     |> where([t], t.expiration_date <= ^now)
     |> Repo.update_all(
-      set: [
-        status: @expired,
-        expired_at: NaiveDateTime.utc_now()
-      ]
+      [
+        set: [
+          status: @expired,
+          expired_at: NaiveDateTime.utc_now()
+        ]
+      ],
+      returning: true
     )
   end
 

--- a/apps/ewallet_db/mix.exs
+++ b/apps/ewallet_db/mix.exs
@@ -54,8 +54,6 @@ defmodule EWalletDB.Mixfile do
       {:plug, "~> 1.0"},
       {:arc, "~> 0.8.0"},
       {:arc_ecto, "~> 0.7.0"},
-      {:quantum, "~> 2.2.6"},
-      {:timex, "~> 3.0"},
 
       # arc GCS dependencies
       {:arc_gcs, "~> 0.0.3", runtime: false},


### PR DESCRIPTION
Issue/Task Number: T264

# Overview

There is currently no way for a client to know that a consumption has expired. This PR adds the submission of a failed finalized consumption to represent the expiration.

# Changes

- Move Scheduler from EWalletDB to EWallet in order to be able to trigger events
- Add Scheduler modules that take care of sending events
- Add `returning` when doing the `update_all` call (expiration) to get the list of consumptions that need to be sent as events
