### PR TITLE
Fix API spec not up to date with the changed ID format

### DIFF
--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -951,7 +951,7 @@ components:
             account:
               object: "account"
               id: "acc_01ca2p8jqans5aty5gj5etmjcf"
-              parent_id: "acc_01ca2pkge49aabzd6k6msho0y"
+              parent_id: "acc_01ca26pkge49aabzd6k6mshn0y"
               name: "Account Name"
               description: "The account description"
               master: true
@@ -1012,7 +1012,7 @@ components:
             success: true
             data:
               object: "token"
-              id: "tok_ABC_01cbfge9qhmsdbjyb7a8e8pxt3"
+              id: "tok_abc_01cbfge9qhmsdbjyb7a8e8pxt3"
               symbol: "ABC"
               name: "ABC Point"
               subunit_to_unit: 100
@@ -1043,7 +1043,7 @@ components:
               object: "list"
               data:
                 - object: "token"
-                  id: "tok_ABC_01cbfge9qhmsdbjyb7a8e8pxt3"
+                  id: "tok_abc_01cbfge9qhmsdbjyb7a8e8pxt3"
                   symbol: "ABC"
                   name: "ABC Point"
                   subunit_to_unit: 100
@@ -1231,7 +1231,7 @@ components:
           data:
             object: "account"
             id: "acc_01ca2p8jqans5aty5gj5etmjcf"
-            parent_id: "acc_01ca2pkge49aabzd6k6msho0y"
+            parent_id: "acc_01ca26pkge49aabzd6k6mshn0y"
             name: "Account Name"
             description: "The account description"
             master: true
@@ -1268,7 +1268,7 @@ components:
             data:
               - object: "account"
                 id: "acc_01ca2p8jqans5aty5gj5etmjcf"
-                parent_id: "acc_01ca2pkge49aabzd6k6msho0y"
+                parent_id: "acc_01ca26pkge49aabzd6k6mshn0y"
                 name: "Account name"
                 description: "The account description"
                 master: true
@@ -1322,7 +1322,7 @@ components:
         - updated_at
       example:
         object: "user"
-        id: "cec34607-0761-4a59-8357-18963e42a1aa"
+        id: "usr_01ce83zf80j542z4q4zqd8qvfx"
         provider_user_id: "wijf-fbancomw-dqwjudb"
         username: "johndoe"
         email: "johndoe@omise.co"
@@ -1345,7 +1345,7 @@ components:
         example:
           data:
             object: "user"
-            id: "cec34607-0761-4a59-8357-18963e42a1aa"
+            id: "usr_01ce83zf80j542z4q4zqd8qvfx"
             provider_user_id: "wijf-fbancomw-dqwjudb"
             username: "johndoe"
             email: "johndoe@omise.co"
@@ -1378,7 +1378,7 @@ components:
             object: "list"
             data:
               - object: "user"
-                id: "cec34607-0761-4a59-8357-18963e42a1aa"
+                id: "usr_01ce83zf80j542z4q4zqd8qvfx"
                 provider_user_id: "wijf-fbancomw-dqwjudb"
                 username: "johndoe"
                 email: "johndoe@omise.co"
@@ -1588,7 +1588,7 @@ components:
         example:
           data:
             object: "user"
-            id: "cec34607-0761-4a59-8357-18963e42a1aa"
+            id: "usr_01ce83zf80j542z4q4zqd8qvfx"
             provider_user_id: "wijf-fbancomw-dqwjudb"
             username: "johndoe"
             email: "johndoe@omise.co"
@@ -1622,7 +1622,7 @@ components:
             object: "list"
             data:
               - object: "user"
-                id: "cec34607-0761-4a59-8357-18963e42a1aa"
+                id: "usr_01ce83zf80j542z4q4zqd8qvfx"
                 provider_user_id: "wijf-fbancomw-dqwjudb"
                 username: "johndoe"
                 email: "johndoe@omise.co"
@@ -1648,7 +1648,6 @@ components:
           type: string
         id:
           type: string
-          format: uuid
         from:
           type: object
           properties:
@@ -1722,11 +1721,11 @@ components:
           success: true
           data:
             object: "transaction"
-            id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+            id: "txn_01ce840q5svw6058r8yk6jzf65"
             idempotency_token: "123982f5-4a27-498d-a91b-7bb2e2a8d3d1"
             from:
               object: "transaction_source"
