### PR TITLE
Remove searching capabilities from Wallet Controller

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/wallet_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/wallet_controller.ex
@@ -31,7 +31,6 @@ defmodule AdminAPI.V1.WalletController do
     with %Account{} = account <- Account.get(id) || :account_id_not_found do
       account
       |> Wallet.all_for()
-      |> SearchParser.to_query(attrs, @search_fields)
       |> SortParser.to_query(attrs, @sort_fields, @mapped_fields)
       |> Paginator.paginate_attrs(attrs)
       |> respond_multiple(conn)
@@ -46,7 +45,6 @@ defmodule AdminAPI.V1.WalletController do
     with %User{} = user <- User.get(id) || :user_id_not_found do
       user
       |> Wallet.all_for()
-      |> SearchParser.to_query(attrs, @search_fields)
       |> SortParser.to_query(attrs, @sort_fields, @mapped_fields)
       |> Paginator.paginate_attrs(attrs)
       |> respond_multiple(conn)

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -2310,26 +2310,22 @@ components:
         application/vnd.omisego.v1+json:
           schema:
             properties:
-              account_id:
+              id:
                 type: string
               page:
                 type: integer
                 minimum: 1
               per_page:
                 type: integer
-                minimum: 1
-              search_term:
-                type: string
               sort_by:
                 type: string
               sort_dir:
                 type: string
                 enum: ["asc", "desc"]
             example:
-              account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
+              id: "acc_01ca2p8jqans5aty5gj5etmjcf"
               page: 1
               per_page: 10
-              search_term: ""
               sort_by: "field_name"
               sort_dir: "asc"
     WalletUserBody:
@@ -2339,7 +2335,7 @@ components:
         application/vnd.omisego.v1+json:
           schema:
             properties:
-              user:
+              id:
                 type: string
               page:
                 type: integer
@@ -2347,18 +2343,15 @@ components:
               per_page:
                 type: integer
                 minimum: 1
-              search_term:
-                type: string
               sort_by:
                 type: string
               sort_dir:
                 type: string
                 enum: ["asc", "desc"]
             example:
-              user: usr_01cc02x0v98qcctvycfx4vsk8x
+              id: usr_01cc02x0v98qcctvycfx4vsk8x
               page: 1
               per_page: 10
-              search_term: ""
               sort_by: "field_name"
               sort_dir: "asc"
     WalletGetBody:

--- a/apps/admin_api/test/admin_api/v1/controllers/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/wallet_controller_test.exs
@@ -55,11 +55,14 @@ defmodule AdminAPI.V1.WalletControllerTest do
 
       wallets = response["data"]["data"]
       assert length(wallets) == 2
-      assert Enum.at(wallets, 0)["account_id"] == account.id
-      assert Enum.at(wallets, 0)["identifier"] == "burn"
 
-      assert Enum.at(wallets, 1)["account_id"] == account.id
-      assert Enum.at(wallets, 1)["identifier"] == "primary"
+      wallets =
+        Enum.map(wallets, fn wallet ->
+          {wallet["account_id"], wallet["identifier"]}
+        end)
+
+      assert Enum.member?(wallets, {account.id, "primary"})
+      assert Enum.member?(wallets, {account.id, "burn"})
 
       # Asserts pagination data
       pagination = response["data"]["pagination"]
@@ -69,8 +72,8 @@ defmodule AdminAPI.V1.WalletControllerTest do
       assert is_boolean(pagination["is_first_page"])
     end
 
-    test "returns a list of wallets according to search_term, sort_by and sort_direction" do
-      {:ok, account} = :account |> params_for() |> Account.insert()
+    test "returns a list of wallets according to sort_by and sort_direction" do
+      account = insert(:account)
       insert(:wallet, %{account: account, address: "XYZ1", identifier: "secondary_1"})
       insert(:wallet, %{account: account, address: "XYZ3", identifier: "secondary_2"})
       insert(:wallet, %{account: account, address: "XYZ2", identifier: "secondary_3"})
@@ -79,7 +82,6 @@ defmodule AdminAPI.V1.WalletControllerTest do
       attrs = %{
         "id" => account.id,
         # Search is case-insensitive
-        "search_term" => "xYz",
         "sort_by" => "address",
         "sort_dir" => "desc"
       }
