### PR TITLE
T278 me.transfer

### DIFF
--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -70,7 +70,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     from_address_mismatch: %{
       code: "user:from_address_mismatch",
-      description: "The provided address does not belong to the current user."
+      description: "The provided wallet address does not belong to the current user."
     },
     to_address_not_found: %{
       code: "user:to_address_not_found",

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -68,6 +68,10 @@ defmodule EWallet.Web.V1.ErrorHandler do
       code: "user:from_address_not_found",
       description: "No wallet found for the provided from_address."
     },
+    from_address_mismatch: %{
+      code: "user:from_address_mismatch",
+      description: "The provided address does not belong to the current user."
+    },
     to_address_not_found: %{
       code: "user:to_address_not_found",
       description: "No wallet found for the provided to_address."

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
@@ -1,9 +1,8 @@
 defmodule EWalletAPI.V1.TransferController do
   use EWalletAPI, :controller
-  import EWalletAPI.V1.ErrorHandler
+  import EWalletAPI.V1.{ErrorHandler}
   alias EWallet.{BalanceFetcher, TransactionGate}
-
-  plug(:put_view, EWalletAPI.V1.WalletView)
+  alias EWalletAPI.V1.{WalletView, TransactionView}
 
   def transfer(
         conn,
@@ -19,10 +18,36 @@ defmodule EWalletAPI.V1.TransferController do
     attrs
     |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
     |> TransactionGate.process_with_addresses()
-    |> respond_with_wallets(conn)
+    |> respond_with(:wallets, conn)
   end
 
   def transfer(conn, _attrs), do: handle_error(conn, :invalid_parameter)
+
+  def transfer_for_user(
+        conn,
+        %{
+          "to_address" => to_address,
+          "token_id" => token_id,
+          "amount" => amount
+        } = attrs
+      )
+      when to_address != nil and token_id != nil and is_integer(amount) do
+    balance_res = BalanceFetcher.get(conn.assigns.user, attrs["from_address"])
+
+    case balance_res do
+      {:ok, from_balance} ->
+        attrs
+        |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
+        |> Map.put("from_address", from_balance.address)
+        |> TransactionGate.process_with_addresses()
+        |> respond_with(:transfer, conn)
+
+      {:error, error} ->
+        handle_error(conn, error)
+    end
+  end
+
+  def transfer_for_user(conn, _attrs), do: handle_error(conn, :invalid_parameter)
 
   def credit(conn, attrs), do: credit_or_debit(conn, TransactionGate.credit_type(), attrs)
   def debit(conn, attrs), do: credit_or_debit(conn, TransactionGate.debit_type(), attrs)
@@ -38,12 +63,18 @@ defmodule EWalletAPI.V1.TransferController do
     |> Map.put("type", type)
     |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
     |> TransactionGate.process_credit_or_debit()
-    |> respond_with_wallets(conn)
+    |> respond_with(:wallets, conn)
   end
 
   defp credit_or_debit(conn, _type, _attrs), do: handle_error(conn, :invalid_parameter)
 
-  defp respond_with_wallets({:ok, _transfer, wallets, minted_token}, conn) do
+  defp respond_with({:ok, transfer, _balances, _minted_token}, :transfer, conn) do
+    conn
+    |> put_view(TransactionView)
+    |> render(:transaction, %{transaction: transfer})
+  end
+
+  defp respond_with({:ok, _transfer, wallets, minted_token}, :wallets, conn) do
     wallets =
       Enum.map(wallets, fn wallet ->
         case BalanceFetcher.get(minted_token.id, wallet.address) do
@@ -58,14 +89,16 @@ defmodule EWalletAPI.V1.TransferController do
     end
   end
 
-  defp respond_with_wallets({:error, code}, conn), do: handle_error(conn, code)
+  defp respond_with({:error, code}, _, conn), do: handle_error(conn, code)
 
-  defp respond_with_wallets({:error, _transfer, code, description}, conn) do
+  defp respond_with({:error, _transfer, code, description}, _, conn) do
     handle_error(conn, code, description)
   end
 
   defp respond({:ok, wallets}, conn) do
-    render(conn, :wallets, %{wallets: wallets})
+    conn
+    |> put_view(WalletView)
+    |> render(:wallets, %{wallets: wallets})
   end
 
   defp respond({:error, code, description}, conn) do

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
@@ -34,28 +34,28 @@ defmodule EWalletAPI.V1.TransferController do
       when to_address != nil and token_id != nil and is_integer(amount) do
     conn.assigns.user
     |> WalletFetcher.get(attrs["from_address"])
-    |> transfer_from_balance(conn, attrs)
+    |> transfer_from_wallet(conn, attrs)
   end
 
   def transfer_for_user(conn, _attrs), do: handle_error(conn, :invalid_parameter)
 
-  defp transfer_from_balance({:ok, from_balance}, conn, attrs) do
+  defp transfer_from_wallet({:ok, from_wallet}, conn, attrs) do
     attrs
     |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
-    |> Map.put("from_address", from_balance.address)
+    |> Map.put("from_address", from_wallet.address)
     |> TransactionGate.process_with_addresses()
     |> respond_with(:transfer, conn)
   end
 
-  defp transfer_from_balance({:error, :wallet_not_found}, conn, _attrs) do
+  defp transfer_from_wallet({:error, :wallet_not_found}, conn, _attrs) do
     handle_error(conn, :from_address_not_found)
   end
 
-  defp transfer_from_balance({:error, :user_wallet_mismatch}, conn, _attrs) do
+  defp transfer_from_wallet({:error, :user_wallet_mismatch}, conn, _attrs) do
     handle_error(conn, :from_address_mismatch)
   end
 
-  defp transfer_from_balance({:error, error}, conn, _attrs), do: handle_error(conn, error)
+  defp transfer_from_wallet({:error, error}, conn, _attrs), do: handle_error(conn, error)
 
   def credit(conn, attrs), do: credit_or_debit(conn, TransactionGate.credit_type(), attrs)
   def debit(conn, attrs), do: credit_or_debit(conn, TransactionGate.debit_type(), attrs)

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
@@ -32,19 +32,19 @@ defmodule EWalletAPI.V1.TransferController do
         } = attrs
       )
       when to_address != nil and token_id != nil and is_integer(amount) do
-    balance_res = BalanceFetcher.get(conn.assigns.user, attrs["from_address"])
+      balance_res = BalanceFetcher.get(conn.assigns.user, attrs["from_address"])
 
-    case balance_res do
-      {:ok, from_balance} ->
-        attrs
-        |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
-        |> Map.put("from_address", from_balance.address)
-        |> TransactionGate.process_with_addresses()
-        |> respond_with(:transfer, conn)
-
-      {:error, error} ->
-        handle_error(conn, error)
-    end
+      case balance_res do
+        {:ok, from_balance} ->
+          attrs
+          |> Map.put("idempotency_token", conn.assigns[:idempotency_token])
+          |> Map.put("from_address", from_balance.address)
+          |> TransactionGate.process_with_addresses()
+          |> respond_with(:transfer, conn)
+        {:error, :balance_not_found} -> handle_error(conn, :from_address_not_found)
+        {:error, :user_balance_mismatch} -> handle_error(conn, :from_address_mismatch)
+        {:error, error} -> handle_error(conn, error)
+      end
   end
 
   def transfer_for_user(conn, _attrs), do: handle_error(conn, :invalid_parameter)

--- a/apps/ewallet_api/lib/ewallet_api/v1/router.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/router.ex
@@ -73,6 +73,7 @@ defmodule EWalletAPI.V1.Router do
     scope "/" do
       pipe_through([:idempotency])
       post("/me.consume_transaction_request", TransactionConsumptionController, :consume_for_user)
+      post("/me.transfer", TransferController, :transfer_for_user)
     end
 
     post("/logout", AuthController, :logout)

--- a/apps/ewallet_api/priv/spec.yaml
+++ b/apps/ewallet_api/priv/spec.yaml
@@ -1516,6 +1516,7 @@ components:
       description: |
         The parameters for making a transfer to a specific address.
         The from_address is optional, if specified it must belong to the current user.
+        If not specified, the user's primary balance will be used.
       required: true
       content:
         application/vnd.omisego.v1+json:

--- a/apps/ewallet_api/priv/spec.yaml
+++ b/apps/ewallet_api/priv/spec.yaml
@@ -221,6 +221,7 @@ paths:
           $ref: "#/components/responses/TransactionsResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
+
   /me.list_transactions:
     post:
       tags:
@@ -285,6 +286,23 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/MultipleWalletsResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+  /me.transfer:
+    post:
+      tags:
+        - Transaction
+      summary: Client - Transfer the specified amount to a wallet.
+      operationId: me_transfer
+      security:
+        - ClientAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyToken"
+      requestBody:
+        $ref: '#/components/requestBodies/ClientTransferBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/TransactionResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
 
@@ -1484,6 +1502,38 @@ components:
                 type: object
             required:
               - from_address
+              - to_address
+              - token_id
+              - amount
+            example:
+              from_address: "81e75f46-ee14-4e4c-a1e5-cddcb26dce9c"
+              to_address: "4aa07691-2f99-4cb1-b36c-50763e2d2ba8"
+              token_id: "tok_BTC_01cbffybmtbbb449r05zgfct2h"
+              amount: 100
+              metadata: {}
+              encrypted_metadata: {}
+    ClientTransferBody:
+      description: |
+        The parameters for making a transfer to a specific address.
+        The from_address is optional, if specified it must belong to the current user.
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              from_address:
+                type: string
+              to_address:
+                type: string
+              token_id:
+                type: string
+              amount:
+                type: integer
+              metadata:
+                type: object
+              encrypted_metadata:
+                type: object
+            required:
               - to_address
               - token_id
               - amount

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -385,7 +385,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
              }
     end
 
