### PR TITLE
T17 update credit debit

### DIFF
--- a/apps/ewallet/lib/ewallet/fetchers/credit_debit_record_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/credit_debit_record_fetcher.ex
@@ -6,30 +6,19 @@ defmodule EWallet.CreditDebitRecordFetcher do
 
   def fetch(
         %{
+          "account_id" => account_id,
           "provider_user_id" => provider_user_id,
           "token_id" => token_id
-        } = attrs
+        }
       ) do
+    account = Account.get(account_id, preload: :wallets)
     user = User.get_by_provider_user_id(provider_user_id)
     token = Token.get(token_id)
-    account = load_account(attrs["account_id"], attrs["account_address"])
-    handle_result(account, user, token, attrs["account_id"])
+    handle_result(account, user, token)
   end
 
-  defp load_account(nil, nil), do: Account.get_master_account(preload: :wallets)
-
-  defp load_account(nil, _address), do: nil
-
-  defp load_account(account_id, _address), do: Account.get(account_id, preload: :wallets)
-
-  defp handle_result(_, _, nil, _), do: {:error, :token_not_found}
-  defp handle_result(_, nil, _, _), do: {:error, :provider_user_id_not_found}
-
-  # master / account = nil and account_id is nil
-  defp handle_result(account, user, token, nil), do: {:ok, account, user, token}
-
-  # has account id but account was not found
-  defp handle_result(nil, _, _, _account_id), do: {:error, :account_id_not_found}
-
-  defp handle_result(account, user, token, _account_id), do: {:ok, account, user, token}
+  defp handle_result(_, _, nil), do: {:error, :token_not_found}
+  defp handle_result(_, nil, _), do: {:error, :provider_user_id_not_found}
+  defp handle_result(nil, _, _), do: {:error, :account_id_not_found}
+  defp handle_result(account, user, token), do: {:ok, account, user, token}
 end

--- a/apps/ewallet/lib/ewallet/fetchers/credit_debit_record_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/credit_debit_record_fetcher.ex
@@ -12,15 +12,13 @@ defmodule EWallet.CreditDebitRecordFetcher do
       ) do
     user = User.get_by_provider_user_id(provider_user_id)
     token = Token.get(token_id)
-    account = load_account(attrs["account_id"], token)
+    account = load_account(attrs["account_id"])
     handle_result(account, user, token)
   end
 
-  defp load_account(nil, nil), do: nil
+  defp load_account(nil), do: Account.get_master_account(preload: :wallets)
 
-  defp load_account(nil, token), do: Account.get_by([uuid: token.account_uuid], preload: :wallets)
-
-  defp load_account(account_id, _token), do: Account.get(account_id, preload: :wallets)
+  defp load_account(account_id), do: Account.get(account_id, preload: :wallets)
 
   defp handle_result(_, _, nil), do: {:error, :token_not_found}
   defp handle_result(nil, _, _), do: {:error, :account_id_not_found}

