### PR TITLE
Updating a master account should not return maximum child error

### DIFF
--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -262,12 +262,16 @@ defmodule EWalletDB.Account do
   @doc """
   Determine the relative depth to the master account.
 
+  Returns a non-negative integer if the account is found.
   The master account has a relative depth of 0.
+
+  It raises an error if passed nil, because a nil does not belong to any account level.
+  And it is unsafe to default it, for example, to being a top level account.
   """
-  @spec get_depth(account :: %Account{} | account_uuid :: String.t()) :: non_neg_integer()
+  @spec get_depth(%Account{} | String.t()) :: non_neg_integer() | no_return()
   def get_depth(%Account{} = account), do: get_depth(account.uuid)
 
-  def get_depth(account_uuid) do
+  def get_depth(account_uuid) when not is_nil(account_uuid) do
     case Account.get_master_account() do
       nil ->
         # No master account means that this account is at level 0.

--- a/apps/ewallet_db/test/ewallet_db/account_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/account_test.exs
@@ -175,5 +175,13 @@ defmodule EWalletDB.AccountTest do
       account3 = insert(:account, %{parent: account2})
       assert Account.get_depth(account3) == 3
     end
+
+    # Returning a value, e.g. 0, is unsafe since that would be assuming that
+    # some arbitary account or value is the top level account. Safer to raise an error.
+    test "raises an error if given nil" do
+      assert_raise FunctionClauseError, fn ->
+        Account.get_depth(nil)
+      end
+    end
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/account_validator_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/account_validator_test.exs
@@ -41,7 +41,39 @@ defmodule EWalletDB.AccountValidatorTest do
     end
   end
 
-  describe "validate_account_level/2" do
+  describe "validate_account_level/2 with top-level account" do
+    test "returns a valid changeset if the given max child level is == 0" do
+      changeset =
+        %Account{}
+        |> change()
+        |> force_change(:parent_uuid, nil)
+        |> validate_account_level(0)
+
+      assert changeset.valid?
+    end
+
+    test "returns a valid changeset if the given max child level is > 0" do
+      changeset =
+        %Account{}
+        |> change()
+        |> force_change(:parent_uuid, nil)
+        |> validate_account_level(1)
+
+      assert changeset.valid?
+    end
+
+    test "returns a changeset error if the given max child level is < 0" do
+      changeset =
+        %Account{}
+        |> change()
+        |> force_change(:parent_uuid, nil)
+        |> validate_account_level(-1)
+
+      refute changeset.valid?
+    end
+  end
+
+  describe "validate_account_level/2 with sub-level account" do
     test "returns valid if the account's parent is not at the given max child level" do
       account0 = Account.get_master_account()
 


### PR DESCRIPTION
Issue/Task Number: T314

# Overview

This PR fixes `/account.update` returning maximum child level validation error even though updating the master account.

# Changes

- Updated `Account.get_depth/1` to raise error if nil is provided as the account.
- Updated `AccountValidator.validate_account_level/2` to properly validate accounts with parent_uuid == nil

# Implementation Details

This error was caused because a master account would have `account.parent_uuid == nil`. When this nil is passed to `Account.get_depth/1`, the query would return `nil` back instead of a non-negative number.

This nil value that got passed back and evaluated in `depth >= child_level_limit` as `nil >= child_level_limit` which returns true (whyyyyyy) and hence passed right into `add_error/4` and thus the validation error.

`Account.get_depth(nil)` should raise an error because a nil should not reflect any account level. For example, defaulting to 0 means that a nil is a top level account, which is super incorrect and the system might be tricked to think that it's working on a top level account. So `parent_uuid: nil` is handled specifically in `AccountValidator.validate_account_level/2` instead, where we know for sure that an account with `parent_uuid: nil` here is a top level account.

# Usage

Make a call to `/account.update` and update the master account.

# Impact

Deploy as usual.
