### PR TITLE
Show data schemas on Swagger UI

### DIFF
--- a/apps/ewallet/priv/swagger.html
+++ b/apps/ewallet/priv/swagger.html
@@ -76,8 +76,8 @@ window.onload = function() {
     url: window.location.origin + window.location.pathname.replace(/docs\.ui\/?$/, 'docs.yaml'),
     dom_id: '#swagger-ui',
     deepLinking: true,
-    defaultModelsExpandDepth: -1,
-    defaultModelExpandDepth: 10,
+    defaultModelsExpandDepth: 1,
+    defaultModelExpandDepth: 1,
     filter: true,
     presets: [
       SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
Issue/Task Number: T279

# Overview

Shows data models at the bottom of the Swagger UI.

# Changes

- Changed SwaggerUI's `defaultModelsExpandDepth` to 1 
- Changed SwaggerUI's `defaultModelExpandDepth` to 1

![image](https://user-images.githubusercontent.com/921194/39908315-c213a1d2-5517-11e8-920d-069df5a51df6.png)


# Implementation Details

- Changed SwaggerUI's `defaultModelsExpandDepth` to 1 so the models are shown
- Changed SwaggerUI's `defaultModelExpandDepth` to 1 so it expands only 1 level and not clutter the screen too much

# Usage

Try access via browser: `/api/docs` or `/admin/api/docs`

# Impact

Deploy as usual