-              address: "XXX123"
+              address: "bec66785-f0d8-416c-a650-2859aa680166"
               amount: 1000
               token:
                 object: "token"
@@ -1738,7 +1737,7 @@ components:
                 updated_at: "2018-01-01T10:00:00Z"
             to:
               object: "transaction_source"
-              address: "XXX123"
+              address: "47218ab4-d94f-44e9-b7f2-36061f76ce58"
               amount: 1000
               token:
                 object: "token"
@@ -1781,10 +1780,10 @@ components:
             object: "list"
             data:
               - object: "transaction"
-                id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+                id: "txn_01ce842dxrrprkak0rzq716ax1"
                 from:
                   object: "transaction_source"
-                  address: "XXX123"
+                  address: "bec66785-f0d8-416c-a650-2859aa680166"
                   amount: 1000
                   token:
                     object: "token"
@@ -1796,7 +1795,7 @@ components:
                     updated_at: "2018-01-01T10:00:00Z"
                 to:
                   object: "transaction_source"
-                  address: "XXX123"
+                  address: "47218ab4-d94f-44e9-b7f2-36061f76ce58"
                   amount: 1000
                   token:
                     object: "token"
@@ -1831,7 +1830,6 @@ components:
           type: string
         id:
           type: string
-          format: uuid
         access_key:
           type: string
         secret_key:
@@ -1873,7 +1871,7 @@ components:
           success: true
           data:
             object: "key"
-            id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+            id: "key_01ce843mvg5fa1zpk5myy69h4q"
             access_key: "jZKpGKgwy5LJTWwXqSD4jVWYDdnTKHlRYkaNB6SqsaQ"
             secret_key: "the_secret_key_or_null"
             account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
@@ -1905,7 +1903,7 @@ components:
             object: "list"
             data:
               - object: "key"
-                id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+                id: "key_01ce843mvg5fa1zpk5myy69h4q"
                 access_key: "jZKpGKgwy5LJTWwXqSD4jVWYDdnTKHlRYkaNB6SqsaQ"
                 secret_key: "the_secret_key_or_null"
                 account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
@@ -1929,7 +1927,6 @@ components:
           type: string
         id:
           type: string
-          format: uuid
         key:
           type: string
         owner_app:
@@ -1971,7 +1968,7 @@ components:
           success: true
           data:
             object: "api_key"
-            id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+            id: "api_01ce844d5w9e81snekr5kprvem"
             key: "jZKpGKgwy5LJTWwXqSD4jVWYDdnTKHlRYkaNB6SqsaQ"
             owner_app: "admin_api"
             account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
@@ -2003,7 +2000,7 @@ components:
             object: "list"
             data:
               - object: "api_key"
-                id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+                id: "api_01ce844d5w9e81snekr5kprvem"
                 key: "jZKpGKgwy5LJTWwXqSD4jVWYDdnTKHlRYkaNB6SqsaQ"
                 owner_app: "admin_api"
                 account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
@@ -2140,7 +2137,7 @@ components:
             required:
               - id
             example:
-              id: "tok_ABC_01cbfge9qhmsdbjyb7a8e8pxt3"
+              id: "tok_abc_01cbfge9qhmsdbjyb7a8e8pxt3"
     # Request body for creating a token
     TokenCreateBody:
         description: The parameters to create a token. Note that if amount is specified, the token will be minted automatically.
@@ -2203,7 +2200,7 @@ components:
                 - id
                 - amount
               example:
-                id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+                id: "tok_ABC_01ce846km1syzwezxfmgdn7dt7"
                 amount: 1000
 
     ###########################################
@@ -2377,7 +2374,7 @@ components:
             example:
               name: "Account Name"
               description: "The account description"
-              parent_id: "acc_01ca2pkge49aabzd6k6msho0y"
+              parent_id: "acc_01ca26pkge49aabzd6k6mshn0y"
               category_ids: []
               metadata: {}
               encrypted_metadata: {}
@@ -2434,7 +2431,6 @@ components:
               - properties:
                   user_id:
                     type: string
-                    format: uuid
                   account_id:
                     type: string
                   role_name:
@@ -2447,7 +2443,7 @@ components:
                   - role_name
                   - redirect_url
                 example:
