### PR TITLE
/category.update to support updating account_ids

### DIFF
--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -102,6 +102,7 @@ defmodule EWalletDB.Account do
     case InputAttribute.get(attrs, attr_name) do
       ids when is_list(ids) ->
         put_categories(changeset, ids)
+
       _ ->
         changeset
     end

--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -9,6 +9,7 @@ defmodule EWalletDB.Account do
   import EWalletDB.{AccountValidator, Helpers.Preloader}
   alias Ecto.{Multi, UUID}
   alias EWalletDB.{Repo, Account, APIKey, Category, Key, Membership, Token, Wallet}
+  alias EWalletDB.Helpers.InputAttribute
 
   @primary_key {:uuid, UUID, autogenerate: true}
 
@@ -97,27 +98,21 @@ defmodule EWalletDB.Account do
     |> put_categories(attrs, :category_ids)
   end
 
-  # Since the attribute key could be either an atom or string, the two functions below
-  # are created to support both types.
-  defp put_categories(changeset, attrs, attr_name) when is_atom(attr_name) do
-    category_ids = Map.get(attrs, attr_name) || Map.get(attrs, to_string(attr_name))
-    put_categories(changeset, category_ids)
+  defp put_categories(changeset, attrs, attr_name) do
+    case InputAttribute.get(attrs, attr_name) do
+      ids when is_list(ids) ->
+        put_categories(changeset, ids)
+      _ ->
+        changeset
+    end
   end
 
-  defp put_categories(changeset, attrs, attr_name) when is_binary(attr_name) do
-    category_ids = Map.get(attrs, attr_name) || Map.get(attrs, String.to_existing_atom(attr_name))
-    put_categories(changeset, category_ids)
-  end
-
-  defp put_categories(changeset, category_ids) when is_list(category_ids) do
+  defp put_categories(changeset, category_ids) do
     # Associations need to be preloaded before updating
     changeset = Map.put(changeset, :data, Repo.preload(changeset.data, :categories))
     categories = Repo.all(from(c in Category, where: c.id in ^category_ids))
     put_assoc(changeset, :categories, categories)
   end
-
-  # Categories are not updated if nil is passed
-  defp put_categories(changeset, nil), do: changeset
 
   @spec avatar_changeset(changeset :: Ecto.Changeset.t() | %Account{}, attrs :: map()) ::
           Ecto.Changeset.t() | no_return()

--- a/apps/ewallet_db/lib/ewallet_db/category.ex
+++ b/apps/ewallet_db/lib/ewallet_db/category.ex
@@ -42,6 +42,7 @@ defmodule EWalletDB.Category do
     case InputAttribute.get(attrs, attr_name) do
       ids when is_list(ids) ->
         put_accounts(changeset, ids)
+
       _ ->
         changeset
     end

--- a/apps/ewallet_db/lib/ewallet_db/helpers/input_attribute.ex
+++ b/apps/ewallet_db/lib/ewallet_db/helpers/input_attribute.ex
@@ -1,0 +1,19 @@
+defmodule EWalletDB.Helpers.InputAttribute do
+  @moduledoc """
+  Helper functions to deal with input attributes.
+  """
+
+  @doc """
+  Get an input attribute by name.
+
+  The name and the input key can be agnostically either an atom or string.
+  """
+  @spec get(map(), atom() | String.t()) :: any()
+  def get(attrs, attr_name) when is_atom(attr_name) do
+    Map.get(attrs, attr_name) || Map.get(attrs, to_string(attr_name))
+  end
+
+  def get(attrs, attr_name) when is_binary(attr_name) do
+    Map.get(attrs, attr_name) || Map.get(attrs, String.to_existing_atom(attr_name))
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/account_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/account_test.exs
@@ -91,7 +91,7 @@ defmodule EWalletDB.AccountTest do
 
   describe "update/2 with category_ids" do
     test "associates the category if it's been added to category_ids" do
-      # Prepare 4 categories. We will start of the account with 2, add 1, and leave one behind.
+      # Prepare 4 categories. We will start off the account with 2, add 1, and leave one behind.
       [cat1, cat2, cat3, _not_used] = insert_list(4, :category)
 
       {:ok, account} =
@@ -141,7 +141,7 @@ defmodule EWalletDB.AccountTest do
       # Make sure that the account has 2 categories
       assert_categories(account, [cat1, cat2])
 
-      # Now update by removing a category from category_ids
+      # Now update by setting category_ids to an empty list
       {:ok, updated} = Account.update(account, %{category_ids: []})
 
       # No category should be left

--- a/apps/ewallet_db/test/ewallet_db/category_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/category_test.exs
@@ -121,8 +121,8 @@ defmodule EWalletDB.CategoryTest do
         |> Enum.map(fn account -> account.id end)
 
       assert Enum.all?(expected, fn account ->
-        account.id in actual_account_ids
-      end)
+               account.id in actual_account_ids
+             end)
 
       assert Enum.count(actual_account_ids) == Enum.count(expected)
     end

