### PR TITLE
Fix already started Endpoint error

### DIFF
--- a/apps/ewallet/test/ewallet/fetchers/transaction_consumption_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/transaction_consumption_fetcher_test.exs
@@ -11,7 +11,7 @@ defmodule EWallet.TransactionConsumptionFetcherTest do
   alias EWalletDB.{User, TransactionConsumption}
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    TestEndpoint.start_link()
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
@@ -13,7 +13,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
   alias EWalletDB.{User, TransactionConsumption, TransactionRequest}
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    TestEndpoint.start_link()
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -10,7 +10,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
   alias EWalletDB.{User, TransactionConsumption, TransactionRequest}
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    TestEndpoint.start_link()
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
+++ b/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
@@ -6,7 +6,7 @@ defmodule EWallet.TransactionConsumptionSchedulerTest do
   alias Phoenix.Socket.Broadcast
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    TestEndpoint.start_link()
     :ok
   end
 

--- a/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
+++ b/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
@@ -125,7 +125,7 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     end
 
     test "returns max_consumptions_per_user_reached if the max has been reached" do
-      {:ok, _} = TestEndpoint.start_link()
+      TestEndpoint.start_link()
 
       {:ok, user_1} = :user |> params_for() |> User.insert()
       {:ok, user_2} = :user |> params_for() |> User.insert()
@@ -167,7 +167,7 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     end
 
     test "expires consumption if past expiration" do
-      {:ok, _} = TestEndpoint.start_link()
+      TestEndpoint.start_link()
 
       now = NaiveDateTime.utc_now()
       {:ok, user} = :user |> params_for() |> User.insert()
@@ -189,7 +189,7 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     end
 
     test "returns expired_transaction_consumption if the consumption has expired" do
-      {:ok, _} = TestEndpoint.start_link()
+      TestEndpoint.start_link()
 
       {:ok, user} = :user |> params_for() |> User.insert()
       request = insert(:transaction_request, account_uuid: nil, user_uuid: user.uuid)
@@ -207,7 +207,7 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     end
 
     test "returns the consumption if valid" do
-      {:ok, _} = TestEndpoint.start_link()
+      TestEndpoint.start_link()
 
       {:ok, user} = :user |> params_for() |> User.insert()
       request = insert(:transaction_request, account_uuid: nil, user_uuid: user.uuid)

--- a/apps/ewallet/test/ewallet/web/v1/event_handlers/event_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/event_handlers/event_test.exs
@@ -12,7 +12,7 @@ defmodule EWallet.Web.V1.EventTest do
       Logger.configure(level: :warn)
     end)
 
-    {:ok, _} = TestEndpoint.start_link()
+    TestEndpoint.start_link()
     :ok
   end
 

--- a/apps/ewallet/test/ewallet/web/v1/event_handlers/transaction_consumption_confirmation_event_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/event_handlers/transaction_consumption_confirmation_event_test.exs
@@ -5,7 +5,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandlerTest do
   alias EWalletDB.Repo
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    TestEndpoint.start_link()
     :ok
   end
 


### PR DESCRIPTION
Issue/Task Number: T331

# Overview

I tried stopping the processes after the tests, but it doesn't seem to work (keeps saying the process isn't running anymore already).

So I just remove the `:ok` check.

# Changes

- Remove ` {:ok, _} = ` when starting `TestEndpoint`