### PR TITLE
Move AdminPanel front-end build target to /priv/static

### DIFF
--- a/apps/admin_panel/.gitignore
+++ b/apps/admin_panel/.gitignore
@@ -4,14 +4,9 @@
 /deps
 /*.ez
 
-# Ignore all files in `/priv/dist` but keep the folder.
-/priv/dist/*
-!/priv/dist/.gitkeep
-
-# Temporily ignoring `/assets` which is a symlink of `admin-panel` repo.
-# Once the admin-panel has been moved into this eWallet repo,
-# the following `/assets` should be removed from `.gitignore`.
-/assets
+# Ignore all files in `/priv/static` but keep the folder.
+/priv/static/*
+!/priv/static/.gitkeep
 
 # Generated on crash by the VM
 erl_crash.dump

--- a/apps/admin_panel/assets/config/webpack.js
+++ b/apps/admin_panel/assets/config/webpack.js
@@ -40,7 +40,7 @@ module.exports = {
     ],
   },
   plugins: [
-    new CleanWebpackPlugin(['priv/dist'], {
+    new CleanWebpackPlugin(['priv/static'], {
       root: __dirname + '/../../',
     }),
     new HtmlWebpackPlugin({
@@ -51,7 +51,7 @@ module.exports = {
   ],
   output: {
     filename: 'bundle.js',
-    path: path.resolve(__dirname, '../../priv/dist'),
+    path: path.resolve(__dirname, '../../priv/static'),
     publicPath: '/admin/',
   },
 };

--- a/apps/admin_panel/config/config.exs
+++ b/apps/admin_panel/config/config.exs
@@ -9,7 +9,7 @@ use Mix.Config
 config :admin_panel,
   namespace: AdminPanel,
   ecto_repos: [],
-  dist_path: Path.expand("../priv/dist/", __DIR__),
+  dist_path: Path.expand("../priv/static/", __DIR__),
   webpack_watch: false
 
 # Configures the endpoint

--- a/apps/admin_panel/lib/admin_panel/endpoint.ex
+++ b/apps/admin_panel/lib/admin_panel/endpoint.ex
@@ -1,14 +1,14 @@
 defmodule AdminPanel.Endpoint do
   use Phoenix.Endpoint, otp_app: :admin_panel
 
-  # Serve at "/admin" the static files from "priv/dist" directory.
+  # Serve at "/admin" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
   plug(
     Plug.Static,
     at: "/admin",
-    from: {:admin_panel, "priv/dist"},
+    from: {:admin_panel, "priv/static"},
     gzip: false
   )
 

--- a/apps/admin_panel/test/admin_panel/test_assets/dist/index.html
+++ b/apps/admin_panel/test/admin_panel/test_assets/dist/index.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     This file is created as a test stub, so that tests do not need
-    to refer to `priv/dist/index.html` which may not be available
+    to refer to `priv/static/index.html` which may not be available
     if the front-end assets has not been built.
     <div id="app" class="app"></div>
   </body>


### PR DESCRIPTION
Issue/Task Number: T268

# Overview

This PR moves the AdminPanel's front-end build target to `/priv/static` as suggested by @sirn and [recommended by Phoenix](http://phoenixframework.org/blog/static-assets).

# Changes

- Update .gitignore to ignore /priv/static
- Changed webpack's output to /priv/static
- Changed AdminPanel.Endpoint to serve static assets from /priv/static

# Implementation Details

Straightforward text replacements from /priv/dist to /priv/static

# Usage

Running `mix omg.server` should produce successful front end build messages. Browse to `/admin` should return login page with static files served.

# Impact

Deploy as usual.
