### PR TITLE
Fix transaction calculation fail

### DIFF
--- a/apps/local_ledger_db/lib/local_ledger_db/transaction.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/transaction.ex
@@ -96,8 +96,10 @@ defmodule LocalLedgerDB.Transaction do
   end
 
   defp subtract(credits, debits) do
-    Enum.map(credits, fn {id, amount} ->
-      {id, amount - (debits[id] || 0)}
+    tokens = Enum.uniq(Map.keys(credits) ++ Map.keys(debits))
+
+    Enum.map(tokens, fn token ->
+      {token, (credits[token] || 0) - (debits[token] || 0)}
     end)
   end
 

--- a/apps/local_ledger_db/test/local_ledger_db/transaction_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/transaction_test.exs
@@ -198,6 +198,18 @@ defmodule LocalLedgerDB.TransactionTest do
       assert wallets == %{"tok_BTC_789" => 300, "tok_KNC_456" => 100, "tok_OMG_123" => 700}
     end
 
+    test "works even if the wallet only had debits" do
+      {:ok, balance} = :wallet |> build |> Repo.insert()
+      {:ok, omg} = :token |> build(id: "tok_OMG_123") |> Repo.insert()
+
+      transfer(balance, omg, 100, Transaction.debit_type())
+      transfer(balance, omg, 300, Transaction.debit_type())
+      transfer(balance, omg, 500, Transaction.debit_type())
+
+      wallets = Transaction.calculate_all_balances(balance.address)
+      assert wallets == %{"tok_OMG_123" => -900}
+    end
+
     test "returns the correct balance for the specified token" do
       {:ok, balance} = :wallet |> build |> Repo.insert()
       {:ok, omg} = :token |> build(id: "tok_OMG_123") |> Repo.insert()


### PR DESCRIPTION
Issue/Task Number: T416

# Overview

There was a problem in the way balances were calculated - if no credits ever happened, it would fail. For most cases, that was fine since you can't spend money you haven't received, but due to the possibility of passing `since: date` to that function, it was failing if only debits happened after `date`.
 
This PR fixes it!
