### PR TITLE
Fix `Account.put_categories/3` to support both atom and string attribute keys

### DIFF
--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -97,16 +97,27 @@ defmodule EWalletDB.Account do
     |> put_categories(attrs, :category_ids)
   end
 
-  defp put_categories(changeset, attrs, attr_name) do
-    case attrs[attr_name] do
-      ids when is_list(ids) ->
-        categories = Repo.all(from(c in Category, where: c.id in ^attrs[attr_name]))
-        put_assoc(changeset, :categories, categories)
-
-      nil ->
-        changeset
-    end
+  # Since the attribute key could be either an atom or string, the two functions below
+  # are created to support both types.
+  defp put_categories(changeset, attrs, attr_name) when is_atom(attr_name) do
+    category_ids = Map.get(attrs, attr_name) || Map.get(attrs, to_string(attr_name))
+    put_categories(changeset, category_ids)
   end
+
+  defp put_categories(changeset, attrs, attr_name) when is_binary(attr_name) do
+    category_ids = Map.get(attrs, attr_name) || Map.get(attrs, String.to_existing_atom(attr_name))
+    put_categories(changeset, category_ids)
+  end
+
+  defp put_categories(changeset, category_ids) when is_list(category_ids) do
+    # Associations need to be preloaded before updating
+    changeset = Map.put(changeset, :data, Repo.preload(changeset.data, :categories))
+    categories = Repo.all(from(c in Category, where: c.id in ^category_ids))
+    put_assoc(changeset, :categories, categories)
+  end
+
+  # Categories are not updated if nil is passed
+  defp put_categories(changeset, nil), do: changeset
 
   @spec avatar_changeset(changeset :: Ecto.Changeset.t() | %Account{}, attrs :: map()) ::
           Ecto.Changeset.t() | no_return()


### PR DESCRIPTION
Issue/Task Number: T392

# Overview

This PR fixes the issue that `/account.update` does not update account categories even though category_ids are passed.

# Changes

- Update `Account.put_categories/3` to support both string and atom keys in attributes

# Usage

Try update account categories by passing a different `category_ids` during `/account.update`