-    test "returns insufficient_funds when the user is too poor `:(" do
+    test "returns insufficient_funds when the user is too poor :~(" do
       wallet1 = User.get_primary_wallet(get_test_user())
       wallet2 = insert(:wallet)
       minted_token = insert(:minted_token)

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -3,6 +3,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
   alias EWalletDB.{User, MintedToken, Account, Transfer}
   alias Ecto.UUID
   alias EWallet.Web.Date
+  alias EWallet.BalanceFetcher
 
   describe "/transfer" do
     test "returns idempotency error if header is not specified" do
@@ -241,6 +242,309 @@ defmodule EWalletAPI.V1.TransferControllerTest do
                "data" => %{
                  "code" => "minted_token:minted_token_not_found",
                  "description" => "There is no minted token matching the provided token_id.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+  end
+
+  describe "/transfer_for_user" do
+    test "returns idempotency error if header is not specified" do
+      wallet1 = User.get_primary_wallet(get_test_user())
+      wallet2 = insert(:wallet)
+      minted_token = insert(:minted_token)
+
+      request_data = %{
+        from_address: wallet1.address,
+        to_address: wallet2.address,
+        token_id: minted_token.id,
+        amount: 1_000 * minted_token.subunit_to_unit,
+        metadata: %{}
+      }
+
+      response = client_request("/me.transfer", request_data)
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "client:no_idempotency_token_provided",
+                 "description" =>
+                   "The call you made requires the Idempotency-Token header to prevent duplication.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+
+    test "updates the wallets and returns the transaction" do
+      wallet1 = User.get_primary_wallet(get_test_user())
+      wallet2 = insert(:wallet)
+      minted_token = insert(:minted_token)
+
+      set_initial_balance(%{
+        address: wallet1.address,
+        minted_token: minted_token,
+        amount: 200_000
+      })
+
+      response =
+        client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+          from_address: wallet1.address,
+          to_address: wallet2.address,
+          token_id: minted_token.id,
+          amount: 100 * minted_token.subunit_to_unit,
+          metadata: %{something: "interesting"},
+          encrypted_metadata: %{something: "secret"}
+        })
+
+      {:ok, b1} = BalanceFetcher.get(minted_token.id, wallet1.address)
+      assert List.first(b1.balances).amount == (200_000 - 100) * minted_token.subunit_to_unit
+      {:ok, b2} = BalanceFetcher.get(minted_token.id, wallet2.address)
+      assert List.first(b2.balances).amount == 100 * minted_token.subunit_to_unit
+
+      transfer = get_last_inserted(Transfer)
+
+      assert response == %{
+               "success" => true,
+               "version" => "1",
+               "data" => %{
+                 "object" => "transaction",
+                 "id" => transfer.id,
+                 "idempotency_token" => transfer.idempotency_token,
+                 "from" => %{
+                   "object" => "transaction_source",
+                   "address" => transfer.from,
+                   "amount" => transfer.amount,
+                   "minted_token_id" => minted_token.id,
+                   "minted_token" => %{
+                     "name" => minted_token.name,
+                     "object" => "minted_token",
+                     "subunit_to_unit" => minted_token.subunit_to_unit,
+                     "id" => minted_token.id,
+                     "symbol" => minted_token.symbol,
+                     "metadata" => %{},
+                     "encrypted_metadata" => %{},
+                     "created_at" => Date.to_iso8601(minted_token.inserted_at),
+                     "updated_at" => Date.to_iso8601(minted_token.updated_at)
+                   }
+                 },
+                 "to" => %{
+                   "object" => "transaction_source",
+                   "address" => transfer.to,
+                   "amount" => transfer.amount,
+                   "minted_token_id" => minted_token.id,
+                   "minted_token" => %{
+                     "name" => minted_token.name,
+                     "object" => "minted_token",
+                     "subunit_to_unit" => 100,
+                     "id" => minted_token.id,
+                     "symbol" => minted_token.symbol,
+                     "metadata" => %{},
+                     "encrypted_metadata" => %{},
+                     "created_at" => Date.to_iso8601(minted_token.inserted_at),
+                     "updated_at" => Date.to_iso8601(minted_token.updated_at)
+                   }
+                 },
+                 "exchange" => %{
+                   "object" => "exchange",
+                   "rate" => 1
+                 },
+                 "metadata" => transfer.metadata || %{},
+                 "encrypted_metadata" => transfer.encrypted_metadata || %{},
+                 "status" => transfer.status,
+                 "created_at" => Date.to_iso8601(transfer.inserted_at),
+                 "updated_at" => Date.to_iso8601(transfer.updated_at)
+               }
+             }
+    end
+
+    test "returns a 'same_address' error when the addresses are the same" do
+      wallet = User.get_primary_wallet(get_test_user())
+      minted_token = insert(:minted_token)
+
+      response =
+        client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+          from_address: wallet.address,
+          to_address: wallet.address,
+          token_id: minted_token.id,
+          amount: 100_000 * minted_token.subunit_to_unit
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction:same_address",
+                 "description" =>
+                   "Found identical addresses in senders and receivers: #{wallet.address}.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+
+    test "returns insufficient_funds when the user is too poor `:(" do
+      wallet1 = User.get_primary_wallet(get_test_user())
+      wallet2 = insert(:wallet)
+      minted_token = insert(:minted_token)
+
+      response =
+        client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+          from_address: wallet1.address,
+          to_address: wallet2.address,
+          token_id: minted_token.id,
+          amount: 100_000 * minted_token.subunit_to_unit
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction:insufficient_funds",
+                 "description" =>
+                   "The specified wallet (#{wallet1.address}) does not " <>
+                     "contain enough funds. Available: 0.0 #{minted_token.id} - " <>
+                     "Attempted debit: 100000.0 #{minted_token.id}",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+
+    test "returns from_address_not_found when no wallet found for the 'from_address'" do
+      wallet = insert(:wallet)
+      minted_token = insert(:minted_token)
+
+      response =
+        client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+          from_address: "00000000-0000-0000-0000-000000000000",
+          to_address: wallet.address,
+          token_id: minted_token.id,
+          amount: 100_000
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:from_address_not_found",
+                 "description" => "No wallet found for the provided from_address.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+
+    test "returns a from_address_mismatch error if 'from_address' does not belong to the user" do
+      wallet1 = insert(:wallet)
+      wallet2 = insert(:wallet)
+      minted_token = insert(:minted_token)
+
+      response =
+        client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+          from_address: wallet1.address,
+          to_address: wallet2.address,
+          token_id: minted_token.id,
+          amount: 100_000
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:from_address_mismatch",
+                 "description" =>
+                   "The provided wallet address does not belong to the current user.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+
+    test "returns to_address_not_found when the to wallet is not found" do
+      wallet = User.get_primary_wallet(get_test_user())
+      minted_token = insert(:minted_token)
+
+      response =
+        client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+          from_address: wallet.address,
+          to_address: "00000000-0000-0000-0000-000000000000",
+          token_id: minted_token.id,
+          amount: 100_000
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "user:to_address_not_found",
+                 "description" => "No wallet found for the provided to_address.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+
+    test "returns minted_token_not_found when the minted token is not found" do
+      wallet1 = User.get_primary_wallet(get_test_user())
+      wallet2 = insert(:wallet)
+
+      response =
+        client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+          from_address: wallet1.address,
+          to_address: wallet2.address,
+          token_id: "BTC:456",
+          amount: 100_000
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "minted_token:minted_token_not_found",
+                 "description" => "There is no minted token matching the provided token_id.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+
+    test "takes primary wallet if 'from_address' is not specified" do
+      wallet1 = User.get_primary_wallet(get_test_user())
+      wallet2 = insert(:wallet)
+      minted_token = insert(:minted_token)
+
+      set_initial_balance(%{
+        address: wallet1.address,
+        minted_token: minted_token,
+        amount: 200_000
+      })
+
+      client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+        to_address: wallet2.address,
+        token_id: minted_token.id,
+        amount: 100_000
+      })
+
+      transfer = get_last_inserted(Transfer)
+      assert transfer.from == wallet1.address
+    end
+
+    test "returns an invalid_parameter error if a parameter is missing" do
+      response =
+        client_request_with_idempotency("/me.transfer", UUID.generate(), %{
+          token_id: "an_id",
+          amount: 100_000
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Invalid parameter provided",
                  "messages" => nil,
                  "object" => "error"
                }


### PR DESCRIPTION
Issue/Task Number: 278

# Overview

This PR adds the `me.transfer` endpoint for clients.
It allows authenticated clients to transfer funds to an other address.

# Changes

- Add `me.transfer` endpoint.

# Implementation Details

Pretty straightforward implementation.

# Usage

The easiest way to test is to use the updated openapi spec.

# Impact

na