-                  user_id: "582edb32-1b7e-46aa-95f2-e0b3f57d71d3"
+                  user_id: "usr_01ce83q2zw7zk1dqr79t22zr1v"
                   account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
                   role_name: "admin"
                   redirect_url: "https://domain/redirect_path?email={email}&token={token}"
@@ -2470,7 +2466,7 @@ components:
                   redirect_url: "https://domain/redirect_path?email={email}&token={token}"
             example:
               account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
-              user_id: "582edb32-1b7e-46aa-95f2-e0b3f57d71d3"
+              user_id: "usr_01ce83q2zw7zk1dqr79t22zr1v"
               role_name: "admin"
               redirect_url: "https://domain/redirect_path?email={email}&token={token}"
     AccountUnassignUserBody:
@@ -2482,7 +2478,6 @@ components:
             properties:
               user_id:
                 type: string
-                format: uuid
               account_id:
                 type: string
             required:
@@ -2490,7 +2485,7 @@ components:
               - account_id
             example:
               account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
-              user_id: "582edb32-1b7e-46aa-95f2-e0b3f57d71d3"
+              user_id: "usr_01ce83q2zw7zk1dqr79t22zr1v"
     AccountUploadBody:
       description: The parameters to use for uploading an account's avatar. Only supports .jpg, .jpeg, .gif and .png.
       required: true
@@ -2548,11 +2543,10 @@ components:
             properties:
               id:
                 type: string
-                format: uuid
             required:
               - id
             example:
-              id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+              id: "usr_01ce83q2zw7zk1dqr79t22zr1v"
     InviteAcceptBody:
       description: The parameters to use for accepting an invite
       required: true
@@ -2728,11 +2722,10 @@ components:
             properties:
               id:
                 type: string
-                format: uuid
             required:
               - id
             example:
-              id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+              id: "txn_01ce83x8w4db56f3fcjy4n4qpc"
     TransactionCreateBody:
       description: The parameters to use for creating a transaction
       required: true
@@ -2794,11 +2787,10 @@ components:
             properties:
               id:
                 type: string
-                format: uuid
             required:
               - id
             example:
-              id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+              id: "usr_01ce83xvrsh8bzpctq3wqbprf8"
     AdminUploadBody:
       description: The parameters to use for uploading an admin's avatar. Only supports .jpg, .jpeg, .gif and .png.
       required: true
@@ -2808,7 +2800,6 @@ components:
             properties:
               id:
                 type: string
-                format: uuid
               avatar:
                 type: string
                 format: binary
@@ -2816,7 +2807,7 @@ components:
               - id
               - avatar
             example:
-              id: "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+              id: "usr_01ce83xvrsh8bzpctq3wqbprf8"
               avatar: "/path/to/file"
 
     ######################################
@@ -2858,11 +2849,10 @@ components:
               - properties:
                   id:
                     type: string
-                    format: uuid
                 required:
                   - id
                 example:
-                  id: "582edb32-1b7e-46aa-95f2-e0b3f57d71d3"
+                  id: "key_01ce83yphmq6vt4qnmn3ykwcw6"
               - properties:
                   access_key:
                     type: string
@@ -2871,7 +2861,7 @@ components:
                 example:
                   access_key: "jZKpGKgwy5LJTWwXqSD4jVWYDdnTKHlRYkaNB6SqsaQ"
             example:
-              id: "582edb32-1b7e-46aa-95f2-e0b3f57d71d3"
+              id: "key_01ce83yphmq6vt4qnmn3ykwcw6"
 
     ######################################
     #       API KEY REQUEST BODIES       #
@@ -2924,11 +2914,10 @@ components:
             properties:
               id:
                 type: string
-                format: uuid
             required:
               - id
             example:
-              id: "582edb32-1b7e-46aa-95f2-e0b3f57d71d3"
+              id: "key_01ce83yphmq6vt4qnmn3ykwcw6"
 
   ######################################
   #          SECURITY SCHEMES          #


### PR DESCRIPTION
Issue/Task Number: -

# Overview

Some IDs on the API spec is still in the old format (uuid). This PR updates the spec to the sym_ULID format when appropriate.

# Changes

- Updated spec.yml for ewallet_api
- Updated spec.yml for admin_api

# Implementation Details

Searched for uuid, checked that it's the incorrect format, changed the value.

# Usage

Read the docs

# Impact

Deploy as usual.
