### PR TITLE
Fix failed logging of consumption errors

### DIFF
--- a/apps/ewallet/lib/ewallet/web/v1/event_handlers/event.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/event_handlers/event.ex
@@ -30,7 +30,7 @@ defmodule EWallet.Web.V1.Event do
     end)
   end
 
-  defp log(event, topics, payload) do
+  def log(event, topics, payload) do
     Logger.info("")
     Logger.info("WEBSOCKET EVENT: Dispatching event '#{event}' to:")
     Logger.info("-- Endpoints:")
@@ -51,7 +51,7 @@ defmodule EWallet.Web.V1.Event do
 
       error ->
         Logger.info("With error:")
-        Logger.info(error)
+        error |> inspect() |> Logger.info()
     end
 
     Logger.info("Ending event dispatch...")

--- a/apps/ewallet/test/ewallet/web/v1/event_handlers/event_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/event_handlers/event_test.exs
@@ -1,0 +1,42 @@
+defmodule EWallet.Web.V1.EventTest do
+  use EWallet.LocalLedgerCase, async: true
+  import ExUnit.CaptureLog
+  require Logger
+  alias EWallet.Web.V1.Event
+  alias EWallet.TestEndpoint
+
+  setup do
+    Logger.configure(level: :info)
+
+    on_exit(fn ->
+      Logger.configure(level: :warn)
+    end)
+
+    {:ok, _} = TestEndpoint.start_link()
+    :ok
+  end
+
+  describe "log/3" do
+    test "logs the event" do
+      assert capture_log(fn ->
+               Event.log("event", ["topic1"], %{"something" => "cool"})
+             end) =~ "WEBSOCKET EVENT: Dispatching event 'event'"
+    end
+
+    test "logs a map error" do
+      assert capture_log(fn ->
+               Event.log("event", ["topic1"], %{
+                 error: %{
+                   code: "insufficient_funds",
+                   description: %{
+                     "address" => "b1c49cc8-7bed-4f18-a9b6-db696c012859",
+                     "amount_to_debit" => 10_000_000,
+                     "current_amount" => 0,
+                     "minted_token_id" => "tok_jon532_01CE0MF708E3B296FM4GFSXGRT"
+                   }
+                 }
+               })
+             end) =~ "WEBSOCKET EVENT: Dispatching event 'event'"
+    end
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T311

# Overview

The logging of errors triggered by failed consumptions wasn't working as expected (The Logger couldn't format maps). This PR fixes that and add tests to ensure it doesn't happen again.

# Changes

- Add `inspect` to format error map
- Add tests to ensure it's working as expected
