### PR TITLE
Fixing Transfer retrieval after safe insert

### DIFF
--- a/apps/ewallet/lib/ewallet/formatters/transfer_formatter.ex
+++ b/apps/ewallet/lib/ewallet/formatters/transfer_formatter.ex
@@ -4,7 +4,7 @@ defmodule EWallet.TransferFormatter do
   """
   def format(transfer) do
     %{
-      "correlation_id" => transfer.idempotency_token,
+      "idempotency_token" => transfer.idempotency_token,
       "metadata" => transfer.metadata,
       "token" => %{
         "id" => transfer.token.id,

--- a/apps/ewallet/lib/ewallet/gates/transfer_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transfer_gate.ex
@@ -90,6 +90,11 @@ defmodule EWallet.TransferGate do
     |> update_transfer(transfer)
   end
 
+  defp update_transfer(_, %Transfer{ledger_response: ledger_response} = transfer)
+       when ledger_response != nil do
+    transfer
+  end
+
   defp update_transfer({:ok, entry}, transfer) do
     Transfer.confirm(transfer, %{
       entry_uuid: entry.uuid

--- a/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
@@ -113,6 +113,23 @@ defmodule EWallet.TransferTest do
 
       assert transfer.status == Transfer.failed()
     end
+
+    test "returns the previously inserted transfer", attrs do
+      assert Transfer |> Repo.all() |> length() == 2
+
+      {:ok, transfer_1} = TransferGate.get_or_insert(attrs)
+      transfer_1 = TransferGate.process(transfer_1)
+
+      assert %{"entry_uuid" => _} = transfer_1.ledger_response
+      assert transfer_1.status == Transfer.confirmed()
+
+      transfer_2 = TransferGate.process(transfer_1)
+
+      assert %{"entry_uuid" => _} = transfer_2.ledger_response
+      assert transfer_2.status == Transfer.confirmed()
+      assert transfer_1.uuid == transfer_2.uuid
+      assert Transfer |> Repo.all() |> length() == 3
+    end
   end
 
   describe "genesis/1" do

--- a/apps/local_ledger/lib/local_ledger/entry.ex
+++ b/apps/local_ledger/lib/local_ledger/entry.ex
@@ -32,8 +32,8 @@ defmodule LocalLedger.Entry do
   @doc """
   Retrieve a specific entry based on a correlation ID from the database.
   """
-  def get_with_idempotency_token(idempotency_token) do
-    {:ok, Entry.get_with_idempotency_token(idempotency_token)}
+  def get_by_idempotency_token(idempotency_token) do
+    {:ok, Entry.get_by_idempotency_token(idempotency_token)}
   end
 
   @doc """
@@ -123,13 +123,13 @@ defmodule LocalLedger.Entry do
 
       Transaction.check_balance(transactions, %{genesis: genesis})
 
-      changes = %{
+      %{
         idempotency_token: idempotency_token,
         transactions: transactions,
         metadata: metadata
       }
-
-      case Entry.insert(changes) do
+      |> Entry.get_or_insert()
+      |> case do
         {:ok, entry} ->
           entry
 

--- a/apps/local_ledger/lib/local_ledger/entry.ex
+++ b/apps/local_ledger/lib/local_ledger/entry.ex
@@ -32,8 +32,8 @@ defmodule LocalLedger.Entry do
   @doc """
   Retrieve a specific entry based on a correlation ID from the database.
   """
-  def get_with_correlation_id(correlation_id) do
-    {:ok, Entry.get_with_correlation_id(correlation_id)}
+  def get_with_idempotency_token(idempotency_token) do
+    {:ok, Entry.get_with_idempotency_token(idempotency_token)}
   end
 
   @doc """
@@ -76,7 +76,7 @@ defmodule LocalLedger.Entry do
           id: "tok_OMG_01cbennsd8q4xddqfmewpwzxdy",
           metadata: %{}
         },
-        correlation_id: "123"
+        idempotency_token: "123"
       })
 
   """
@@ -86,7 +86,7 @@ defmodule LocalLedger.Entry do
           "debits" => debits,
           "credits" => credits,
           "token" => token,
-          "correlation_id" => correlation_id
+          "idempotency_token" => idempotency_token
         },
         %{genesis: genesis},
         callback \\ nil
