### PR TITLE
Surround Transfer retrieval after insert with transaction

### DIFF
--- a/apps/ewallet_db/lib/ewallet_db/transfer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transfer.ex
@@ -172,16 +172,24 @@ defmodule EWalletDB.Transfer do
   using the passed idempotency token.
   """
   def insert(attrs) do
-    changeset = changeset(%Transfer{}, attrs)
     opts = [on_conflict: :nothing, conflict_target: :idempotency_token]
 
-    case Repo.insert(changeset, opts) do
-      {:ok, transfer} ->
-        {:ok, get_by_idempotency_token(transfer.idempotency_token)}
+    %Transfer{}
+    |> changeset(attrs)
+    |> do_insert(opts)
+    |> case do {_, res} -> res end
+  end
 
-      changeset ->
-        changeset
-    end
+  defp do_insert(changeset, opts) do
+    Repo.transaction(fn ->
+      case Repo.insert(changeset, opts) do
+        {:ok, transfer} ->
+          {:ok, get_by_idempotency_token(transfer.idempotency_token)}
+
+        changeset ->
+          changeset
+      end
+    end)
   end
 
   @doc """

--- a/apps/ewallet_db/lib/ewallet_db/transfer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transfer.ex
@@ -177,7 +177,9 @@ defmodule EWalletDB.Transfer do
     %Transfer{}
     |> changeset(attrs)
     |> do_insert(opts)
-    |> case do {_, res} -> res end
+    |> case do
+      {_, res} -> res
+    end
   end
 
   defp do_insert(changeset, opts) do


### PR DESCRIPTION
Issue/Task Number: T347

# Overview

Since we have multiple nodes of the DB, there seem to be some randomly failing method in the Transfer insert flow. Basically, the retrieval after the insert fails because the record was "potentially" inserted in another node. This PR surrounds the insert/get flow with a transaction as an attempt to fix that.

# Changes

- Add `Repo.transaction()` around in `insert`
