### PR TITLE
Added formatted_id to simplify transaction request flow

### DIFF
--- a/apps/ewallet/lib/ewallet/fetchers/transaction_request_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/transaction_request_fetcher.ex
@@ -8,9 +8,10 @@ defmodule EWallet.TransactionRequestFetcher do
   """
   alias EWalletDB.TransactionRequest
 
-  @spec get(UUID.t()) :: {:ok, TransactionRequest.t()} | {:error, :transaction_request_not_found}
-  def get(id) do
-    id
+  @spec get(String.t()) ::
+          {:ok, TransactionRequest.t()} | {:error, :transaction_request_not_found}
+  def get(transaction_request_id) do
+    transaction_request_id
     |> TransactionRequest.get(preload: [:token, :user, :wallet])
     |> handle_request_existence()
   end
@@ -18,11 +19,11 @@ defmodule EWallet.TransactionRequestFetcher do
   defp handle_request_existence(nil), do: {:error, :transaction_request_not_found}
   defp handle_request_existence(request), do: {:ok, request}
 
-  @spec get_with_lock(UUID.t()) ::
+  @spec get_with_lock(String.t()) ::
           {:ok, TransactionRequest.t()}
           | {:error, :transaction_request_not_found}
-  def get_with_lock(id) do
-    request = TransactionRequest.get_with_lock(id)
+  def get_with_lock(transaction_request_id) do
+    request = TransactionRequest.get_with_lock(transaction_request_id)
 
     case request do
       nil -> {:error, :transaction_request_not_found}

--- a/apps/ewallet/lib/ewallet/gates/transaction_consumption_consumer_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_consumption_consumer_gate.ex
@@ -113,7 +113,7 @@ defmodule EWallet.TransactionConsumptionConsumerGate do
   def consume(
         %Wallet{} = wallet,
         %{
-          "transaction_request_id" => _,
+          "formatted_transaction_request_id" => _,
           "idempotency_token" => _
         } = attrs
       ) do
@@ -130,12 +130,12 @@ defmodule EWallet.TransactionConsumptionConsumerGate do
   defp do_consume(
          wallet,
          %{
-           "transaction_request_id" => request_id,
+           "formatted_transaction_request_id" => formatted_request_id,
            "idempotency_token" => idempotency_token
          } = attrs
        ) do
     with {v, f} <- {TransactionConsumptionValidator, TransactionConsumptionFetcher},
-         {:ok, request} <- TransactionRequestFetcher.get_with_lock(request_id),
+         {:ok, request} <- TransactionRequestFetcher.get_with_lock(formatted_request_id),
          {:ok, nil} <- f.idempotent_fetch(idempotency_token),
          {:ok, request, token, amount} <- v.validate_before_consumption(request, wallet, attrs),
          {:ok, consumption} <- insert(wallet, token, request, amount, attrs),

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
@@ -21,6 +21,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
     %{
       object: "transaction_request",
       id: transaction_request.id,
+      formatted_id: transaction_request.id,
       socket_topic: "transaction_request:#{transaction_request.id}",
       type: transaction_request.type,
       amount: transaction_request.amount,

--- a/apps/ewallet/test/ewallet/fetchers/transaction_consumption_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/transaction_consumption_fetcher_test.exs
@@ -51,7 +51,7 @@ defmodule EWallet.TransactionConsumptionFetcherTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
@@ -63,7 +63,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -104,7 +104,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -141,7 +141,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -175,7 +175,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -212,7 +212,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -250,7 +250,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       params = fn ->
         %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -319,7 +319,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -360,7 +360,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -397,7 +397,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -431,7 +431,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -468,7 +468,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -48,7 +48,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with nil account_id and no address", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -63,7 +63,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with invalid account_id and no address", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -78,7 +78,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with valid account_id and nil address", meta do
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -95,7 +95,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with valid account_id and no address", meta do
       {res, request} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -111,7 +111,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with valid account_id and a valid address", meta do
       {res, request} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -131,7 +131,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, request} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -150,7 +150,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with valid account_id, valid user but not owned address", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -167,7 +167,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with valid account_id and an invalid address", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -183,7 +183,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with valid account_id and an address that does not belong to the account", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -211,7 +211,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
           "account_id" => meta.account.id,
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -226,7 +226,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(%{
           "account_id" => meta.account.id,
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -257,7 +257,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with invalid provider_user_id and no address", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -274,7 +274,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, request} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -292,7 +292,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, request} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -309,7 +309,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with valid provider_user_id and an invalid address", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -325,7 +325,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with valid provider_user_id and an address that does not belong to the user", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -343,7 +343,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with nil address", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -358,7 +358,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with a valid address", meta do
       {res, request} =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -374,7 +374,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with an invalid address", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -391,7 +391,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
     test "with invalid parameters", meta do
       res =
         TransactionConsumptionConsumerGate.consume(%{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "metadata" => nil,
@@ -411,7 +411,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -428,7 +428,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -457,7 +457,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption, error, _error_data} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -473,7 +473,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption, error, _error_data} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -505,7 +505,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -528,7 +528,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => "123",
           "amount" => 1_000,
           "address" => meta.sender_wallet.address,
@@ -550,7 +550,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, error} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => "123",
           "amount" => 1_000,
           "address" => meta.sender_wallet.address,
@@ -581,7 +581,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -595,7 +595,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption_2} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -627,7 +627,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -641,7 +641,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, error} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -669,7 +669,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
           {res, response} =
             TransactionConsumptionConsumerGate.consume(meta.sender, %{
-              "transaction_request_id" => request.id,
+              "formatted_transaction_request_id" => request.id,
               "correlation_id" => nil,
               "amount" => nil,
               "address" => nil,
@@ -690,7 +690,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
           {res, response} =
             TransactionConsumptionConsumerGate.consume(meta.sender, %{
-              "transaction_request_id" => request.id,
+              "formatted_transaction_request_id" => request.id,
               "correlation_id" => nil,
               "amount" => nil,
               "address" => nil,
@@ -711,7 +711,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
           {res, response} =
             TransactionConsumptionConsumerGate.consume(meta.sender, %{
-              "transaction_request_id" => request.id,
+              "formatted_transaction_request_id" => request.id,
               "correlation_id" => nil,
               "amount" => nil,
               "address" => nil,
@@ -732,7 +732,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
           {res, response} =
             TransactionConsumptionConsumerGate.consume(meta.sender, %{
-              "transaction_request_id" => request.id,
+              "formatted_transaction_request_id" => request.id,
               "correlation_id" => nil,
               "amount" => nil,
               "address" => nil,
@@ -786,7 +786,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -800,7 +800,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption_2} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -822,7 +822,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -836,7 +836,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, error} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -864,7 +864,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
           {res, response} =
             TransactionConsumptionConsumerGate.consume(meta.sender, %{
-              "transaction_request_id" => request.id,
+              "formatted_transaction_request_id" => request.id,
               "correlation_id" => nil,
               "amount" => nil,
               "address" => nil,
@@ -885,7 +885,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
           {res, response} =
             TransactionConsumptionConsumerGate.consume(meta.sender, %{
-              "transaction_request_id" => request.id,
+              "formatted_transaction_request_id" => request.id,
               "correlation_id" => nil,
               "amount" => nil,
               "address" => nil,
@@ -906,7 +906,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
           {res, response} =
             TransactionConsumptionConsumerGate.consume(meta.sender, %{
-              "transaction_request_id" => request.id,
+              "formatted_transaction_request_id" => request.id,
               "correlation_id" => nil,
               "amount" => nil,
               "address" => nil,
@@ -927,7 +927,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
           {res, response} =
             TransactionConsumptionConsumerGate.consume(meta.sender, %{
-              "transaction_request_id" => request.id,
+              "formatted_transaction_request_id" => request.id,
               "correlation_id" => nil,
               "amount" => nil,
               "address" => nil,
@@ -962,7 +962,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -976,7 +976,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -1005,7 +1005,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => "123",
           "amount" => 1_000,
           "address" => meta.sender_wallet.address,
@@ -1019,7 +1019,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, error} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -1044,7 +1044,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => "123",
           "amount" => 1_000,
           "address" => meta.sender_wallet.address,
@@ -1058,7 +1058,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => "123",
           "amount" => 1_000,
           "address" => meta.sender_wallet.address,
@@ -1084,7 +1084,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => "123",
           "amount" => 1_000,
           "address" => meta.sender_wallet.address,
@@ -1111,7 +1111,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => "123",
           "amount" => 1_000,
           "address" => meta.sender_wallet.address,
@@ -1135,7 +1135,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => "123",
           "amount" => 1_123,
           "address" => meta.sender_wallet.address,
@@ -1161,7 +1161,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, error} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => request.id,
+          "formatted_transaction_request_id" => request.id,
           "correlation_id" => "123",
           "amount" => 1_123,
           "address" => meta.sender_wallet.address,
@@ -1180,7 +1180,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, error} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => "123",
           "amount" => 0,
           "address" => meta.sender_wallet.address,
@@ -1198,7 +1198,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, changeset} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => "123",
           "amount" => 0,
           "address" => meta.sender_wallet.address,
@@ -1219,7 +1219,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption_1} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -1232,7 +1232,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, consumption_2} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -1259,7 +1259,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {error, changeset} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => transaction_request.id,
+          "formatted_transaction_request_id" => transaction_request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => nil,
@@ -1277,7 +1277,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, error} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => "fake",
@@ -1296,7 +1296,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       {res, error} =
         TransactionConsumptionConsumerGate.consume(meta.sender, %{
-          "transaction_request_id" => meta.request.id,
+          "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
           "address" => wallet.address,

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
@@ -24,6 +24,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializerTest do
       expected = %{
         object: "transaction_request",
         id: transaction_request.id,
+        formatted_id: transaction_request.id,
         socket_topic: "transaction_request:#{transaction_request.id}",
         type: transaction_request.type,
         token_id: Assoc.get(transaction_request, [:token, :id]),

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_controller.ex
@@ -19,8 +19,8 @@ defmodule EWalletAPI.V1.TransactionRequestController do
     |> respond(conn)
   end
 
-  def get(conn, %{"id" => id}) do
-    id
+  def get(conn, %{"formatted_id" => formatted_id}) do
+    formatted_id
     |> TransactionRequestFetcher.get()
     |> respond(conn)
   end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
@@ -54,7 +54,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
 
       response =
         provider_request_with_idempotency("/transaction_request.consume", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: nil,
           address: nil,
@@ -122,7 +122,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
 
       response =
         provider_request_with_idempotency("/transaction_request.consume", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: nil,
           address: nil,
@@ -173,7 +173,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
 
       response =
         provider_request_with_idempotency("/transaction_request.consume", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: nil,
           address: nil,
@@ -206,7 +206,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
 
       response =
         provider_request_with_idempotency("/transaction_request.consume", "1234", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: nil,
           address: nil,
@@ -223,7 +223,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
 
       response =
         client_request_with_idempotency("/me.consume_transaction_request", "1234", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: nil,
           address: nil,
@@ -289,7 +289,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       # create a pending consumption that will need to be confirmed
       response =
         provider_request_with_idempotency("/transaction_request.consume", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: 100_000 * meta.token.subunit_to_unit,
           metadata: nil,
@@ -382,7 +382,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       # create a pending consumption that will need to be confirmed
       response =
         provider_request_with_idempotency("/transaction_request.consume", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: 100_000 * meta.token.subunit_to_unit,
           metadata: nil,
@@ -478,7 +478,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       # create a pending consumption that will need to be confirmed
       response =
         provider_request_with_idempotency("/transaction_request.consume", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: 100_000 * meta.token.subunit_to_unit,
           metadata: nil,
@@ -574,7 +574,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       # create a pending consumption that will need to be confirmed
       response =
         provider_request_with_idempotency("/transaction_request.consume", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: 100_000 * meta.token.subunit_to_unit,
           metadata: nil,
@@ -667,7 +667,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       # create a pending consumption that will need to be confirmed
       response =
         provider_request_with_idempotency("/transaction_request.consume", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: 100_000 * meta.token.subunit_to_unit,
           metadata: nil,
@@ -729,7 +729,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       # create a pending consumption that will need to be confirmed
       response =
         provider_request_with_idempotency("/transaction_request.consume", "1234", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: 100_000 * meta.token.subunit_to_unit,
           metadata: nil,
@@ -811,7 +811,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
 
       response =
         client_request_with_idempotency("/me.consume_transaction_request", "123", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: nil,
           address: nil,
@@ -885,7 +885,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
 
       response =
         client_request_with_idempotency("/me.consume_transaction_request", "1234", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: nil,
           address: nil,
@@ -901,7 +901,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
 
       response =
         client_request_with_idempotency("/me.consume_transaction_request", "1234", %{
-          transaction_request_id: transaction_request.id,
+          formatted_transaction_request_id: transaction_request.id,
           correlation_id: nil,
           amount: nil,
           address: nil,

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -29,6 +29,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "address" => wallet.address,
                  "correlation_id" => "123",
                  "id" => request.id,
+                 "formatted_id" => request.id,
                  "socket_topic" => "transaction_request:#{request.id}",
                  "token_id" => token.id,
                  "token" => token |> TokenSerializer.serialize() |> stringify_keys(),
@@ -80,6 +81,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "address" => wallet.address,
                  "correlation_id" => nil,
                  "id" => request.id,
+                 "formatted_id" => request.id,
                  "socket_topic" => "transaction_request:#{request.id}",
                  "token_id" => token.id,
                  "token" => token |> TokenSerializer.serialize() |> stringify_keys(),
@@ -236,6 +238,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "address" => wallet.address,
                  "correlation_id" => "123",
                  "id" => request.id,
+                 "formatted_id" => request.id,
                  "socket_topic" => "transaction_request:#{request.id}",
                  "token_id" => token.id,
                  "token" => token |> TokenSerializer.serialize() |> stringify_keys(),
@@ -287,6 +290,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "address" => wallet.address,
                  "correlation_id" => nil,
                  "id" => request.id,
+                 "formatted_id" => request.id,
                  "socket_topic" => "transaction_request:#{request.id}",
                  "token_id" => token.id,
                  "token" => token |> TokenSerializer.serialize() |> stringify_keys(),
@@ -415,7 +419,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
 
       response =
         provider_request("/transaction_request.get", %{
-          id: transaction_request.id
+          formatted_id: transaction_request.id
         })
 
       assert response["success"] == true
@@ -425,7 +429,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
     test "returns an error when the request ID is not found" do
       response =
         provider_request("/transaction_request.get", %{
-          id: "123"
+          formatted_id: "123"
         })
 
       assert response == %{
@@ -448,7 +452,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
 
       response =
         client_request("/me.get_transaction_request", %{
-          id: transaction_request.id
+          formatted_id: transaction_request.id
         })
 
       assert response["success"] == true
@@ -458,7 +462,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
     test "returns an error when the request ID is not found" do
       response =
         client_request("/me.get_transaction_request", %{
-          id: "123"
+          formatted_id: "123"
         })
 
       assert response == %{


### PR DESCRIPTION
Issue/Task Number: T350

# Overview

Currently, the client is responsible for formatting and storing data inside the QR code before decrypting and sending them. The server should take care of that to make it easier to upgrade the format. 

# Changes

- Change `request_id` and `id` to `formatted_transaction_request_id`
- Add `formatted_id` to `TransactionRequest` serializer which can be directly encoded in a QR code and sent when consuming in `formatted_transaction_request_id`
