### PR TITLE
Refactor ledger_response into multiple columns

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -105,7 +105,7 @@ defmodule AdminAPI.V1.TokenController do
     }
     |> MintGate.insert()
     |> case do
-      {:ok, _mint, _ledger_response} -> {:ok, token}
+      {:ok, _mint, _transfer} -> {:ok, token}
       {:error, code, description} -> {:error, code, description}
       {:error, changeset} -> {:error, changeset}
     end

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -132,7 +132,7 @@ defmodule AdminAPI.ConnCase do
   end
 
   def mint!(token, amount \\ 1_000_000) do
-    {:ok, mint, _ledger_response} =
+    {:ok, mint, _transfer} =
       MintGate.insert(%{
         "idempotency_token" => UUID.generate(),
         "token_id" => token.id,

--- a/apps/ewallet/lib/ewallet/gates/mint_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/mint_gate.ex
@@ -24,7 +24,7 @@ defmodule EWallet.MintGate do
     })
 
     case res do
-      {:ok, mint, ledger_response} ->
+      {:ok, mint, transfer} ->
         # Everything went well, do something.
         # response is the response returned by the local ledger (LocalLedger for
         # example).
@@ -93,8 +93,10 @@ defmodule EWallet.MintGate do
   end
 
   defp process_with_transfer(%Transfer{status: "failed"} = transfer, mint) do
-    resp = transfer.ledger_response
-    confirm_and_return({:error, resp["code"], resp["description"]}, mint)
+    confirm_and_return(
+      {:error, transfer.error_code, transfer.error_description || transfer.error_data},
+      mint
+    )
   end
 
   defp confirm_and_return({:error, code, description}, mint),

--- a/apps/ewallet/lib/ewallet/gates/transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_gate.ex
@@ -143,7 +143,6 @@ defmodule EWallet.TransactionGate do
   end
 
   defp process_with_transfer(%Transfer{status: "failed"} = transfer, _wallets, _token) do
-    resp = transfer.ledger_response
-    {:error, transfer, resp["code"], resp["description"]}
+    {:error, transfer, transfer.error_code, transfer.error_description || transfer.error_data}
   end
 end

--- a/apps/ewallet/lib/ewallet/gates/transfer_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transfer_gate.ex
@@ -54,7 +54,7 @@ defmodule EWallet.TransferGate do
     res = Transactions.Transfer.process(transfer)
 
     case res do
-      {:ok, ledger_response} ->
+      {:ok, transfer} ->
         # Everything went well, do something.
       {:error, code, description} ->
         # Something went wrong with the transfer processing.
@@ -76,7 +76,7 @@ defmodule EWallet.TransferGate do
     res = Transactions.Transfer.genesis(transfer)
 
     case res do
-      {:ok, ledger_response} ->
+      {:ok, transfer} ->
         # Everything went well, do something.
       {:error, code, description} ->
         # Something went wrong with the transfer processing.
@@ -90,21 +90,17 @@ defmodule EWallet.TransferGate do
     |> update_transfer(transfer)
   end
 
-  defp update_transfer(_, %Transfer{ledger_response: ledger_response} = transfer)
-       when ledger_response != nil do
+  defp update_transfer(_, %Transfer{entry_uuid: entry_uuid, error_code: error_code} = transfer)
+       when entry_uuid != nil
+       when error_code != nil do
     transfer
   end
 
   defp update_transfer({:ok, entry}, transfer) do
-    Transfer.confirm(transfer, %{
-      entry_uuid: entry.uuid
-    })
+    Transfer.confirm(transfer, entry.uuid)
   end
 
   defp update_transfer({:error, code, description}, transfer) do
-    Transfer.fail(transfer, %{
-      code: code,
-      description: description
-    })
+    Transfer.fail(transfer, code, description)
   end
 end

--- a/apps/ewallet/lib/ewallet/web/v1/event_handlers/transaction_consumption_event_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/event_handlers/transaction_consumption_event_handler.ex
@@ -73,8 +73,12 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandler do
 
     case consumption.status do
       "failed" ->
-        ledger = consumption.transfer.ledger_response
-        %{code: ledger["code"], description: ledger["description"]}
+        transfer = consumption.transfer
+
+        %{
+          code: transfer.error_code,
+          description: transfer.error_description || transfer.error_data
+        }
 
       "expired" ->
         :expired_transaction_consumption

--- a/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transfer_gate_test.exs
@@ -92,7 +92,7 @@ defmodule EWallet.TransferTest do
       {:ok, transfer} = TransferGate.get_or_insert(attrs)
       transfer = TransferGate.process(transfer)
 
-      assert %{"entry_uuid" => _} = transfer.ledger_response
+      assert transfer.entry_uuid != nil
       assert transfer.status == Transfer.confirmed()
     end
 
@@ -102,9 +102,10 @@ defmodule EWallet.TransferTest do
       transfer = TransferGate.process(transfer)
 
       assert transfer.status == Transfer.failed()