@@ -96,7 +96,7 @@ defmodule LocalLedger.Entry do
     |> Validator.validate_zero_sum()
     |> Validator.validate_positive_amounts()
     |> Transaction.build_all(token)
-    |> locked_insert(metadata, correlation_id, genesis, callback)
+    |> locked_insert(metadata, idempotency_token, genesis, callback)
   rescue
     e in InsufficientFundsError ->
       {:error, :insufficient_funds, e.message}
@@ -115,7 +115,7 @@ defmodule LocalLedger.Entry do
   # amounts, before inserting one entry and the associated transactions.
   # If the genesis argument is passed as true, the balance check will be
   # skipped.
-  defp locked_insert(transactions, metadata, correlation_id, genesis, callback) do
+  defp locked_insert(transactions, metadata, idempotency_token, genesis, callback) do
     addresses = Transaction.get_addresses(transactions)
 
     Wallet.lock(addresses, fn ->
@@ -124,7 +124,7 @@ defmodule LocalLedger.Entry do
       Transaction.check_balance(transactions, %{genesis: genesis})
 
       changes = %{
-        correlation_id: correlation_id,
+        idempotency_token: idempotency_token,
         transactions: transactions,
         metadata: metadata
       }

--- a/apps/local_ledger/test/local_ledger/entry_test.exs
+++ b/apps/local_ledger/test/local_ledger/entry_test.exs
@@ -80,7 +80,7 @@ defmodule LocalLedger.EntryTest do
             "debits" => debits(),
             "credits" => credits(),
             "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-            "correlation_id" => UUID.generate()
+            "idempotency_token" => UUID.generate()
           },
           %{genesis: true}
         )
@@ -126,7 +126,7 @@ defmodule LocalLedger.EntryTest do
               }
             ],
             "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-            "correlation_id" => UUID.generate()
+            "idempotency_token" => UUID.generate()
           },
           %{genesis: false}
         )
@@ -137,7 +137,7 @@ defmodule LocalLedger.EntryTest do
       assert get_current_balance("thibault") == 250
     end
 
-    test "fails when the correlation_id is already in the database" do
+    test "fails when the idempotency_token is already in the database" do
       genesis_entry = genesis()
 
       {status, error} =
@@ -159,13 +159,13 @@ defmodule LocalLedger.EntryTest do
               }
             ],
             "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-            "correlation_id" => genesis_entry.correlation_id
+            "idempotency_token" => genesis_entry.idempotency_token
           },
           %{genesis: false}
         )
 
       assert status == :error
-      assert error.errors == [correlation_id: {"has already been taken", []}]
+      assert error.errors == [idempotency_token: {"has already been taken", []}]
     end
 
     test "returns a 'same address' error when the from/to addresses are identical" do
@@ -193,7 +193,7 @@ defmodule LocalLedger.EntryTest do
               "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
               "metadata" => %{}
             },
-            "correlation_id" => UUID.generate()
+            "idempotency_token" => UUID.generate()
           },
           %{genesis: false}
         )
@@ -230,7 +230,7 @@ defmodule LocalLedger.EntryTest do
               "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
               "metadata" => %{}
             },
-            "correlation_id" => UUID.generate()
+            "idempotency_token" => UUID.generate()
           },
           %{genesis: false}
         )
@@ -261,7 +261,7 @@ defmodule LocalLedger.EntryTest do
               "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
               "metadata" => %{}
             },
-            "correlation_id" => UUID.generate()
+            "idempotency_token" => UUID.generate()
           },
           %{genesis: false}
         )
@@ -289,7 +289,7 @@ defmodule LocalLedger.EntryTest do
               }
             ],
             "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-            "correlation_id" => UUID.generate()
+            "idempotency_token" => UUID.generate()
           },
           %{genesis: false}
         )
@@ -320,7 +320,7 @@ defmodule LocalLedger.EntryTest do
               "debits" => [%{"address" => "mederic", "metadata" => %{}, "amount" => 50}],
               "credits" => [%{"address" => "sirn", "metadata" => %{}, "amount" => 50}],
               "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-              "correlation_id" => UUID.generate()
+              "idempotency_token" => UUID.generate()
             },
             %{genesis: false}
           )
