### PR TITLE
Ensure processes started in tests are properly terminated

### DIFF
--- a/apps/ewallet/test/ewallet/fetchers/transaction_consumption_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/transaction_consumption_fetcher_test.exs
@@ -11,7 +11,12 @@ defmodule EWallet.TransactionConsumptionFetcherTest do
   alias EWalletDB.{User, TransactionConsumption}
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    {:ok, pid} = TestEndpoint.start_link()
+
+    on_exit fn ->
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, _, _, _}
+    end
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/fetchers/transaction_consumption_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/transaction_consumption_fetcher_test.exs
@@ -13,10 +13,10 @@ defmodule EWallet.TransactionConsumptionFetcherTest do
   setup do
     {:ok, pid} = TestEndpoint.start_link()
 
-    on_exit fn ->
+    on_exit(fn ->
       ref = Process.monitor(pid)
       assert_receive {:DOWN, ^ref, _, _, _}
-    end
+    end)
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
@@ -13,7 +13,12 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
   alias EWalletDB.{User, TransactionConsumption, TransactionRequest}
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    {:ok, pid} = TestEndpoint.start_link()
+
+    on_exit fn ->
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, _, _, _}
+    end
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
@@ -15,10 +15,10 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
   setup do
     {:ok, pid} = TestEndpoint.start_link()
 
-    on_exit fn ->
+    on_exit(fn ->
       ref = Process.monitor(pid)
       assert_receive {:DOWN, ^ref, _, _, _}
-    end
+    end)
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -10,7 +10,12 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
   alias EWalletDB.{User, TransactionConsumption, TransactionRequest}
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    {:ok, pid} = TestEndpoint.start_link()
+
+    on_exit fn ->
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, _, _, _}
+    end
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -12,10 +12,10 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
   setup do
     {:ok, pid} = TestEndpoint.start_link()
 
-    on_exit fn ->
+    on_exit(fn ->
       ref = Process.monitor(pid)
       assert_receive {:DOWN, ^ref, _, _, _}
-    end
+    end)
 
     token = insert(:token)
     {:ok, receiver} = :user |> params_for() |> User.insert()

--- a/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
+++ b/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
@@ -6,7 +6,13 @@ defmodule EWallet.TransactionConsumptionSchedulerTest do
   alias Phoenix.Socket.Broadcast
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    {:ok, pid} = TestEndpoint.start_link()
+    
+    on_exit fn ->
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, _, _, _}
+    end
+
     :ok
   end
 

--- a/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
+++ b/apps/ewallet/test/ewallet/schedulers/transaction_consumption_scheduler_test.exs
@@ -7,11 +7,11 @@ defmodule EWallet.TransactionConsumptionSchedulerTest do
 
   setup do
     {:ok, pid} = TestEndpoint.start_link()
-    
-    on_exit fn ->
+
+    on_exit(fn ->
       ref = Process.monitor(pid)
       assert_receive {:DOWN, ^ref, _, _, _}
-    end
+    end)
 
     :ok
   end

--- a/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
+++ b/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
@@ -57,10 +57,10 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     setup do
       {:ok, pid} = TestEndpoint.start_link()
 
-      on_exit fn ->
+      on_exit(fn ->
         ref = Process.monitor(pid)
         assert_receive {:DOWN, ^ref, _, _, _}
-      end
+      end)
 
       :ok
     end

--- a/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
+++ b/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
@@ -54,6 +54,17 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
   end
 
   describe "validate_before_confirmation/2" do
+    setup do
+      {:ok, pid} = TestEndpoint.start_link()
+
+      on_exit fn ->
+        ref = Process.monitor(pid)
+        assert_receive {:DOWN, ^ref, _, _, _}
+      end
+
+      :ok
+    end
+
     test "returns not_transaction_request_owner if the request is not owned by user" do
       {:ok, user} = :user |> params_for() |> User.insert()
       consumption = :transaction_consumption |> insert() |> Repo.preload([:transaction_request])
@@ -125,8 +136,6 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     end
 
     test "returns max_consumptions_per_user_reached if the max has been reached" do
-      {:ok, _} = TestEndpoint.start_link()
-
       {:ok, user_1} = :user |> params_for() |> User.insert()
       {:ok, user_2} = :user |> params_for() |> User.insert()
       wallet = User.get_primary_wallet(user_2)
@@ -167,8 +176,6 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     end
 
     test "expires consumption if past expiration" do
-      {:ok, _} = TestEndpoint.start_link()
-
       now = NaiveDateTime.utc_now()
       {:ok, user} = :user |> params_for() |> User.insert()
       request = insert(:transaction_request, account_uuid: nil, user_uuid: user.uuid)
@@ -189,8 +196,6 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     end
 
     test "returns expired_transaction_consumption if the consumption has expired" do
-      {:ok, _} = TestEndpoint.start_link()
-
       {:ok, user} = :user |> params_for() |> User.insert()
       request = insert(:transaction_request, account_uuid: nil, user_uuid: user.uuid)
 
@@ -207,8 +212,6 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
     end
 
     test "returns the consumption if valid" do
-      {:ok, _} = TestEndpoint.start_link()
-
       {:ok, user} = :user |> params_for() |> User.insert()
       request = insert(:transaction_request, account_uuid: nil, user_uuid: user.uuid)
 

--- a/apps/ewallet/test/ewallet/web/v1/event_handlers/event_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/event_handlers/event_test.exs
@@ -7,12 +7,14 @@ defmodule EWallet.Web.V1.EventTest do
 
   setup do
     Logger.configure(level: :info)
+    {:ok, pid} = TestEndpoint.start_link()
 
     on_exit(fn ->
       Logger.configure(level: :warn)
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, _, _, _}
     end)
 
-    {:ok, _} = TestEndpoint.start_link()
     :ok
   end
 

--- a/apps/ewallet/test/ewallet/web/v1/event_handlers/transaction_consumption_confirmation_event_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/event_handlers/transaction_consumption_confirmation_event_test.exs
@@ -5,7 +5,13 @@ defmodule EWallet.Web.V1.TransactionConsumptionEventHandlerTest do
   alias EWalletDB.Repo
 
   setup do
-    {:ok, _} = TestEndpoint.start_link()
+    {:ok, pid} = TestEndpoint.start_link()
+
+    on_exit(fn ->
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, _, _, _}
+    end)
+
     :ok
   end
 


### PR DESCRIPTION
Issue/Task Number: T383

# Overview

Because the way ExUnit works, and with processes being decoupled from tests, we sometimes have race conditions where processes are still running. This PR adds a check to ensure a process has stopped running (or else will wait for it) after each test. If this doesn't fix all the tests, we'll change the `async` option to `false`.

```
 1) test consume/1 with invalid parameters with invalid parameters (EWallet.TransactionConsumptionConsumerGateTest)
     test/ewallet/gates/transaction_consumption_consumer_gate_test.exs:391
     ** (MatchError) no match of right hand side value: {:error, {:already_started, #PID<0.11737.0>}}
     stacktrace:
       test/ewallet/gates/transaction_consumption_consumer_gate_test.exs:13: EWallet.TransactionConsumptionConsumerGateTest.__ex_unit_setup_1/1
       test/ewallet/gates/transaction_consumption_consumer_gate_test.exs:1: EWallet.TransactionConsumptionConsumerGateTest.__ex_unit__/2

..................................................................................................
```

I attempted to extract the calls in a function (in one of the cases) but had weird errors, so I ended up putting the receive in each file since it's only used once per file.

# Changes

- Add `assert_receive {:DOWN, ^ref, _, _, _}` on the processes started in tests