--- a/apps/ewallet/lib/ewallet/fetchers/credit_debit_record_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/credit_debit_record_fetcher.ex
@@ -4,13 +4,11 @@ defmodule EWallet.CreditDebitRecordFetcher do
   """
   alias EWalletDB.{User, Token, Account}
 
-  def fetch(
-        %{
-          "account_id" => account_id,
-          "provider_user_id" => provider_user_id,
-          "token_id" => token_id
-        }
-      ) do
+  def fetch(%{
+        "account_id" => account_id,
+        "provider_user_id" => provider_user_id,
+        "token_id" => token_id
+      }) do
     account = Account.get(account_id, preload: :wallets)
     user = User.get_by_provider_user_id(provider_user_id)
     token = Token.get(token_id)

--- a/apps/ewallet/lib/ewallet/fetchers/wallet_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/wallet_fetcher.ex
@@ -22,7 +22,7 @@ defmodule EWallet.WalletFetcher do
   end
 
   def get(%User{} = user, address) do
-    with %Wallet{} = wallet <- Wallet.get(address) || :wallet_not_found,
+    with %Wallet{} = wallet <- Wallet.get(address) || :user_wallet_not_found,
          true <- wallet.user_uuid == user.uuid || :user_wallet_mismatch do
       {:ok, wallet}
     else
@@ -31,7 +31,7 @@ defmodule EWallet.WalletFetcher do
   end
 
   def get(%Account{} = account, address) do
-    with %Wallet{} = wallet <- Wallet.get(address) || :wallet_not_found,
+    with %Wallet{} = wallet <- Wallet.get(address) || :account_wallet_not_found,
          true <- wallet.account_uuid == account.uuid || :account_wallet_mismatch do
       {:ok, wallet}
     else

--- a/apps/ewallet/lib/ewallet/gates/transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_gate.ex
@@ -86,6 +86,7 @@ defmodule EWallet.TransactionGate do
   """
   def process_credit_or_debit(
         %{
+          "account_id" => _,
           "provider_user_id" => _,
           "token_id" => _,
           "amount" => _,

--- a/apps/ewallet/test/ewallet/fetchers/credit_debit_record_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/credit_debit_record_fetcher_test.exs
@@ -10,8 +10,8 @@ defmodule EWallet.CreditDebitRecordFetcherTest do
   end
 
   describe "fetch/2" do
-    test "fetches the user and token correctly" do
-      {:ok, inserted_account} = Account.insert(params_for(:account))
+    test "fetches the user and token, and get the default master_account correctly" do
+      {:ok, master_account} = Account.insert(params_for(:account))
       {:ok, inserted_token} = Token.insert(params_for(:token))
       {:ok, inserted_user} = User.insert(params_for(:user))
 
@@ -21,8 +21,7 @@ defmodule EWallet.CreditDebitRecordFetcherTest do
           "token_id" => inserted_token.id
         })
 
-      assert account.uuid != inserted_account.uuid
-      assert account.uuid == inserted_token.account_uuid
+      assert account.uuid == master_account.uuid
       assert user == inserted_user
       assert token == inserted_token
     end

--- a/apps/ewallet/test/ewallet/fetchers/credit_debit_record_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/credit_debit_record_fetcher_test.exs
@@ -26,7 +26,24 @@ defmodule EWallet.CreditDebitRecordFetcherTest do
       assert token == inserted_token
     end
 
-    test "returns the given account if provided" do
+    test "returns nil account given an address but no account_id" do
+      {:ok, master_account} = Account.insert(params_for(:account))
+      {:ok, inserted_token} = Token.insert(params_for(:token))
+      {:ok, inserted_user} = User.insert(params_for(:user))
+
+      {:ok, account, user, token} =
+        CreditDebitRecordFetcher.fetch(%{
+          "provider_user_id" => inserted_user.provider_user_id,
+          "token_id" => inserted_token.id,
+          "account_address" => Account.get_default_burn_wallet(master_account).address
+        })
+
+      assert account == nil
+      assert user == inserted_user
+      assert token == inserted_token
+    end
+
+    test "returns the given account if account_id is provided" do
       {:ok, inserted_account} = Account.insert(params_for(:account))
       {:ok, inserted_token} = Token.insert(params_for(:token))
       {:ok, inserted_user} = User.insert(params_for(:user))

--- a/apps/ewallet/test/ewallet/fetchers/credit_debit_record_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/credit_debit_record_fetcher_test.exs
@@ -10,62 +10,31 @@ defmodule EWallet.CreditDebitRecordFetcherTest do
   end
 
   describe "fetch/2" do
-    test "fetches the user and token, and get the default master_account correctly" do
+    test "fetches the user, token and get account correctly" do
       {:ok, master_account} = Account.insert(params_for(:account))
       {:ok, inserted_token} = Token.insert(params_for(:token))
       {:ok, inserted_user} = User.insert(params_for(:user))
 
       {:ok, account, user, token} =
         CreditDebitRecordFetcher.fetch(%{
+          "account_id" => master_account.id,
           "provider_user_id" => inserted_user.provider_user_id,
           "token_id" => inserted_token.id
         })
 