@@ -334,7 +334,7 @@ defmodule LocalLedger.EntryTest do
           "debits" => [%{"address" => "mederic", "metadata" => %{}, "amount" => 100}],
           "credits" => [%{"address" => "thibault", "metadata" => %{}, "amount" => 100}],
           "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-          "correlation_id" => UUID.generate()
+          "idempotency_token" => UUID.generate()
         },
         %{genesis: false},
         fn ->
@@ -385,7 +385,7 @@ defmodule LocalLedger.EntryTest do
                   "id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
                   "metadata" => %{}
                 },
-                "correlation_id" => UUID.generate()
+                "idempotency_token" => UUID.generate()
               },
               %{genesis: false}
             )
@@ -415,7 +415,7 @@ defmodule LocalLedger.EntryTest do
             }
           ],
           "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-          "correlation_id" => UUID.generate()
+          "idempotency_token" => UUID.generate()
         },
         %{genesis: false}
       )
@@ -446,7 +446,7 @@ defmodule LocalLedger.EntryTest do
               }
             ],
             "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-            "correlation_id" => UUID.generate()
+            "idempotency_token" => UUID.generate()
           },
           %{genesis: true}
         )
@@ -478,7 +478,7 @@ defmodule LocalLedger.EntryTest do
                 }
               ],
               "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}},
-              "correlation_id" => UUID.generate()
+              "idempotency_token" => UUID.generate()
             },
             %{genesis: true}
           )

--- a/apps/local_ledger/test/local_ledger/entry_test.exs
+++ b/apps/local_ledger/test/local_ledger/entry_test.exs
@@ -137,10 +137,10 @@ defmodule LocalLedger.EntryTest do
       assert get_current_balance("thibault") == 250
     end
 
-    test "fails when the idempotency_token is already in the database" do
+    test "returns the same entry when the idempotency token is already in the DB" do
       genesis_entry = genesis()
 
-      {status, error} =
+      {status, entry} =
         Entry.insert(
           %{
             "metadata" => %{},
@@ -164,8 +164,8 @@ defmodule LocalLedger.EntryTest do
           %{genesis: false}
         )
 
-      assert status == :error
-      assert error.errors == [idempotency_token: {"has already been taken", []}]
+      assert status == :ok
+      assert entry.uuid == genesis_entry.uuid
     end
 
     test "returns a 'same address' error when the from/to addresses are identical" do

--- a/apps/local_ledger/test/local_ledger/transaction_test.exs
+++ b/apps/local_ledger/test/local_ledger/transaction_test.exs
@@ -81,7 +81,7 @@ defmodule LocalLedger.TransactionTest do
 
       Entry.insert(%{
         metadata: %{},
-        correlation_id: UUID.generate(),
+        idempotency_token: UUID.generate(),
         transactions: [
           %{
             type: LocalLedgerDB.Transaction.credit_type(),

--- a/apps/local_ledger_db/priv/repo/migrations/20180606072241_rename_correlation_id_to_idempotency_token.exs
+++ b/apps/local_ledger_db/priv/repo/migrations/20180606072241_rename_correlation_id_to_idempotency_token.exs
@@ -1,0 +1,9 @@
+defmodule LocalLedgerDB.Repo.Migrations.RenameCorrelationIDToIdempotencyToken do
+  use Ecto.Migration
+
+  def change do
+    drop index(:entry, [:correlation_id])
+    rename table(:entry), :correlation_id, to: :idempotency_token
+    create unique_index(:entry, [:idempotency_token])
+  end
+end

--- a/apps/local_ledger_db/test/support/factory.ex
+++ b/apps/local_ledger_db/test/support/factory.ex
@@ -32,7 +32,7 @@ defmodule LocalLedgerDB.Factory do
 
   def entry_factory do
     %Entry{
-      correlation_id: UUID.generate(),
+      idempotency_token: UUID.generate(),
       metadata: %{
         merchant_id: "123"
       }


### PR DESCRIPTION
Issue/Task Number: T346

# Overview

Attempting to fix [this issue](https://github.com/omisego/ewallet/issues/224) using Repo.Multi. Removed the retries as it wasn't a good solution. The code can be improved but I want to test it in staging, see if it actually fixes anything or not. My next step will be to try reproducing in local with a cluster.

# Changes

- Use `Repo.Multi` to insert a Transfer and retrieve the latest inserted
- Ensure the local ledger can handle existing idempotency token by returning the existing entry instead or returning an error.