--- a/apps/ewallet_db/test/ewallet_db/category_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/category_test.exs
@@ -35,6 +35,99 @@ defmodule EWalletDB.CategoryTest do
     test_update_field_ok(Category, :description)
   end
 
+  describe "update/2 with account_ids" do
+    test "associates the account if it's been added to account_ids" do
+      # Prepare 4 accounts. We will start off the category with 2, add 1, and leave one behind.
+      [acc1, acc2, acc3, _not_used] = insert_list(4, :account)
+
+      {:ok, category} =
+        :category
+        |> params_for()
+        |> Map.put(:account_ids, [acc1.id, acc2.id])
+        |> Category.insert()
+
+      # Make sure that the category has 2 accounts
+      assert_accounts(category, [acc1, acc2])
+
+      # Now update with additional account_ids
+      {:ok, updated} = Category.update(category, %{account_ids: [acc1.id, acc2.id, acc3.id]})
+
+      # Assert that the 3rd account is added
+      assert_accounts(updated, [acc1, acc2, acc3])
+    end
+
+    test "removes the account if it's no longer in the account_ids" do
+      [acc1, acc2] = insert_list(2, :account)
+
+      {:ok, category} =
+        :category
+        |> params_for()
+        |> Map.put(:account_ids, [acc1.id, acc2.id])
+        |> Category.insert()
+
+      # Make sure that the category has 2 accounts
+      assert_accounts(category, [acc1, acc2])
+
+      # Now update by removing a account from category_ids
+      {:ok, updated} = Category.update(category, %{account_ids: [acc1.id]})
+
+      # Only one account should be left
+      assert_accounts(updated, [acc1])
+    end
+
+    test "removes all accounts if account_ids is an empty list" do
+      [acc1, acc2] = insert_list(2, :account)
+
+      {:ok, category} =
+        :category
+        |> params_for()
+        |> Map.put(:account_ids, [acc1.id, acc2.id])
+        |> Category.insert()
+
+      # Make sure that the category has 2 accounts
+      assert_accounts(category, [acc1, acc2])
+
+      # Now update by setting account_ids to an empty list
+      {:ok, updated} = Category.update(category, %{account_ids: []})
+
+      # No category should be left
+      assert_accounts(updated, [])
+    end
+
+    test "does nothing if account_ids is nil" do
+      [acc1, acc2] = insert_list(2, :account)
+
+      {:ok, category} =
+        :category
+        |> params_for()
+        |> Map.put(:account_ids, [acc1.id, acc2.id])
+        |> Category.insert()
+
+      # Make sure that the category has 2 accounts
+      assert_accounts(category, [acc1, acc2])
+
+      # Now update by passing a nil account_ids
+      {:ok, updated} = Category.update(category, %{account_ids: nil})
+
+      # The categories should remain the same
+      assert_accounts(updated, [acc1, acc2])
+    end
+
+    defp assert_accounts(category, expected) do
+      actual_account_ids =
+        category
+        |> Repo.preload(:accounts)
+        |> Map.get(:accounts)
+        |> Enum.map(fn account -> account.id end)
+
+      assert Enum.all?(expected, fn account ->
+        account.id in actual_account_ids
+      end)
+
+      assert Enum.count(actual_account_ids) == Enum.count(expected)
+    end
+  end
+
   describe "deleted?/1" do
     test_deleted_checks_nil_deleted_at(Category)
   end

--- a/apps/ewallet_db/test/ewallet_db/helpers/input_attribute_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/helpers/input_attribute_test.exs
@@ -1,0 +1,22 @@
+defmodule EWalletDB.Helpers.InputAttributeTest do
+  use ExUnit.Case
+  alias EWalletDB.Helpers.InputAttribute
+
+  describe "get/2" do
+    test "returns the value if the map key is atom and argument is atom" do
+      assert InputAttribute.get(%{match: "matched"}, :match) == "matched"
+    end
+
+    test "returns the value if the map key is string and argument is atom" do
+      assert InputAttribute.get(%{"match" => "matched"}, :match) == "matched"
+    end
+
+    test "returns the value if the map key is string and argument is string" do
+      assert InputAttribute.get(%{"match" => "matched"}, "match") == "matched"
+    end
+
+    test "returns the value if the map key is atom and argument is string" do
+      assert InputAttribute.get(%{match: "matched"}, "match") == "matched"
+    end
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T402

# Overview

This PR adds support for `/category.update` to update its associated accounts by passing `account_ids`

# Changes

- Implemented `Category.put_accounts/3` and attach it to `Category.changeset/2`
- Refactored attribute retrieval into `EWalletDB.Helpers.InputAttribute.get/2`

# Implementation Details

This is basically the same implementation as the existing [`Account.put_categories/3`](https://github.com/omisego/ewallet/blob/develop/apps/ewallet_db/lib/ewallet_db/account.ex#L102-L120) but the other way around.

Also since the string/atom attribute retrieval is now used in multiple places, I refactored it into `EWalletDB.Helpers.InputAttribute.get/2`.

# Usage

Make a request to `/category.update` with `{"account_ids": [], ...}`