-      assert account.uuid == master_account.uuid
-      assert user == inserted_user
-      assert token == inserted_token
-    end
-
-    test "returns nil account given an address but no account_id" do
-      {:ok, master_account} = Account.insert(params_for(:account))
-      {:ok, inserted_token} = Token.insert(params_for(:token))
-      {:ok, inserted_user} = User.insert(params_for(:user))
-
-      {:ok, account, user, token} =
-        CreditDebitRecordFetcher.fetch(%{
-          "provider_user_id" => inserted_user.provider_user_id,
-          "token_id" => inserted_token.id,
-          "account_address" => Account.get_default_burn_wallet(master_account).address
-        })
-
-      assert account == nil
-      assert user == inserted_user
-      assert token == inserted_token
-    end
-
-    test "returns the given account if account_id is provided" do
-      {:ok, inserted_account} = Account.insert(params_for(:account))
-      {:ok, inserted_token} = Token.insert(params_for(:token))
-      {:ok, inserted_user} = User.insert(params_for(:user))
-
-      {:ok, account, user, token} =
-        CreditDebitRecordFetcher.fetch(%{
-          "provider_user_id" => inserted_user.provider_user_id,
-          "token_id" => inserted_token.id,
-          "account_id" => inserted_account.id
-        })
-
-      assert account.uuid == inserted_account.uuid
+      assert account == master_account
       assert user == inserted_user
       assert token == inserted_token
     end
 
     test "raises an error if the user is not found" do
+      {:ok, inserted_account} = Account.insert(params_for(:account))
       {:ok, inserted_token} = Token.insert(params_for(:token))
       provider_user_id = "invalid_provider_user_id"
 
       res =
         CreditDebitRecordFetcher.fetch(%{
+          "account_id" => inserted_account.id,
           "provider_user_id" => provider_user_id,
           "token_id" => inserted_token.id
         })

--- a/apps/ewallet/test/ewallet/fetchers/wallet_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/wallet_fetcher_test.exs
@@ -5,13 +5,14 @@ defmodule EWallet.WalletFetcherTest do
 
   setup do
     {:ok, user} = :user |> params_for() |> User.insert()
+    {:ok, account} = :account |> params_for() |> Account.insert()
     token = insert(:token)
     wallet = User.get_primary_wallet(user)
 
-    %{user: user, token: token, wallet: wallet}
+    %{user: user, account: account, token: token, wallet: wallet}
   end
 
-  describe "get_wallet/2" do
+  describe "get/2" do
     test "retrieves the user's primary wallet if address is nil", meta do
       {:ok, wallet} = WalletFetcher.get(meta.user, nil)
       assert wallet == User.get_primary_wallet(meta.user)
@@ -23,15 +24,27 @@ defmodule EWallet.WalletFetcherTest do
       assert wallet.uuid == inserted_wallet.uuid
     end
 
-    test "returns 'wallet_not_found' if the address is not found", meta do
+    test "returns 'user_wallet_not_found' if the address is not found", meta do
       {:error, error} = WalletFetcher.get(meta.user, "fake")
-      assert error == :wallet_not_found
+      assert error == :user_wallet_not_found
     end
 
     test "returns 'user_wallet_mismatch' if the wallet found does not belong to the user", meta do
       wallet = insert(:wallet)
       {:error, error} = WalletFetcher.get(meta.user, wallet.address)
       assert error == :user_wallet_mismatch
+    end
+
+    test "returns 'account_wallet_not_found' if the address is not found", meta do
+      {:error, error} = WalletFetcher.get(meta.account, "fake")
+      assert error == :account_wallet_not_found
+    end
+
+    test "returns 'account_wallet_mismatch' if the wallet found does not belong to the account",
+         meta do
+      wallet = insert(:wallet)
+      {:error, error} = WalletFetcher.get(meta.account, wallet.address)
+      assert error == :account_wallet_mismatch
     end
   end
 end

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -177,7 +177,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
           "address" => "fake"
         })
 
