### PR TITLE
Update local ledger migration to run with non-superuser permission

### DIFF
--- a/apps/local_ledger_db/priv/repo/migrations/20180430105449_update_predictable_minted_token_id.exs
+++ b/apps/local_ledger_db/priv/repo/migrations/20180430105449_update_predictable_minted_token_id.exs
@@ -1,7 +1,6 @@
 defmodule LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId do
   use Ecto.Migration
   import Ecto.Query
-  alias Ecto.Adapters.SQL
   alias Ecto.UUID
   alias ExULID.ULID
   alias LocalLedgerDB.Repo
@@ -21,11 +20,28 @@ defmodule LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId do
   # and use the leading part of existing uuid (the shared value between the two database)
   # for the 16-character randomness.
   def up do
+    ##################
+    # Add new fields #
+    ##################
+    alter table(:minted_token) do
+      add :new_id, :string, null: true
+    end
+
+    create index(:minted_token, :new_id, unique: true)
+
+    alter table(:transaction) do
+      add :new_minted_token_id, references(:minted_token, type: :string, column: :new_id),
+                                null: true
+    end
+
+    flush()
+
+    #######################
+    # Populate new fields #
+    #######################
     query = from(t in "minted_token",
                  select: [t.id, t.uuid, t.metadata],
                  lock: "FOR UPDATE")
-
-    SQL.query(Repo, "ALTER TABLE minted_token DISABLE TRIGGER ALL")
 
     for [id, uuid, metadata] <- Repo.all(query) do
       # The id's format is "OMG:756412b1-4a79-4963-9017-4eb49845c740", split to get symbol and uuid.
@@ -37,13 +53,13 @@ defmodule LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId do
 
       query = from(t in "minted_token",
                    where: t.uuid == ^uuid,
-                   update: [set: [id: ^new_id, metadata: ^metadata]])
+                   update: [set: [new_id: ^new_id, metadata: ^metadata]])
 
       Repo.update_all(query, [])
 
       query = from(t in "transaction",
                    where: t.minted_token_id == ^id,
-                   update: [set: [minted_token_id: ^new_id]])
+                   update: [set: [new_minted_token_id: ^new_id]])
 
       Repo.update_all(query, [])
 
@@ -57,7 +73,43 @@ defmodule LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId do
       Repo.update_all(query, [])
     end
 
-    SQL.query(Repo, "ALTER TABLE minted_token ENABLE TRIGGER ALL")
+    #################################
+    # Swap old fields with new ones #
+    #################################
+
+    # Now that the `new_minted_token_id` column is populated, disallow null values.
+    # Then, remove the old `minted_token_id` column and replace it with the new one
+    alter table(:transaction) do
+      modify :new_minted_token_id, :string, null: false
+      remove(:minted_token_id)
+    end
+    rename table(:transaction), :new_minted_token_id, to: :minted_token_id
+
+    # Now that the `new_id` column is populated, disallow null values.
+    # Then, remove the old `id` column and replace it with the new one
+    alter table(:minted_token) do
+      modify :new_id, :string, null: false
+      remove(:id)
+    end
+    rename table(:minted_token), :new_id, to: :id
+    flush()
+
+    ##################
+    # Rename indexes #
+    ##################
+
+    # Indexes and constraints don't get renamed when fields are renamed,
+    # so we manually rename them for consistency.
+    execute """
+      ALTER INDEX minted_token_new_id_index
+      RENAME TO minted_token_id_index
+      """
+
+    execute """
+      ALTER TABLE transaction
+      RENAME CONSTRAINT transaction_new_minted_token_id_fkey
+      TO transaction_minted_token_id_fkey
+      """
   end
 
   # We'll prepare the new ID using <prefix><symbol>_<ulid_timestamp><uuid_first_16_chars> format.
@@ -74,24 +126,41 @@ defmodule LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId do
 
   # Rollback
   def down do
+    ##################
+    # Add new fields #
+    ##################
+    alter table(:minted_token) do
+      add :old_id, :string, null: true
+    end
+
+    create index(:minted_token, :old_id, unique: true)
+
+    alter table(:transaction) do
+      add :old_minted_token_id, references(:minted_token, type: :string, column: :old_id),
+                                null: true
+    end
+
+    flush()
+
+    #######################
+    # Populate new fields #
+    #######################
     query = from(t in "minted_token",
                  select: [t.id, t.uuid, t.metadata, t.inserted_at],
                  lock: "FOR UPDATE")
 
-    SQL.query(Repo, "ALTER TABLE minted_token DISABLE TRIGGER ALL")
-
     for [id, uuid, metadata, inserted_at] <- Repo.all(query) do
-      {new_id, metadata} = revert(metadata, @prefix, id, inserted_at)
+      {old_id, metadata} = revert(metadata, @prefix, id, inserted_at)
 
       query = from(t in "minted_token",
                    where: t.uuid == ^uuid,
-                   update: [set: [id: ^new_id, metadata: ^metadata]])
+                   update: [set: [old_id: ^old_id, metadata: ^metadata]])
 
       Repo.update_all(query, [])
 
       query = from(t in "transaction",
                    where: t.minted_token_id == ^id,
-                   update: [set: [minted_token_id: ^new_id]])
+                   update: [set: [old_minted_token_id: ^old_id]])
 
       Repo.update_all(query, [])
 