@@ -88,10 +90,11 @@ defmodule AdminAPI.V1.WalletControllerTest do
       wallets = response["data"]["data"]
 
       assert response["success"]
-      assert Enum.count(wallets) == 3
-      assert Enum.at(wallets, 0)["address"] == "XYZ3"
-      assert Enum.at(wallets, 1)["address"] == "XYZ2"
-      assert Enum.at(wallets, 2)["address"] == "XYZ1"
+      assert Enum.count(wallets) == 4
+      assert Enum.at(wallets, 0)["address"] == "ZZZ1"
+      assert Enum.at(wallets, 1)["address"] == "XYZ3"
+      assert Enum.at(wallets, 2)["address"] == "XYZ2"
+      assert Enum.at(wallets, 3)["address"] == "XYZ1"
 
       Enum.each(wallets, fn wallet ->
         assert wallet["account_id"] == account.id
@@ -122,8 +125,8 @@ defmodule AdminAPI.V1.WalletControllerTest do
       assert is_boolean(pagination["is_first_page"])
     end
 
-    test "returns a list of wallets according to search_term, sort_by and sort_direction" do
-      {:ok, user} = :user |> params_for() |> User.insert()
+    test "returns a list of wallets according to sort_by and sort_direction" do
+      user = insert(:user)
       insert(:wallet, %{user: user, address: "XYZ1", identifier: "secondary_1"})
       insert(:wallet, %{user: user, address: "XYZ3", identifier: "secondary_2"})
       insert(:wallet, %{user: user, address: "XYZ2", identifier: "secondary_3"})
@@ -131,8 +134,6 @@ defmodule AdminAPI.V1.WalletControllerTest do
 
       attrs = %{
         "id" => user.id,
-        # Search is case-insensitive
-        "search_term" => "xYz",
         "sort_by" => "address",
         "sort_dir" => "desc"
       }
@@ -141,10 +142,11 @@ defmodule AdminAPI.V1.WalletControllerTest do
       wallets = response["data"]["data"]
 
       assert response["success"]
-      assert Enum.count(wallets) == 3
-      assert Enum.at(wallets, 0)["address"] == "XYZ3"
-      assert Enum.at(wallets, 1)["address"] == "XYZ2"
-      assert Enum.at(wallets, 2)["address"] == "XYZ1"
+      assert Enum.count(wallets) == 4
+      assert Enum.at(wallets, 0)["address"] == "ZZZ1"
+      assert Enum.at(wallets, 1)["address"] == "XYZ3"
+      assert Enum.at(wallets, 2)["address"] == "XYZ2"
+      assert Enum.at(wallets, 3)["address"] == "XYZ1"
 
       Enum.each(wallets, fn wallet ->
         assert wallet["user_id"] == user.id

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -405,7 +405,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
   describe "consume/2 with user" do
     test "consumes the receive request and transfer the appropriate amount of token with min
-    params (and is idempotent)", meta do
+    params (and is idempotent)",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
 
       {res, consumption} =
@@ -488,7 +489,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "consumes an account receive request and transfer the appropriate amount of token with min
-    params", meta do
+    params",
+         meta do
       transaction_request =
         insert(
           :transaction_request,
@@ -520,7 +522,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "consumes the receive request and transfer the appropriate amount
-          of token with all params", meta do
+          of token with all params",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
 
       {res, consumption} =
@@ -561,7 +564,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "works with reached max_consumptions_per_user is reached but
-          same idempotent token is provided", meta do
+          same idempotent token is provided",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
 
       request =
@@ -606,7 +610,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "returns a 'max_consumptions_per_user_reached' error if the maximum number of
-          consumptions has been reached for the current user", meta do
+          consumptions has been reached for the current user",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
 
       request =
@@ -774,7 +779,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "works and returns the previous consumption with max_consumptions and
-         same idempotency_token", meta do
+         same idempotency_token",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
       {:ok, request} = TransactionRequest.update(meta.request, %{max_consumptions: 1})
 
@@ -809,7 +815,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "returns a 'max_consumptions_reached' error if the maximum number of
-          consumptions has been reached", meta do
+          consumptions has been reached",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
       {:ok, request} = TransactionRequest.update(meta.request, %{max_consumptions: 1})
 
@@ -948,7 +955,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "proceeds if the maximum number of consumptions hasn't been reached and
-          increment it", meta do
+          increment it",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
       {:ok, request} = TransactionRequest.update(meta.request, %{max_consumptions: 2})
 
@@ -1025,7 +1033,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "returns a pending request with no transfer is the request requires confirmation
-         (and is idempotent)", meta do
+         (and is idempotent)",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
 
       {:ok, request} =
@@ -1141,7 +1150,8 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     end
 
     test "returns an 'unauthorized_amount_override' error if the consumption tries to
-          illegally override the amount", meta do
+          illegally override the amount",
+         meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
 
       {:ok, request} =

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
@@ -297,7 +297,8 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
     end
 
     test "ignores search terms if both from and to are provided and
-          address does not belong to user", meta do
+          address does not belong to user",
+         meta do
       response =
         client_request("/me.list_transactions", %{
           "sort_by" => "created_at",

--- a/apps/ewallet_db/lib/ewallet_db/wallet.ex
+++ b/apps/ewallet_db/lib/ewallet_db/wallet.ex
@@ -111,8 +111,12 @@ defmodule EWalletDB.Wallet do
     |> put_change(:encryption_version, Cloak.version())
   end
 
-  def all_for(%Account{} = account), do: from(t in Wallet, where: t.account_uuid == ^account.uuid)
-  def all_for(%User{} = user), do: from(t in Wallet, where: t.user_uuid == ^user.uuid)
+  def all_for(%Account{} = account),
+    do: from(t in Wallet, where: t.account_uuid == ^account.uuid, preload: [:user, :account])
+
+  def all_for(%User{} = user),
+    do: from(t in Wallet, where: t.user_uuid == ^user.uuid, preload: [:user, :account])
+
   def all_for(_), do: nil
 
   @doc """

--- a/apps/ewallet_db/lib/ewallet_db/wallet.ex
+++ b/apps/ewallet_db/lib/ewallet_db/wallet.ex
@@ -111,11 +111,13 @@ defmodule EWalletDB.Wallet do
     |> put_change(:encryption_version, Cloak.version())
   end
 
-  def all_for(%Account{} = account),
-    do: from(t in Wallet, where: t.account_uuid == ^account.uuid, preload: [:user, :account])
+  def all_for(%Account{} = account) do
+    from(t in Wallet, where: t.account_uuid == ^account.uuid, preload: [:user, :account])
+  end
 
-  def all_for(%User{} = user),
-    do: from(t in Wallet, where: t.user_uuid == ^user.uuid, preload: [:user, :account])
+  def all_for(%User{} = user) do
+    from(t in Wallet, where: t.user_uuid == ^user.uuid, preload: [:user, :account])
+  end
 
   def all_for(_), do: nil
 

--- a/apps/local_ledger/test/local_ledger/cached_balance_test.exs
+++ b/apps/local_ledger/test/local_ledger/cached_balance_test.exs
@@ -87,7 +87,8 @@ defmodule LocalLedger.CachedBalanceTest do
     end
 
     test "reuses the previous cached balance to calculate the new one when
-          strategy = 'since_last_cached'", %{token_1: token_1, wallet: wallet} do
+          strategy = 'since_last_cached'",
+         %{token_1: token_1, wallet: wallet} do
       Application.put_env(:local_ledger, :balance_caching_strategy, "since_last_cached")
 
       CachedBalance.cache_all()
@@ -124,7 +125,8 @@ defmodule LocalLedger.CachedBalanceTest do
     end
 
     test "reuses the previous cached balance to calculate the new one when
-          strategy = 'since_beginning'", %{token_1: token_1, wallet: wallet} do
+          strategy = 'since_beginning'",
+         %{token_1: token_1, wallet: wallet} do
       Application.put_env(:local_ledger, :balance_caching_strategy, "since_beginning")
 
       CachedBalance.cache_all()


### PR DESCRIPTION
Issue/Task Number: T346

# Overview

Currently, the way the searcher works isn't great and it was causing the `account.get_wallets` and `user.get_wallets` endpoints to return unwanted results. For now, this PR removes the search step.