-      assert res == {:error, :wallet_not_found}
+      assert res == {:error, :account_wallet_not_found}
     end
 
     test "with valid account_id and an address that does not belong to the account", meta do
@@ -319,7 +319,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
           "address" => "fake"
         })
 
-      assert res == {:error, :wallet_not_found}
+      assert res == {:error, :user_wallet_not_found}
     end
 
     test "with valid provider_user_id and an address that does not belong to the user", meta do
@@ -1245,7 +1245,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
       assert changeset.errors == [amount: {"can't be blank", [validation: :required]}]
     end
 
-    test "returns 'wallet_not_found' when address is invalid", meta do
+    test "returns 'user_wallet_not_found' when address is invalid", meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
 
       {res, error} =
@@ -1260,7 +1260,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
         })
 
       assert res == :error
-      assert error == :wallet_not_found
+      assert error == :user_wallet_not_found
     end
 
     test "returns 'wallet_not_found' when address does not belong to sender", meta do

--- a/apps/ewallet/test/ewallet/gates/transaction_request_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_request_gate_test.exs
@@ -102,7 +102,7 @@ defmodule EWallet.TransactionRequestGateTest do
           "address" => "fake"
         })
 
-      assert res == {:error, :wallet_not_found}
+      assert res == {:error, :account_wallet_not_found}
     end
 
     test "with valid account_id, valid user and a valid address", meta do
@@ -222,7 +222,7 @@ defmodule EWallet.TransactionRequestGateTest do
           "address" => "fake"
         })
 
-      assert res == {:error, :wallet_not_found}
+      assert res == {:error, :user_wallet_not_found}
     end
 
     test "with valid provider_user_id and an address that does not belong to the user", meta do
@@ -342,7 +342,7 @@ defmodule EWallet.TransactionRequestGateTest do
       assert changeset.errors == [type: {"is invalid", [validation: :inclusion]}]
     end
 
-    test "receives a 'wallet_not_found' error when the address is invalid", meta do
+    test "receives a 'user_wallet_not_found' error when the address is invalid", meta do
       {:error, error} =
         TransactionRequestGate.create(meta.user, %{
           "type" => "receive",
@@ -352,7 +352,7 @@ defmodule EWallet.TransactionRequestGateTest do
           "address" => "fake"
         })
 
-      assert error == :wallet_not_found
+      assert error == :user_wallet_not_found
     end
 
     test "receives an 'user_wallet_mismatch' error when the address does not belong to the user",

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
@@ -47,7 +47,7 @@ defmodule EWalletAPI.V1.TransferController do
     |> respond_with(:transfer, conn)
   end
 
-  defp transfer_from_wallet({:error, :wallet_not_found}, conn, _attrs) do
+  defp transfer_from_wallet({:error, :user_wallet_not_found}, conn, _attrs) do
     handle_error(conn, :from_address_not_found)
   end
 

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transfer_controller.ex
@@ -63,10 +63,15 @@ defmodule EWalletAPI.V1.TransferController do
   defp credit_or_debit(
          conn,
          type,
-         %{"provider_user_id" => provider_user_id, "token_id" => token_id, "amount" => amount} =
-           attrs
+         %{
+           "provider_user_id" => provider_user_id,
+           "token_id" => token_id,
+           "amount" => amount,
+           "account_id" => account_id
+         } = attrs
        )
-       when provider_user_id != nil and token_id != nil and is_integer(amount) do
+       when provider_user_id != nil and token_id != nil and is_integer(amount) and
+              account_id != nil do
     attrs
     |> Map.put("type", type)
     |> Map.put("idempotency_token", conn.assigns[:idempotency_token])

