### PR TITLE
Add warnings_as_errors flag to Mixfile

### DIFF
--- a/apps/admin_api/mix.exs
+++ b/apps/admin_api/mix.exs
@@ -11,6 +11,7 @@ defmodule AdminAPI.Mixfile do
       lockfile: "../../mix.lock",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_options: [warnings_as_errors: true],
       compilers: [:phoenix] ++ Mix.compilers,
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/apps/admin_panel/mix.exs
+++ b/apps/admin_panel/mix.exs
@@ -11,6 +11,7 @@ defmodule AdminPanel.Mixfile do
       lockfile: "../../mix.lock",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_options: [warnings_as_errors: true],
       compilers: [:phoenix] ++ Mix.compilers,
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/category_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/category_serializer.ex
@@ -6,7 +6,6 @@ defmodule EWallet.Web.V1.CategorySerializer do
   alias EWallet.Web.V1.{AccountSerializer, PaginatorSerializer}
   alias EWallet.Web.{Paginator, Date}
   alias EWalletDB.Category
-  alias EWalletDB.Helpers.Preloader
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)

--- a/apps/ewallet/mix.exs
+++ b/apps/ewallet/mix.exs
@@ -11,6 +11,7 @@ defmodule EWallet.Mixfile do
       lockfile: "../../mix.lock",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_options: [warnings_as_errors: true],
       compilers: [:phoenix] ++ Mix.compilers,
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/apps/ewallet_api/mix.exs
+++ b/apps/ewallet_api/mix.exs
@@ -11,6 +11,7 @@ defmodule EWalletAPI.Mixfile do
       lockfile: "../../mix.lock",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_options: [warnings_as_errors: true],
       compilers: [:phoenix] ++ Mix.compilers,
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/apps/ewallet_db/mix.exs
+++ b/apps/ewallet_db/mix.exs
@@ -11,6 +11,7 @@ defmodule EWalletDB.Mixfile do
       lockfile: "../../mix.lock",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [

--- a/apps/local_ledger/mix.exs
+++ b/apps/local_ledger/mix.exs
@@ -10,6 +10,7 @@ defmodule LocalLedger.Mixfile do
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixir: "~> 1.5",
+      elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [

--- a/apps/local_ledger_db/mix.exs
+++ b/apps/local_ledger_db/mix.exs
@@ -11,6 +11,7 @@ defmodule LocalLedgerDB.Mixfile do
       lockfile: "../../mix.lock",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [

--- a/apps/url_dispatcher/mix.exs
+++ b/apps/url_dispatcher/mix.exs
@@ -10,6 +10,7 @@ defmodule UrlDispatcher.Mixfile do
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixir: "~> 1.5",
+      elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [


### PR DESCRIPTION
Issue/Task Number: T312

# Overview

This PR adds warnings_as_errors flag as suggested by @InoMurko so we detect warnings in our code.

# Changes

- Add `elixirc_options: [warnings_as_errors: true]` to all app's Mixfiles

# Implementation Details

InoMurko originally suggested using `--warnings_as_errors` flag during compilation, but since we can add this as default in the Mixfile, I decided to add it to Mixfile instead so we can continue using `mix compile`

# Usage

Run `mix compile` with warnings such as unused variable or alias should raise an error.

# Impact

Deploy as usual