### PR TITLE
Add max_consumption_per_user for transaction requests

### DIFF
--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -86,6 +86,11 @@ defmodule EWallet.Web.V1.ErrorHandler do
       description:
         "The specified transaction request has reached the allowed amount of consumptions."
     },
+    max_consumptions_per_user_reached: %{
+      code: "transaction_request:max_consumptions_per_user_reached",
+      description:
+        "The specified transaction request has reached the allowed amount of consumptions for the current user."
+    },
     unauthorized_amount_override: %{
       code: "transaction_request:unauthorized_amount_override",
       description: "The amount for this transaction request cannot be overridden."

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
@@ -36,6 +36,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
       require_confirmation: transaction_request.require_confirmation,
       current_consumptions_count: length(transaction_request.consumptions),
       max_consumptions: transaction_request.max_consumptions,
+      max_consumptions_per_user: transaction_request.max_consumptions_per_user,
       consumption_lifetime: transaction_request.consumption_lifetime,
       expiration_reason: transaction_request.expiration_reason,
       allow_amount_override: transaction_request.allow_amount_override,

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
@@ -46,6 +46,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializerTest do
         expiration_reason: nil,
         expired_at: nil,
         max_consumptions: nil,
+        max_consumptions_per_user: nil,
         current_consumptions_count: 2,
         created_at: Date.to_iso8601(transaction_request.inserted_at),
         updated_at: Date.to_iso8601(transaction_request.updated_at)

--- a/apps/ewallet_api/priv/spec.yaml
+++ b/apps/ewallet_api/priv/spec.yaml
@@ -1182,6 +1182,8 @@ components:
             type: boolean
           max_consumptions:
             type: integer
+          max_consumptions_per_user:
+            type: integer
           consumption_lifetime:
             type: integer
           expiration_reason:
@@ -1219,6 +1221,7 @@ components:
           - account_id
           - require_confirmation
           - max_consumptions
+          - max_consumptions_per_user
           - consumption_lifetime
           - expiration_reason
           - allow_amount_override
@@ -1244,6 +1247,7 @@ components:
             account_id: "acc_01cbfg9b5hn05rszm3na8jac7f"
             require_confirmation: true
             max_consumptions: 3
+            max_consumptions_per_user: null
             consumption_lifetime: 1000
             expiration_reason: null
             allow_amount_override: false
@@ -1646,6 +1650,11 @@ components:
                 default: null
                 description:
                   "The number of times this created request can be consumed."
+              max_consumptions_per_user:
+                type: integer
+                default: null
+                description:
+                  "The maximum number of times a user can consume the request."
               consumption_lifetime:
                 type: integer
                 default: null
@@ -1723,6 +1732,11 @@ components:
                 default: null
                 description:
                   "The number of times this created request can be consumed."
+              max_consumptions_per_user:
+                type: integer
+                default: null
+                description:
+                  "The maximum number of times a user can consume the request."
               consumption_lifetime:
                 type: integer
                 default: null

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -48,6 +48,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "expired_at" => nil,
                  "max_consumptions" => nil,
                  "current_consumptions_count" => 0,
+                 "max_consumptions_per_user" => nil,
                  "metadata" => %{},
                  "created_at" => Date.to_iso8601(request.inserted_at),
                  "updated_at" => Date.to_iso8601(request.updated_at)
@@ -100,6 +101,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "expired_at" => nil,
                  "max_consumptions" => nil,
                  "current_consumptions_count" => 0,
+                 "max_consumptions_per_user" => nil,
                  "created_at" => Date.to_iso8601(request.inserted_at),
                  "updated_at" => Date.to_iso8601(request.updated_at)
                }
@@ -220,7 +222,9 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           token_id: minted_token.id,
           correlation_id: "123",
           amount: 1_000,
-          address: balance.address
+          address: balance.address,
+          max_consumptions: 3,
+          max_consumptions_per_user: 1
         })
 
       request = TransactionRequest |> Repo.all() |> Enum.at(0)
@@ -252,7 +256,8 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "expiration_date" => nil,
                  "expiration_reason" => nil,
                  "expired_at" => nil,
-                 "max_consumptions" => nil,
+                 "max_consumptions" => 3,
+                 "max_consumptions_per_user" => nil,
                  "current_consumptions_count" => 0,
                  "created_at" => Date.to_iso8601(request.inserted_at),
                  "updated_at" => Date.to_iso8601(request.updated_at)
@@ -298,6 +303,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "expiration_reason" => nil,
                  "expired_at" => nil,
                  "max_consumptions" => nil,
+                 "max_consumptions_per_user" => nil,
                  "current_consumptions_count" => 0,
                  "type" => "send",
                  "status" => "valid",

--- a/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
@@ -239,13 +239,28 @@ defmodule EWalletDB.TransactionConsumption do
   end
 
   @doc """
-  Get all confirmed and pending transaction consumptions.
+  Get all confirmed transaction consumptions.
   """
   @spec all_active_for_request(UUID.t()) :: List.t()
+  def all_active_for_request(nil), do: []
+
   def all_active_for_request(request_uuid) do
     TransactionConsumption
     |> where([t], t.status == @confirmed)
     |> where([t], t.transaction_request_uuid == ^request_uuid)
+    |> Repo.all()
+  end
+
+  @doc """
+  Get all confirmed transaction consumptions for the given user uuid.
+  """
+  @spec all_active_for_user(UUID.t()) :: List.t()
+  def all_active_for_user(nil), do: []
+
+  def all_active_for_user(user_uuid) do
+    TransactionConsumption
+    |> where([t], t.status == @confirmed)
+    |> where([t], t.user_uuid == ^user_uuid)
     |> Repo.all()
   end
 

--- a/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
@@ -40,6 +40,7 @@ defmodule EWalletDB.TransactionRequest do
     field(:require_confirmation, :boolean, default: false)
     # nil -> unlimited
     field(:max_consumptions, :integer)
+    field(:max_consumptions_per_user, :integer)
     # milliseconds
     field(:consumption_lifetime, :integer)
     field(:expiration_date, :naive_datetime)
@@ -103,6 +104,7 @@ defmodule EWalletDB.TransactionRequest do
       :balance_address,
       :require_confirmation,
       :max_consumptions,
+      :max_consumptions_per_user,
       :consumption_lifetime,
       :expiration_date,
       :metadata,

--- a/apps/ewallet_db/priv/repo/migrations/20180511045020_add_max_consumptions_per_user_to_transaction_requests.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180511045020_add_max_consumptions_per_user_to_transaction_requests.exs
@@ -1,0 +1,9 @@
+defmodule EWalletDB.Repo.Migrations.AddMaxConsumptionsPerUserToTransactionRequests do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transaction_request) do
+      add :max_consumptions_per_user, :integer
+    end
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T229

# Overview

This PR adds a way to specify that a transaction request should be consumed a specific amount of time per user (usually 1 in the case of a giveaway).

# Changes

- Add `max_consumptions_per_user` to transaction requests
- Ensure that value has not been reached by the current user (set on the balance)
- Add tests 
- Update Swagger spec