--- a/apps/ewallet_api/lib/ewallet_api/v1/error_handler.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/error_handler.ex
@@ -17,8 +17,16 @@ defmodule EWalletAPI.V1.ErrorHandler do
       description: "There is no user corresponding to the provided provider_user_id"
     },
     wallet_not_found: %{
-      code: "user:wallet_not_found",
+      code: "wallet:wallet_not_found",
       description: "There is no wallet corresponding to the provided address"
+    },
+    user_wallet_not_found: %{
+      code: "user:wallet_not_found",
+      description: "There is no user wallet corresponding to the provided address"
+    },
+    account_wallet_not_found: %{
+      code: "account:wallet_not_found",
+      description: "There is no account wallet corresponding to the provided address"
     },
     user_wallet_mismatch: %{
       code: "user:user_wallet_mismatch",
@@ -27,10 +35,6 @@ defmodule EWalletAPI.V1.ErrorHandler do
     account_wallet_mismatch: %{
       code: "account:account_wallet_mismatch",
       description: "The provided wallet does not belong to the given account"
-    },
-    burn_wallet_not_found: %{
-      code: "user:burn_wallet_not_found",
-      description: "There is no burn wallet corresponding to the provided name"
     },
     account_id_not_found: %{
       code: "user:account_id_not_found",

--- a/apps/ewallet_api/priv/spec.yaml
+++ b/apps/ewallet_api/priv/spec.yaml
@@ -1651,7 +1651,6 @@ components:
         The parameters for crediting or debiting the balance of the specified user
         by taking/giving back the given amount from/to the account_id.
 
-        If not specified, the master account will be used as the source.
         You can optionally specify the account_address and/or user_address to use a spcific wallet.
         A convenient way to burn tokens is to make a debit and specify the burn wallet address.
       required: true
@@ -1676,6 +1675,7 @@ components:
               encrypted_metadata:
                 type: object
             required:
+              - account_id
               - provider_user_id
               - token_id
               - amount

--- a/apps/ewallet_api/priv/spec.yaml
+++ b/apps/ewallet_api/priv/spec.yaml
@@ -1651,9 +1651,9 @@ components:
         The parameters for crediting or debiting the balance of the specified user
         by taking/giving back the given amount from/to the account_id.
 
-        If not specified, the account owning the token will be used as the source.
-        If no burn_balance_identifier is specified, the tokens won't be burned
-        and will instead be returned to the primary wallet of the selected account.
+        If not specified, the master account will be used as the source.
+        You can optionally specify the account_address and/or user_address to use a spcific wallet.
+        A convenient way to burn tokens is to make a debit and specify the burn wallet address.
       required: true
       content:
         application/vnd.omisego.v1+json:
@@ -1661,13 +1661,15 @@ components:
             properties:
               provider_user_id:
                 type: string
+              user_address:
+                type: string
               token_id:
                 type: string
               amount:
                 type: integer
               account_id:
                 type: string
-              burn_balance_identifier:
+              account_address:
                 type: string
               metadata:
                 type: object
@@ -1679,10 +1681,11 @@ components:
               - amount
             example:
               provider_user_id: "wijf-fbancomw-dqwjudb"
+              user_address: "d28d5053-a1d5-4314-8c13-4aef396fe1e4"
               token_id: "tok_BTC_01cbffybmtbbb449r05zgfct2h"
               amount: 100
               account_id: "acc_01cbfgbt9hezkbz8mphmwdfcj1"
-              burn_balance_identifier: "burn"
+              account_address: "546570a9-6ebf-4df7-be01-724745d0b298"
               metadata: {}
               encrypted_metadata: {}
     ServerCreateTransactionRequestBody:

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -148,7 +148,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                "success" => false,
                "version" => "1",
                "data" => %{
-                 "code" => "user:wallet_not_found",
+                 "code" => "wallet:wallet_not_found",
                  "description" => "There is no wallet corresponding to the provided address",
                  "messages" => nil,
                  "object" => "error"
@@ -354,7 +354,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "user:wallet_not_found",
-                 "description" => "There is no wallet corresponding to the provided address",
+                 "description" => "There is no user wallet corresponding to the provided address",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -661,7 +661,6 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       transfer = get_last_inserted(Transfer)
       assert transfer.metadata == %{"something" => "interesting"}
       assert transfer.encrypted_metadata == %{"something" => "secret"}
-
     end
 
     test "returns invalid_parameter when the provider_user_id is missing" do
@@ -908,7 +907,6 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       transfer = get_last_inserted(Transfer)
       assert transfer.metadata == %{"something" => "interesting"}
       assert transfer.encrypted_metadata == %{"something" => "secret"}
-
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -608,16 +608,13 @@ defmodule EWalletAPI.V1.TransferControllerTest do
 
       response =
         provider_request_with_idempotency("/user.credit_wallet", UUID.generate(), %{
+          account_id: account.id,
           provider_user_id: user.provider_user_id,
           token_id: token.id,
           amount: 1_000 * token.subunit_to_unit,
           metadata: %{something: "interesting"},
           encrypted_metadata: %{something: "secret"}
         })
-
-      transfer = get_last_inserted(Transfer)
-      assert transfer.metadata == %{"something" => "interesting"}
-      assert transfer.encrypted_metadata == %{"something" => "secret"}
 
       assert response == %{
                "success" => true,
@@ -660,6 +657,11 @@ defmodule EWalletAPI.V1.TransferControllerTest do
                  ]
                }
              }
+
+      transfer = get_last_inserted(Transfer)
+      assert transfer.metadata == %{"something" => "interesting"}
+      assert transfer.encrypted_metadata == %{"something" => "secret"}
+
     end
 
     test "returns invalid_parameter when the provider_user_id is missing" do
@@ -690,6 +692,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
 
       response =
         provider_request_with_idempotency("/user.credit_wallet", UUID.generate(), %{
+          account_id: account.id,
           provider_user_id: "fake",
           token_id: token.id,
           amount: 100_000,
@@ -768,6 +771,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
 
       response =
         provider_request("/user.debit_wallet", %{
+          account_id: account.id,
           provider_user_id: user.provider_user_id,
           token_id: token.id,
           amount: 100_000,
@@ -787,7 +791,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
              }
     end
 
-    test "returns insufficient_funds when the user is too poor" do
+    test "returns insufficient_funds when the user is too poor :~(" do
       {:ok, account} = :account |> params_for() |> Account.insert()
       {:ok, user} = :user |> params_for() |> User.insert()
       user_wallet = User.get_primary_wallet(user)
@@ -795,6 +799,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
 
       response =
         provider_request_with_idempotency("/user.debit_wallet", UUID.generate(), %{
+          account_id: account.id,
           provider_user_id: user.provider_user_id,
           token_id: token.id,
           amount: 100_000,
@@ -833,16 +838,13 @@ defmodule EWalletAPI.V1.TransferControllerTest do
 
       response =
         provider_request_with_idempotency("/user.debit_wallet", UUID.generate(), %{
+          account_id: account.id,
           provider_user_id: user.provider_user_id,
           token_id: token.id,
           amount: 150_000 * token.subunit_to_unit,
           metadata: %{something: "interesting"},
           encrypted_metadata: %{something: "secret"}
         })
-
-      transfer = get_last_inserted(Transfer)
-      assert transfer.metadata == %{"something" => "interesting"}
-      assert transfer.encrypted_metadata == %{"something" => "secret"}
 
       assert response == %{
                "version" => "1",
@@ -902,6 +904,11 @@ defmodule EWalletAPI.V1.TransferControllerTest do
                  ]
                }
              }
+
+      transfer = get_last_inserted(Transfer)
+      assert transfer.metadata == %{"something" => "interesting"}
+      assert transfer.encrypted_metadata == %{"something" => "secret"}
+
     end
   end
 end


### PR DESCRIPTION
Issue/Task Number: 17

# Overview

This PR removes the `burn_balance_identifier` from credit/debit and instead adds `user_address` and `account_address` to let the user specify from/to which wallet the funds are taken/sent.

# Changes

- Remove `burn_balance_identifier`
- Add `user_address` and `account_address`
- Add missing tests