@@ -99,13 +168,50 @@ defmodule LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId do
                    where: fragment("amounts \\? ?", ^id),
                    update: [set: [amounts: fragment("amounts - ? || jsonb_build_object(?, amounts->?)",
                                                     type(^id, :string),
-                                                    type(^new_id, :string),
+                                                    type(^old_id, :string),
                                                     type(^id, :string))]])
 
       Repo.update_all(query, [])
     end
 
-    SQL.query(Repo, "ALTER TABLE minted_token ENABLE TRIGGER ALL")
+    #################################
+    # Swap old fields with new ones #
+    #################################
+
+    # Now that the `old_minted_token_id` column is populated, disallow null values.
+    # Remove the old `minted_token_id` column and replace it with the new one
+    alter table(:transaction) do
+      modify :old_minted_token_id, :string, null: false
+      remove(:minted_token_id)
+    end
+    rename table(:transaction), :old_minted_token_id, to: :minted_token_id
+    flush()
+
+    # Now that the `old_id` column is populated, disallow null values.
+    # Then, remove the old `id` column and replace it with the new one
+    alter table(:minted_token) do
+      modify :old_id, :string, null: false
+      remove(:id)
+    end
+    rename table(:minted_token), :old_id, to: :id
+    flush()
+
+    ##################
+    # Rename indexes #
+    ##################
+
+    # Indexes and constraints don't get renamed when fields are renamed,
+    # so we manually rename them for consistency.
+    execute """
+      ALTER INDEX minted_token_old_id_index
+      RENAME TO minted_token_id_index
+      """
+
+    execute """
+      ALTER TABLE transaction
+      RENAME CONSTRAINT transaction_old_minted_token_id_fkey
+      TO transaction_minted_token_id_fkey
+      """
   end
 
   # Revert back the ID and metadata if possible, otherwise re-generate the ID.


### PR DESCRIPTION
Issue/Task Number: T263

# Overview

Updated #172's migration to work on non-superuser DB users.

# Changes

- Updated local ledger's minted token ID migration to work with extra columns instead of disabling foreign key constraint triggers.

# Implementation Details

#172 ran fine on dev & build machines because the ewallet apps were running with a postgres's superuser. Since running apps with a DB superuser must be avoided on servers, it does not make sense to have the migration requiring superuser privileges. Hence, this PR updates the migration script to avoid that by working with new columns, then replace them when ready instead.

Changes to the migration scripts must be avoided. But this is the case where failing on `develop` branch makes sense, so migrations are tested production-like environment and can be fixed before releasing a stable version.

Example error:
```ex
06:44:51.566 [info]  == Running LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId.up/0 forward
** (Postgrex.Error) ERROR 25P02 (in_failed_sql_transaction): current transaction is aborted, commands ignored until end of transaction block
    (ecto) lib/ecto/adapters/sql.ex:436: Ecto.Adapters.SQL.execute_and_cache/7
    (ecto) lib/ecto/repo/queryable.ex:130: Ecto.Repo.Queryable.execute/5
    (ecto) lib/ecto/repo/queryable.ex:35: Ecto.Repo.Queryable.all/4
    /app/_build/prod/lib/local_ledger_db/priv/repo/migrations/20180430105449_update_predictable_minted_token_id.exs:30: LocalLedgerDB.Repo.Migrations.UpdatePredictableMintedTokenId.up/0
    (stdlib) timer.erl:197: :timer.tc/3
    (ecto) lib/ecto/migration/runner.ex:26: Ecto.Migration.Runner.run/6
    (ecto) lib/ecto/migrator.ex:127: Ecto.Migrator.attempt/6
    (ecto) lib/ecto/migrator.ex:72: anonymous fn/4 in Ecto.Migrator.do_up/4
```

# Usage

Setup the ewallet to use a postgres's non-superuser (see [omisego/goban's #11](https://github.com/omisego/goban/pull/11)).

Then follow the same steps as #172.

> 1. Checkout the commit before #149 is merged with: `git checkout 64bdb3c`.
> 2. Seed the database with `mix do ecto.drop, ecto.create, ecto.migrate, seed --sample`. 
  _This is so that we have a database populated with `minted_token.id` that are in the old format, e.g. `OEM:68199c99-7bf6-4f4f-8e09-184a15819cbd`._
> 3. Checkout the commit right before this branch starts with `git checkout 9cdd60a`.
> 4. Run the migration: `mix ecto.migrate`.
  _This is where the bug happens. `minted_token.id` in `local_ledger_db` and `ewallet_db` should be inconsistent at this point, e.g. `tok_OEM_01ccmny8ynf96dbf02bbcd489d` in `ewallet_db` and `OEM:68199c99-7bf6-4f4f-8e09-184a15819cbd` in `local_ledger_db`._
> 3. Checkout this branch with `git checkout t263-local-ledger-ids`, make sure you are on the latest commit.
> 4. Run the migration: `mix ecto.migrate`.
> 5. Verify that the `minted_token.id` in `local_ledger_db` and `ewallet_db` are now consistent with the minted token's ID appearing the same everywhere.

# Impact

Deploy as usual