### PR TITLE
Prevent burn wallet from sending transactions

### DIFF
--- a/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
@@ -52,7 +52,7 @@ defmodule EWallet.TransferTest do
       assert Transfer |> Repo.all() |> length() == 3
     end
 
-    test "fails to insert a transfer with a burn wallet", attrs do
+    test "fails to insert a transfer from a burn wallet", attrs do
       master_account = Account.get_master_account()
       burn_wallet = Account.get_default_burn_wallet(master_account)
 
@@ -69,7 +69,7 @@ defmodule EWallet.TransferTest do
              ]
     end
 
-    test "fails to insert a transfer with an additional burn wallet", attrs do
+    test "fails to insert a transfer from an additional burn wallet", attrs do
       master_account = Account.get_master_account()
       burn_wallet = insert(:wallet, account: master_account, identifier: "burn_1")
 

--- a/apps/ewallet_db/lib/ewallet_db/transfer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transfer.ex
@@ -96,6 +96,7 @@ defmodule EWalletDB.Transfer do
       :metadata,
       :encrypted_metadata
     ])
+    |> validate_from_wallet_identifier()
     |> validate_inclusion(:status, @statuses)
     |> validate_inclusion(:type, @types)
     |> validate_immutable(:idempotency_token)

--- a/apps/ewallet_db/lib/ewallet_db/validator.ex
+++ b/apps/ewallet_db/lib/ewallet_db/validator.ex
@@ -3,6 +3,7 @@ defmodule EWalletDB.Validator do
   Custom validators that extend Ecto.Changeset's list of built-in validators.
   """
   alias Ecto.Changeset
+  alias EWalletDB.Wallet
 
   @min_password_length Application.get_env(:ewallet_db, :min_password_length, 8)
 
@@ -113,6 +114,24 @@ defmodule EWalletDB.Validator do
 
       {:error, _} ->
         Changeset.add_error(changeset, key, "does not meet the password requirements")
+    end
+  end
+
+  def validate_from_wallet_identifier(changeset) do
+    from = Changeset.get_field(changeset, :from)
+    wallet = Wallet.get(from)
+
+    case Wallet.burn_wallet?(wallet) do
+      true ->
+        Changeset.add_error(
+          changeset,
+          :from,
+          "can't be the address of a burn wallet",
+          validation: :burn_wallet_as_sender_not_allowed
+        )
+
+      false ->
+        changeset
     end
   end
 end

--- a/apps/ewallet_db/lib/ewallet_db/wallet.ex
+++ b/apps/ewallet_db/lib/ewallet_db/wallet.ex
@@ -193,4 +193,11 @@ defmodule EWalletDB.Wallet do
         {:error, changeset}
     end
   end
+
+  @doc """
+  Check if a wallet is a burn wallet.
+  """
+  @spec burn_wallet?(%Wallet{}) :: true | false
+  def burn_wallet?(nil), do: false
+  def burn_wallet?(wallet), do: String.match?(wallet.identifier, ~r/^#{@burn}|#{@burn}:.*/)
 end

--- a/apps/ewallet_db/lib/ewallet_db/wallet.ex
+++ b/apps/ewallet_db/lib/ewallet_db/wallet.ex
@@ -197,7 +197,7 @@ defmodule EWalletDB.Wallet do
   @doc """
   Check if a wallet is a burn wallet.
   """
-  @spec burn_wallet?(%Wallet{}) :: true | false
+  @spec burn_wallet?(%Wallet{} | nil) :: true | false
   def burn_wallet?(nil), do: false
   def burn_wallet?(wallet), do: String.match?(wallet.identifier, ~r/^#{@burn}|#{@burn}:.*/)
 end


### PR DESCRIPTION
Issue/Task Number: T337

# Overview

Prevent burn wallet from sending transactions. This PR checks if the wallet is a burn wallet before allowing the creation of the transfer.