-      assert transfer.ledger_response["code"] == "insufficient_funds"
+      assert transfer.error_code == "insufficient_funds"
+      assert transfer.error_description == nil
 
-      assert transfer.ledger_response["description"] == %{
+      assert transfer.error_data == %{
                "address" => attrs[:from],
                "amount_to_debit" => 1_000_000,
                "current_amount" => 100_000,
@@ -120,12 +121,12 @@ defmodule EWallet.TransferTest do
       {:ok, transfer_1} = TransferGate.get_or_insert(attrs)
       transfer_1 = TransferGate.process(transfer_1)
 
-      assert %{"entry_uuid" => _} = transfer_1.ledger_response
+      assert transfer_1.entry_uuid != nil
       assert transfer_1.status == Transfer.confirmed()
 
       transfer_2 = TransferGate.process(transfer_1)
 
-      assert %{"entry_uuid" => _} = transfer_2.ledger_response
+      assert transfer_2.entry_uuid != nil
       assert transfer_2.status == Transfer.confirmed()
       assert transfer_1.uuid == transfer_2.uuid
       assert Transfer |> Repo.all() |> length() == 3
@@ -138,7 +139,7 @@ defmodule EWallet.TransferTest do
       transfer = TransferGate.genesis(transfer)
 
       assert transfer.status == Transfer.confirmed()
-      assert %{"entry_uuid" => _} = transfer.ledger_response
+      assert transfer.entry_uuid != nil
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
@@ -438,7 +438,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       assert inserted_transfer.amount == 100_000 * meta.token.subunit_to_unit
       assert inserted_transfer.to == meta.alice_wallet.address
       assert inserted_transfer.from == meta.bob_wallet.address
-      assert assert inserted_transfer.entry_uuid != nil
+      assert inserted_transfer.entry_uuid != nil
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "transaction_consumption_finalized",
@@ -870,7 +870,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       assert inserted_transfer.amount == 100_000 * meta.token.subunit_to_unit
       assert inserted_transfer.to == meta.alice_wallet.address
       assert inserted_transfer.from == meta.bob_wallet.address
-      assert assert inserted_transfer.entry_uuid != nil
+      assert inserted_transfer.entry_uuid != nil
     end
 
     test "returns same transaction request consumption when idempotency token is the same",

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
@@ -106,7 +106,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       assert inserted_transfer.amount == 100_000 * meta.token.subunit_to_unit
       assert inserted_transfer.to == meta.alice_wallet.address
       assert inserted_transfer.from == meta.account_wallet.address
-      assert %{} = inserted_transfer.ledger_response
+      assert inserted_transfer.entry_uuid != nil
     end
 
     test "fails to consume and return an insufficient funds error", meta do
@@ -151,7 +151,15 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       assert inserted_transfer.amount == 100_000 * meta.token.subunit_to_unit
       assert inserted_transfer.to == meta.alice_wallet.address
       assert inserted_transfer.from == meta.account_wallet.address
-      assert %{} = inserted_transfer.ledger_response
+      assert inserted_transfer.error_code == "insufficient_funds"
+      assert inserted_transfer.error_description == nil
+
+      assert inserted_transfer.error_data == %{
+               "address" => meta.account_wallet.address,
+               "amount_to_debit" => 100_000 * meta.token.subunit_to_unit,
+               "current_amount" => 0,
+               "token_id" => meta.token.id
+             }
     end
 
     test "returns with preload if `embed` attribute is given", meta do
@@ -337,7 +345,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       assert inserted_transfer.amount == 100_000 * meta.token.subunit_to_unit
       assert inserted_transfer.to == meta.bob_wallet.address
       assert inserted_transfer.from == meta.account_wallet.address
-      assert %{} = inserted_transfer.ledger_response
+      assert inserted_transfer.entry_uuid != nil
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "transaction_consumption_finalized",
@@ -430,7 +438,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       assert inserted_transfer.amount == 100_000 * meta.token.subunit_to_unit
       assert inserted_transfer.to == meta.alice_wallet.address
       assert inserted_transfer.from == meta.bob_wallet.address
-      assert %{} = inserted_transfer.ledger_response
+      assert assert inserted_transfer.entry_uuid != nil
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "transaction_consumption_finalized",
@@ -862,7 +870,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
       assert inserted_transfer.amount == 100_000 * meta.token.subunit_to_unit
       assert inserted_transfer.to == meta.alice_wallet.address
       assert inserted_transfer.from == meta.bob_wallet.address
-      assert %{} = inserted_transfer.ledger_response
+      assert assert inserted_transfer.entry_uuid != nil
     end
 
     test "returns same transaction request consumption when idempotency token is the same",

--- a/apps/ewallet_api/test/support/conn_case.ex
+++ b/apps/ewallet_api/test/support/conn_case.ex
@@ -137,7 +137,7 @@ defmodule EWalletAPI.ConnCase do
   end
 
   def mint!(token, amount \\ 1_000_000) do
-    {:ok, mint, _ledger_response} =
+    {:ok, mint, _transfer} =
       MintGate.insert(%{
         "idempotency_token" => UUID.generate(),
         "token_id" => token.id,

--- a/apps/ewallet_db/lib/ewallet_db/validator.ex
+++ b/apps/ewallet_db/lib/ewallet_db/validator.ex
@@ -57,6 +57,25 @@ defmodule EWalletDB.Validator do
     end
   end
 
+  @doc """
+  Validates that only one out of the provided fields can have value but
+  both can be nil.
+  """
+  def validate_exclusive(changeset, attrs) when is_map(attrs) or is_list(attrs) do
+    case count_fields_present(changeset, attrs) do
+      n when n > 1 ->
+        Changeset.add_error(
+          changeset,
+          attrs,
+          "only one must be present",
+          validation: :only_one_required
+        )
+
+      _ ->
+        changeset
+    end
+  end
+
   def count_fields_present(changeset, attrs) do
     Enum.count(attrs, fn attr -> field_present?(changeset, attr) end)
   end

--- a/apps/ewallet_db/priv/repo/migrations/20180607103719_move_ledger_response_into_specific_fields.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180607103719_move_ledger_response_into_specific_fields.exs
@@ -1,0 +1,96 @@
+defmodule EWalletDB.Repo.Migrations.MoveLedgerResponseIntoSpecificFields do
+  use Ecto.Migration
+  import Ecto.Query
+  alias EWalletDB.Repo
+  alias Cloak.EncryptedMapField
+
+  def up do
+    alter table(:transfer) do
+      add :entry_uuid, :string
+      add :error_code, :string
+      add :error_description, :string
+      add :error_data, :map
+    end
+
+    flush()
+
+    query = from(t in "transfer",
+                 select: [t.uuid, t.ledger_response],
+                 lock: "FOR UPDATE")
+
+    for [uuid, ledger_response] <- Repo.all(query) do
+      {:ok, ledger_response} = EncryptedMapField.load(ledger_response)
+      description = get_data_or_description(ledger_response["description"], :description)
+      data = get_data_or_description(ledger_response["description"], :data)
+
+      query = from(t in "transfer",
+                   where: t.uuid == ^uuid,
+                   update: [set: [entry_uuid: ^ledger_response["entry_uuid"],
+                                  error_code: ^ledger_response["code"],
+                                  error_description: ^description,
+                                  error_data: ^data
+                                  ]])
+
+      Repo.update_all(query, [])
+    end
+
+    flush()
+
+    alter table(:transfer) do
+      remove :ledger_response
+    end
+  end
+
+  def down do
+    alter table(:transfer) do
+      add :ledger_response, :map
+    end
+
+    flush()
+
+    query = from(t in "transfer",
+                 select: [t.uuid, t.entry_uuid, t.error_code, t.error_description, t.error_data],
+                 lock: "FOR UPDATE")
+
+    for [uuid, entry_uuid, error_code, error_description, error_data] <- Repo.all(query) do
+      {:ok, ledger_response} = EncryptedMapField.cast(%{
+        entry_uuid: entry_uuid,
+        error_code: error_code,
+        error_description: error_description || error_data
+      })
+
+      query = from(t in "transfer",
+                   where: t.uuid == ^uuid,
+                   update: [set: [ledger_response: ^ledger_response]])
+
+      Repo.update_all(query, [])
+    end
+
+    alter table(:transfer) do
+      remove :entry_uuid
+      remove :error_code
+      remove :error_description
+      remove :error_data
+    end
+  end
+
+  defp get_data_or_description(nil, _) do
+    nil
+  end
+
+  defp get_data_or_description(desc, :description) when is_map(desc) do
+    nil
+  end
+
+  defp get_data_or_description(desc, :description) when is_binary(desc) do
+    desc
+  end
+
+  defp get_data_or_description(desc, :data) when is_map(desc) do
+    desc
+  end
+
+  defp get_data_or_description(desc, :data) when is_binary(desc) do
+    nil
+  end
+end

--- a/apps/local_ledger_db/lib/local_ledger_db/errors/insufficient_funds_error.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/errors/insufficient_funds_error.ex
@@ -8,10 +8,10 @@ defmodule LocalLedgerDB.Errors.InsufficientFundsError do
         address: address
       }) do
     %{
-      address: address,
-      current_amount: current_amount,
-      amount_to_debit: amount_to_debit,
-      token_id: token_id
+      "address" => address,
+      "current_amount" => current_amount,
+      "amount_to_debit" => amount_to_debit,
+      "token_id" => token_id
     }
   end
 end


### PR DESCRIPTION
Issue/Task Number: T346-3

# Overview

The randomly failing `get_by_idempotency_token` seemed to have been fixed at the creation level, but was still failing when updating. I updated the code to simply return the updated record. I also removed the `ledger_response`and replace it with specific fields: `entry_uuid`, `error_code`, `error_description` and `error_data`.

# Changes

- Remove `ledger_response`
- Return updated `transfer` directly instead of reloading it.
