### PR TITLE
Prevent random failure for consumption consumer gate

### DIFF
--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -744,11 +744,26 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
       send(pid_3, :start_consume)
       send(pid_4, :start_consume)
 
-      assert_receive {:updated_1, _res, _response}, 5000
-      assert_receive {:updated_2, _res, _response}, 5000
-      assert_receive {:updated_3, _res, _response}, 5000
-      assert_receive {:updated_4, _res, response}, 5000
-      assert response == :max_consumptions_per_user_reached
+      assert_receive {:updated_1, _res, response_1}, 5000
+      assert_receive {:updated_2, _res, response_2}, 5000
+      assert_receive {:updated_3, _res, response_3}, 5000
+      assert_receive {:updated_4, _res, response_4}, 5000
+
+      acc = %{errors: 0, consumptions: 0}
+
+      counts = Enum.reduce([response_1, response_2, response_3, response_4], acc, fn response, acc ->
+        case response do
+          :max_consumptions_per_user_reached ->
+            Map.put(acc, :errors, acc[:errors] + 1)
+          _ ->
+            Map.put(acc, :consumptions, acc[:consumptions] + 1)
+        end
+      end)
+
+      assert counts == %{
+        consumptions: 1,
+        errors: 3
+      }
 
       consumptions = TransactionConsumption |> EWalletDB.Repo.all()
       assert length(consumptions) == 1

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -751,19 +751,21 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       acc = %{errors: 0, consumptions: 0}
 
-      counts = Enum.reduce([response_1, response_2, response_3, response_4], acc, fn response, acc ->
-        case response do
-          :max_consumptions_per_user_reached ->
-            Map.put(acc, :errors, acc[:errors] + 1)
-          _ ->
-            Map.put(acc, :consumptions, acc[:consumptions] + 1)
-        end
-      end)
+      counts =
+        Enum.reduce([response_1, response_2, response_3, response_4], acc, fn response, acc ->
+          case response do
+            :max_consumptions_per_user_reached ->
+              Map.put(acc, :errors, acc[:errors] + 1)
+
+            _ ->
+              Map.put(acc, :consumptions, acc[:consumptions] + 1)
+          end
+        end)
 
       assert counts == %{
-        consumptions: 1,
-        errors: 3
-      }
+               consumptions: 1,
+               errors: 3
+             }
 
       consumptions = TransactionConsumption |> EWalletDB.Repo.all()
       assert length(consumptions) == 1

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
@@ -288,14 +288,12 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
 
       assert response["data"]["data"] |> length() == 4
 
-      assert Enum.map(response["data"]["data"], fn t ->
-               t["id"]
-             end) == [
-               meta.transfer_1.id,
-               meta.transfer_2.id,
-               meta.transfer_3.id,
-               meta.transfer_4.id
-             ]
+      ids = Enum.map(response["data"]["data"], fn t -> t["id"] end)
+      assert length(ids) == 4
+      assert Enum.member?(ids, meta.transfer_1.id)
+      assert Enum.member?(ids, meta.transfer_2.id)
+      assert Enum.member?(ids, meta.transfer_3.id)
+      assert Enum.member?(ids, meta.transfer_4.id)
     end
 
     test "ignores search terms if both from and to are provided and


### PR DESCRIPTION
Issue/Task Number: A

# Overview

Saw this test randomly failing yesterday:

```
  1) test consume/2 with user allows only one consume per user with four consumes at the same time (EWallet.TransactionConsumptionConsumerGateTest)
     test/ewallet/gates/transaction_consumption_consumer_gate_test.exs:652
     Assertion with == failed
     code:  assert response == :max_consumptions_per_user_reached
     left:  %{
              __meta__: #Ecto.Schema.Metadata<:loaded, "transaction_consumption">,
              __struct__: EWalletDB.TransactionConsumption,
```
This PR fixes that by checking that one of the responses is a valid consumption and the others are errors.