### PR TITLE
addressing dialyzer reported issues

### DIFF
--- a/.dialyzer_ignore
+++ b/.dialyzer_ignore
@@ -26,8 +26,7 @@ Function run/1 has no local return
 Function configure_no_halt/1 will never be called
 Callback info about the 'Elixir.Mix.Task' behaviour is not available
 Function run/1 has no local return
-apps/ewallet_db/lib/ewallet_db/account.ex:122: The pattern 'invalid' can never match the type #{'avatar':=_}
-apps/ewallet_db/lib/ewallet_db/account.ex:122: The pattern #{'__struct__':='Elixir.Ecto.Changeset'} can never match the type #{'__struct__':='Elixir.EWalletDB.Account', _=>_}
-apps/ewallet_db/lib/ewallet_db/user.ex:112: The pattern 'invalid' can never match the type #{'avatar':=_}
-apps/ewallet_db/lib/ewallet_db/user.ex:112: The pattern #{'__struct__':='Elixir.Ecto.Changeset'} can never match the type #{'__struct__':='Elixir.EWalletDB.User', _=>_}
-apps/admin_api/lib/admin_api/mailer.ex:5: Function deliver/1 only terminates with explicit exception
+The pattern #{'__struct__':='Elixir.Ecto.Changeset'} can never match the type #{'__struct__':='Elixir.EWalletDB.Account', _=>_}
+The pattern 'invalid' can never match the type #{'avatar':=_}
+The pattern #{'__struct__':='Elixir.Ecto.Changeset'} can never match the type #{'__struct__':='Elixir.EWalletDB.User', _=>_}
+Function deliver/1 only terminates with explicit exception

--- a/.dialyzer_ignore
+++ b/.dialyzer_ignore
@@ -11,8 +11,23 @@ Unknown type 'Elixir.Ecto.UUID':t/0
 Unknown type 'Elixir.Integer':t/0
 Unknown type 'Elixir.List':t/0
 Unknown type 'Elixir.Map':t/0
+Unknown type 'Elixir.Balance':t/0
+Unknown type 'Elixir.EWalletDB.Token':t/0
+Unknown type 'Elixir.EWalletDB.TransactionConsumption':t/0
+Unknown type 'Elixir.EWalletDB.TransactionRequest':t/0
+Unknown type 'Elixir.EWalletDB.User':t/0
+Unknown type 'Elixir.EWalletDB.Wallet':t/0
+Unknown type 'Elixir.ExternalID':t/0
+Unknown type 'Elixir.LocalLedgerDB.Wallet':t/0
+Unknown type 'Elixir.UUID':t/0
+Unknown type 'Elixir.User':t/0
 Function 'iex_running?'/0 will never be called
 Function run/1 has no local return
 Function configure_no_halt/1 will never be called
 Callback info about the 'Elixir.Mix.Task' behaviour is not available
 Function run/1 has no local return
+apps/ewallet_db/lib/ewallet_db/account.ex:122: The pattern 'invalid' can never match the type #{'avatar':=_}
+apps/ewallet_db/lib/ewallet_db/account.ex:122: The pattern #{'__struct__':='Elixir.Ecto.Changeset'} can never match the type #{'__struct__':='Elixir.EWalletDB.Account', _=>_}
+apps/ewallet_db/lib/ewallet_db/user.ex:112: The pattern 'invalid' can never match the type #{'avatar':=_}
+apps/ewallet_db/lib/ewallet_db/user.ex:112: The pattern #{'__struct__':='Elixir.Ecto.Changeset'} can never match the type #{'__struct__':='Elixir.EWalletDB.User', _=>_}
+apps/admin_api/lib/admin_api/mailer.ex:5: Function deliver/1 only terminates with explicit exception

--- a/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
@@ -61,7 +61,7 @@ defmodule AdminAPI.V1.AccountController do
   def get(conn, %{"id" => id}) do
     with :ok <- permit(:get, conn.assigns.admin_user.id, id),
          %Account{} = account <- Account.get_by(id: id),
-         account <- Preloader.preload_one(account, @preload_fields) do
+         {:ok, account} <- Preloader.preload_one(account, @preload_fields) do
       render(conn, :account, %{account: account})
     else
       {:error, code} ->
@@ -88,7 +88,7 @@ defmodule AdminAPI.V1.AccountController do
     with :ok <- permit(:create, conn.assigns.admin_user.id, parent.id),
          attrs <- Map.put(attrs, "parent_uuid", parent.uuid),
          {:ok, account} <- Account.insert(attrs),
-         account <- Preloader.preload_one(account, @preload_fields) do
+         {:ok, account} <- Preloader.preload_one(account, @preload_fields) do
       render(conn, :account, %{account: account})
     else
       {:error, %{} = changeset} ->
@@ -108,7 +108,7 @@ defmodule AdminAPI.V1.AccountController do
     with :ok <- permit(:update, conn.assigns.admin_user.id, account_id),
          %{} = original <- Account.get(account_id) || {:error, :account_id_not_found},
          {:ok, updated} <- Account.update(original, attrs),
-         updated <- Preloader.preload_one(updated, @preload_fields) do
+         {:ok, updated} <- Preloader.preload_one(updated, @preload_fields) do
       render(conn, :account, %{account: updated})
     else
       {:error, %{} = changeset} ->
@@ -128,7 +128,7 @@ defmodule AdminAPI.V1.AccountController do
     with :ok <- permit(:update, conn.assigns.admin_user.id, id),
          %{} = account <- Account.get(id) || {:error, :account_id_not_found},
          %{} = saved <- Account.store_avatar(account, attrs),
-         %{} = saved <- Preloader.preload_one(saved, @preload_fields) do
+         {:ok, saved} <- Preloader.preload_one(saved, @preload_fields) do
       render(conn, :account, %{account: saved})
     else
       nil ->

--- a/apps/admin_api/lib/admin_api/v1/controllers/admin_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/admin_controller.ex
@@ -61,11 +61,6 @@ defmodule AdminAPI.V1.AdminController do
     render(conn, UserView, :user, %{user: user})
   end
 
-  # Responds when the given params were invalid
-  defp respond_single({:error, changeset}, conn) do
-    handle_error(conn, :invalid_parameter, changeset)
-  end
-
   # Responds when the admin is not found
   defp respond_single(nil, conn) do
     handle_error(conn, :user_id_not_found)

--- a/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
@@ -27,10 +27,6 @@ defmodule AdminAPI.V1.CategoryController do
   # If the request provides different names, map it via `@mapped_fields` first.
   @sort_fields [:id, :name, :description, :inserted_at, :updated_at]
 
-  defp permit(action, user_id, category_id) do
-    Bodyguard.permit(CategoryPolicy, action, user_id, category_id)
-  end
-
   @doc """
   Retrieves a list of categories.
   """
@@ -68,6 +64,10 @@ defmodule AdminAPI.V1.CategoryController do
       {:error, code} ->
         handle_error(conn, code)
 
+      changeset when is_list(changeset) ->
+        # preloader returned more then one record
+        handle_error(conn, :internal_server_error)
+
       nil ->
         handle_error(conn, :category_id_not_found)
     end
@@ -84,6 +84,10 @@ defmodule AdminAPI.V1.CategoryController do
     else
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
+
+      changeset when is_list(changeset) ->
+        # preloader returned more then one record
+        handle_error(conn, :internal_server_error)
 
       {:error, code} ->
         handle_error(conn, code)
@@ -102,6 +106,10 @@ defmodule AdminAPI.V1.CategoryController do
     else
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
+
+      changeset when is_list(changeset) ->
+        # preloader returned more then one record
+        handle_error(conn, :internal_server_error)
 
       {:error, code} ->
         handle_error(conn, code)
@@ -122,10 +130,20 @@ defmodule AdminAPI.V1.CategoryController do
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
 
+      changeset when is_list(changeset) ->
+        # preloader returned more then one record
+        handle_error(conn, :internal_server_error)
+
       {:error, code} ->
         handle_error(conn, code)
     end
   end
 
   def delete(conn, _), do: handle_error(conn, :invalid_parameter)
+
+  @spec permit(:all | :create | :get | :update, any(), any()) ::
+          :ok | {:error, any()} | no_return()
+  defp permit(action, user_id, category_id) do
+    Bodyguard.permit(CategoryPolicy, action, user_id, category_id)
+  end
 end

--- a/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
@@ -58,7 +58,7 @@ defmodule AdminAPI.V1.CategoryController do
   def get(conn, %{"id" => id}) do
     with :ok <- permit(:get, conn.assigns.admin_user.id, id),
          %Category{} = category <- Category.get_by(id: id),
-         %Category{} = category <- Preloader.preload_one(category, @preload_fields) do
+         {:ok, category} <- Preloader.preload_one(category, @preload_fields) do
       render(conn, :category, %{category: category})
     else
       {:error, code} ->
@@ -75,7 +75,7 @@ defmodule AdminAPI.V1.CategoryController do
   def create(conn, attrs) do
     with :ok <- permit(:create, conn.assigns.admin_user.id, nil),
          {:ok, category} <- Category.insert(attrs),
-         %Category{} = category <- Preloader.preload_one(category, @preload_fields) do
+         {:ok, category} <- Preloader.preload_one(category, @preload_fields) do
       render(conn, :category, %{category: category})
     else
       {:error, %{} = changeset} ->
@@ -93,7 +93,7 @@ defmodule AdminAPI.V1.CategoryController do
     with :ok <- permit(:update, conn.assigns.admin_user.id, id),
          %Category{} = original <- Category.get(id) || {:error, :category_id_not_found},
          {:ok, updated} <- Category.update(original, attrs),
-         %Category{} = updated <- Preloader.preload_one(updated, @preload_fields) do
+         {:ok, updated} <- Preloader.preload_one(updated, @preload_fields) do
       render(conn, :category, %{category: updated})
     else
       {:error, %{} = changeset} ->
@@ -112,7 +112,7 @@ defmodule AdminAPI.V1.CategoryController do
   def delete(conn, %{"id" => id}) do
     with %Category{} = category <- Category.get(id) || {:error, :category_id_not_found},
          {:ok, deleted} = Category.delete(category),
-         %Category{} = deleted <- Preloader.preload_one(deleted, @preload_fields) do
+         {:ok, deleted} <- Preloader.preload_one(deleted, @preload_fields) do
       render(conn, :category, %{category: deleted})
     else
       {:error, %{} = changeset} ->

--- a/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
@@ -58,15 +58,11 @@ defmodule AdminAPI.V1.CategoryController do
   def get(conn, %{"id" => id}) do
     with :ok <- permit(:get, conn.assigns.admin_user.id, id),
          %Category{} = category <- Category.get_by(id: id),
-         %Category{} = category <- Preloader.preload(category, @preload_fields) do
+         %Category{} = category <- Preloader.preload_one(category, @preload_fields) do
       render(conn, :category, %{category: category})
     else
       {:error, code} ->
         handle_error(conn, code)
-
-      changeset when is_list(changeset) ->
-        # preloader returned more then one record
-        handle_error(conn, :internal_server_error)
 
       nil ->
         handle_error(conn, :category_id_not_found)
@@ -79,15 +75,11 @@ defmodule AdminAPI.V1.CategoryController do
   def create(conn, attrs) do
     with :ok <- permit(:create, conn.assigns.admin_user.id, nil),
          {:ok, category} <- Category.insert(attrs),
-         %Category{} = category <- Preloader.preload(category, @preload_fields) do
+         %Category{} = category <- Preloader.preload_one(category, @preload_fields) do
       render(conn, :category, %{category: category})
     else
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
-
-      changeset when is_list(changeset) ->
-        # preloader returned more then one record
-        handle_error(conn, :internal_server_error)
 
       {:error, code} ->
         handle_error(conn, code)
@@ -101,15 +93,11 @@ defmodule AdminAPI.V1.CategoryController do
     with :ok <- permit(:update, conn.assigns.admin_user.id, id),
          %Category{} = original <- Category.get(id) || {:error, :category_id_not_found},
          {:ok, updated} <- Category.update(original, attrs),
-         %Category{} = updated <- Preloader.preload(updated, @preload_fields) do
+         %Category{} = updated <- Preloader.preload_one(updated, @preload_fields) do
       render(conn, :category, %{category: updated})
     else
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
-
-      changeset when is_list(changeset) ->
-        # preloader returned more then one record
-        handle_error(conn, :internal_server_error)
 
       {:error, code} ->
         handle_error(conn, code)
@@ -124,15 +112,11 @@ defmodule AdminAPI.V1.CategoryController do
   def delete(conn, %{"id" => id}) do
     with %Category{} = category <- Category.get(id) || {:error, :category_id_not_found},
          {:ok, deleted} = Category.delete(category),
-         %Category{} = deleted <- Preloader.preload(deleted, @preload_fields) do
+         %Category{} = deleted <- Preloader.preload_one(deleted, @preload_fields) do
       render(conn, :category, %{category: deleted})
     else
       {:error, %{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
-
-      changeset when is_list(changeset) ->
-        # preloader returned more then one record
-        handle_error(conn, :internal_server_error)
 
       {:error, code} ->
         handle_error(conn, code)

--- a/apps/admin_api/lib/admin_api/v1/controllers/mint_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/mint_controller.ex
@@ -70,10 +70,6 @@ defmodule AdminAPI.V1.MintController do
     handle_error(conn, :invalid_parameter, changeset)
   end
 
-  defp respond_single({:error, code, description}, conn) do
-    handle_error(conn, code, description)
-  end
-
   defp respond_single({:ok, mint, _token}, conn) do
     render(conn, :mint, %{mint: mint})
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/status_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/status_controller.ex
@@ -5,6 +5,7 @@ defmodule AdminAPI.V1.StatusController do
     json(conn, %{success: true})
   end
 
+  @spec server_error(any(), any()) :: no_return()
   def server_error(_conn, _attrs) do
     raise "Mock server error"
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -107,10 +107,6 @@ defmodule AdminAPI.V1.TokenController do
     handle_error(conn, :invalid_parameter, changeset)
   end
 
-  defp respond_single({:error, code, description}, conn) do
-    handle_error(conn, code, description)
-  end
-
   defp respond_single({:ok, _mint, token}, conn) do
     render(conn, :token, %{token: token})
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -1,6 +1,7 @@
 defmodule AdminAPI.V1.TransactionConsumptionController do
   use AdminAPI, :controller
-  use EWallet.Web.Embedder
+  alias EWallet.Web.Embedder
+  @behaviour EWallet.Web.Embedder
   import AdminAPI.V1.ErrorHandler
 
   alias EWallet.{
@@ -13,11 +14,11 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
 
   # The fields that are allowed to be embedded.
   # These fields must be one of the schema's association names.
-  @embeddable [:account, :token, :transaction, :transaction_request, :user]
+  def embeddable(), do: [:account, :token, :transaction, :transaction_request, :user]
 
-  # The fields in `@embeddable` that are embedded regardless of the request.
+  # The fields returned by `embeddable/0` are embedded regardless of the request.
   # These fields must be one of the schema's association names.
-  @always_embed [:token]
+  def always_embed(), do: [:token]
 
   def consume(conn, %{"idempotency_token" => idempotency_token} = attrs)
       when idempotency_token != nil do
@@ -56,7 +57,7 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
     dispatch_confirm_event(consumption)
 
     render(conn, :transaction_consumption, %{
-      transaction_consumption: embed(consumption, conn.body_params["embed"])
+      transaction_consumption: Embedder.embed(__MODULE__, consumption, conn.body_params["embed"])
     })
   end
 

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -14,11 +14,11 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
 
   # The fields that are allowed to be embedded.
   # These fields must be one of the schema's association names.
-  def embeddable(), do: [:account, :token, :transaction, :transaction_request, :user]
+  def embeddable, do: [:account, :token, :transaction, :transaction_request, :user]
 
   # The fields returned by `embeddable/0` are embedded regardless of the request.
   # These fields must be one of the schema's association names.
-  def always_embed(), do: [:token]
+  def always_embed, do: [:token]
 
   def consume(conn, %{"idempotency_token" => idempotency_token} = attrs)
       when idempotency_token != nil do

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -47,10 +47,6 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
     handle_error(conn, :invalid_parameter, changeset)
   end
 
-  defp respond({:error, code, description}, conn) do
-    handle_error(conn, code, description)
-  end
-
   defp respond({:error, consumption, code, description}, conn) do
     dispatch_confirm_event(consumption)
     handle_error(conn, code, description)

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
@@ -19,7 +19,6 @@ defmodule AdminAPI.V1.TransactionRequestController do
     |> respond(conn)
   end
 
-  defp respond(nil, conn), do: handle_error(conn, :transaction_request_not_found)
   defp respond({:error, error}, conn) when is_atom(error), do: handle_error(conn, error)
 
   defp respond({:error, changeset}, conn) do

--- a/apps/ewallet/lib/ewallet/cli.ex
+++ b/apps/ewallet/lib/ewallet/cli.ex
@@ -23,6 +23,7 @@ defmodule EWallet.CLI do
 
   def print(message), do: Docs.print(message, width: 100)
 
+  @spec halt(any()) :: no_return()
   def halt(message) do
     error(message)
     System.halt(1)

--- a/apps/ewallet/lib/ewallet/gates/mint_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/mint_gate.ex
@@ -23,7 +23,6 @@ defmodule EWallet.MintGate do
     |> insert()
     |> case do
       {:ok, mint, _entry} -> {:ok, mint, token}
-      {:error, code, description} -> {:error, code, description}
       {:error, changeset} -> {:error, changeset}
     end
   end
@@ -51,9 +50,6 @@ defmodule EWallet.MintGate do
         # Everything went well, do something.
         # response is the response returned by the local ledger (LocalLedger for
         # example).
-      {:error, code, description} ->
-        # Something went wrong on the other side (LocalLedger maybe) and the
-        # insert failed.
       {:error, changeset} ->
         # Something went wrong, check the errors in the changeset!
     end
@@ -99,6 +95,9 @@ defmodule EWallet.MintGate do
     case Repo.transaction(multi) do
       {:ok, result} ->
         process_with_transfer(result.transfer, result.mint_with_transfer)
+
+      {:error, _changeset} = error ->
+        error
 
       {:error, _failed_operation, changeset, _changes_so_far} ->
         {:error, changeset}

--- a/apps/ewallet/lib/ewallet/gates/transaction_consumption_confirmer_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_consumption_confirmer_gate.ex
@@ -33,7 +33,8 @@ defmodule EWallet.TransactionConsumptionConfirmerGate do
 
     case transaction do
       {:ok, res} -> res
-      {:error, error} -> {:error, error}
+      {:error, _changeset} = error -> error
+      {:error, _, changeset, _} -> {:error, changeset}
     end
   end
 

--- a/apps/ewallet/lib/ewallet/gates/transaction_consumption_consumer_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_consumption_consumer_gate.ex
@@ -121,7 +121,8 @@ defmodule EWallet.TransactionConsumptionConsumerGate do
 
     case transaction do
       {:ok, res} -> res
-      {:error, error} -> {:error, error}
+      {:error, _changeset} = error -> error
+      {:error, _, changeset, _} -> {:error, changeset}
     end
   end
 

--- a/apps/ewallet/lib/ewallet/policies/account_policy.ex
+++ b/apps/ewallet/lib/ewallet/policies/account_policy.ex
@@ -27,9 +27,6 @@ defmodule EWallet.AccountPolicy do
   defp do_authorize("viewer", :update), do: false
   defp do_authorize("viewer", :delete), do: false
 
-  # Deny and return the error if provided
-  defp do_authorize({:error, _} = error, _action), do: error
-
   # Catch-all: deny everything else
   defp do_authorize(_role, _action), do: false
 end

--- a/apps/ewallet/lib/ewallet/web/embedder.ex
+++ b/apps/ewallet/lib/ewallet/web/embedder.ex
@@ -5,35 +5,17 @@ defmodule EWallet.Web.Embedder do
   alias EWallet.Helper
   alias EWalletDB.Repo
 
-  defmacro __using__(_opts) do
-    quote do
-      import EWallet.Web.Embedder, only: [embed: 2]
-    end
+  @callback embeddable() :: list(atom())
+  @callback always_embed() :: list(atom())
+
+  def embed(module, record, embeds) do
+    embed(record, embeds, apply(module, :embeddable, []), apply(module, :always_embed, []))
   end
 
-  defmacro embed(record, embeds) do
-    quote do
-      alias EWallet.Web.Embedder
-
-      if is_nil(@embeddable) do
-        raise(ArgumentError, message: "#{unquote(__MODULE__)} requires @embeddable to work")
-      end
-
-      if is_nil(@always_embed) do
-        raise(ArgumentError, message: "#{unquote(__MODULE__)} requires @always_embed to work")
-      end
-
-      Embedder.embed(unquote(record), unquote(embeds), @embeddable, @always_embed)
-    end
-  end
-
-  @doc """
-  Embed association data.
-  """
-  def embed(record, nil, embeddable, always_embed),
+  defp embed(record, nil, embeddable, always_embed),
     do: embed(record, [], embeddable, always_embed)
 
-  def embed(record, requested, embeddable, always_embed) do
+  defp embed(record, requested, embeddable, always_embed) do
     requested = Helper.to_existing_atoms(requested) ++ always_embed
     allowed = embeddable -- embeddable -- requested
 

--- a/apps/ewallet/lib/ewallet/web/preloader.ex
+++ b/apps/ewallet/lib/ewallet/web/preloader.ex
@@ -19,22 +19,23 @@ defmodule EWallet.Web.Preloader do
   @doc """
   Preloads associations into the given record.
   """
-  @spec preload_one(map, atom() | [atom()]) :: Ecto.Schema.t() | {:error, nil}
+  @spec preload_one(map, atom() | [atom()]) :: {:ok, Ecto.Schema.t()} | {:error, nil}
   def preload_one(record, preloads) when is_map(record) do
     case Repo.preload(record, List.wrap(preloads)) do
       nil -> {:error, nil}
-      %{} = result -> result
+      %{} = result -> {:ok, result}
     end
   end
 
   @doc """
   Preloads associations into the given records.
   """
-  @spec preload_all(list(Ecto.Schema.t()), atom() | [atom()]) :: [Ecto.Schema.t()] | {:error, nil}
+  @spec preload_all(list(Ecto.Schema.t()), atom() | [atom()]) ::
+          {:ok, [Ecto.Schema.t()]} | {:error, nil}
   def preload_all(record, preloads) do
     case Repo.preload(record, List.wrap(preloads)) do
       nil -> {:error, nil}
-      result when is_list(result) -> result
+      result when is_list(result) -> {:ok, result}
     end
   end
 end

--- a/apps/ewallet/lib/ewallet/web/preloader.ex
+++ b/apps/ewallet/lib/ewallet/web/preloader.ex
@@ -17,11 +17,24 @@ defmodule EWallet.Web.Preloader do
   def to_query(queryable, _), do: queryable
 
   @doc """
-  Preloads associations into the given record(s).
+  Preloads associations into the given record.
   """
-  @spec preload(Ecto.Schema.t() | Ecto.Schema.t(), atom() | [atom()]) ::
-          Ecto.Schema.t() | [Ecto.Schema.t()]
-  def preload(record, preloads) do
-    Repo.preload(record, List.wrap(preloads))
+  @spec preload_one(map, atom() | [atom()]) :: Ecto.Schema.t() | {:error, nil}
+  def preload_one(record, preloads) when is_map(record) do
+    case Repo.preload(record, List.wrap(preloads)) do
+      nil -> {:error, nil}
+      %{} = result -> result
+    end
+  end
+
+  @doc """
+  Preloads associations into the given records.
+  """
+  @spec preload_all(list(Ecto.Schema.t()), atom() | [atom()]) :: [Ecto.Schema.t()] | {:error, nil}
+  def preload_all(record, preloads) do
+    case Repo.preload(record, List.wrap(preloads)) do
+      nil -> {:error, nil}
+      result when is_list(result) -> result
+    end
   end
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
@@ -12,7 +12,7 @@ defmodule EWallet.Web.V1.KeySerializer do
   end
 
   def serialize(%Key{} = key) do
-    key = Preloader.preload(key, :account)
+    key = Preloader.preload_one(key, :account)
 
     %{
       object: "key",

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
@@ -12,7 +12,7 @@ defmodule EWallet.Web.V1.KeySerializer do
   end
 
   def serialize(%Key{} = key) do
-    key = Preloader.preload_one(key, :account)
+    {:ok, key} = Preloader.preload_one(key, :account)
 
     %{
       object: "key",

--- a/apps/ewallet/test/ewallet/web/embedder_test.exs
+++ b/apps/ewallet/test/ewallet/web/embedder_test.exs
@@ -5,13 +5,14 @@ defmodule EWallet.Web.EmbedderTest do
   alias EWalletDB.Account
 
   defmodule TestModule do
-    use EWallet.Web.Embedder
+    @behaviour EWallet.Web.Embedder
+    alias EWallet.Web.Embedder
 
-    @embeddable [:wallets, :tokens]
-    @always_embed [:wallets]
+    def embeddable(), do: [:wallets, :tokens]
+    def always_embed(), do: [:wallets]
 
     def call_embed(record, embeds) do
-      embed(record, embeds)
+      Embedder.embed(__MODULE__, record, embeds)
     end
   end
 

--- a/apps/ewallet/test/ewallet/web/embedder_test.exs
+++ b/apps/ewallet/test/ewallet/web/embedder_test.exs
@@ -8,8 +8,8 @@ defmodule EWallet.Web.EmbedderTest do
     @behaviour EWallet.Web.Embedder
     alias EWallet.Web.Embedder
 
-    def embeddable(), do: [:wallets, :tokens]
-    def always_embed(), do: [:wallets]
+    def embeddable, do: [:wallets, :tokens]
+    def always_embed, do: [:wallets]
 
     def call_embed(record, embeds) do
       Embedder.embed(__MODULE__, record, embeds)

--- a/apps/ewallet_api/lib/ewallet_api/global/controllers/status_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/global/controllers/status_controller.ex
@@ -14,13 +14,7 @@ defmodule EWalletAPI.StatusController do
   end
 
   defp local_ledger do
-    case Status.check() do
-      :ok ->
-        true
-
-      _ ->
-        false
-    end
+    :ok == Status.check()
   end
 
   defp node_count do

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/self_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/self_controller.ex
@@ -23,9 +23,5 @@ defmodule EWalletAPI.V1.SelfController do
     render(conn, :wallets, %{addresses: [addresses]})
   end
 
-  defp respond({:error, code, description}, conn) do
-    handle_error(conn, code, description)
-  end
-
   defp respond({:error, code}, conn), do: handle_error(conn, code)
 end

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/status_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/status_controller.ex
@@ -5,6 +5,7 @@ defmodule EWalletAPI.V1.StatusController do
     json(conn, %{"success" => true})
   end
 
+  @spec server_error(any(), any()) :: no_return()
   def server_error(_conn, _attrs) do
     raise "Mock server error"
   end

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
@@ -47,10 +47,6 @@ defmodule EWalletAPI.V1.TransactionConsumptionController do
     handle_error(conn, :invalid_parameter, changeset)
   end
 
-  defp respond({:error, code, description}, conn) do
-    handle_error(conn, code, description)
-  end
-
   defp respond({:error, consumption, code, description}, conn) do
     dispatch_confirm_event(consumption)
     handle_error(conn, code, description)

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
@@ -1,6 +1,7 @@
 defmodule EWalletAPI.V1.TransactionConsumptionController do
   use EWalletAPI, :controller
-  use EWallet.Web.Embedder
+  alias EWallet.Web.Embedder
+  @behaviour EWallet.Web.Embedder
   import EWalletAPI.V1.ErrorHandler
 
   alias EWallet.{
@@ -13,11 +14,11 @@ defmodule EWalletAPI.V1.TransactionConsumptionController do
 
   # The fields that are allowed to be embedded.
   # These fields must be one of the schema's association names.
-  @embeddable [:account, :token, :transaction, :transaction_request, :user]
+  def embeddable(), do: [:account, :token, :transaction, :transaction_request, :user]
 
-  # The fields in `@embeddable` that are embedded regardless of the request.
+  # The fields returned by `embeddable/0` are embedded regardless of the request.
   # These fields must be one of the schema's association names.
-  @always_embed [:token]
+  def always_embed(), do: [:token]
 
   def consume_for_user(conn, %{"idempotency_token" => idempotency_token} = attrs)
       when idempotency_token != nil do
@@ -56,7 +57,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionController do
     dispatch_confirm_event(consumption)
 
     render(conn, :transaction_consumption, %{
-      transaction_consumption: embed(consumption, conn.body_params["embed"])
+      transaction_consumption: Embedder.embed(__MODULE__, consumption, conn.body_params["embed"])
     })
   end
 

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
@@ -14,11 +14,11 @@ defmodule EWalletAPI.V1.TransactionConsumptionController do
 
   # The fields that are allowed to be embedded.
   # These fields must be one of the schema's association names.
-  def embeddable(), do: [:account, :token, :transaction, :transaction_request, :user]
+  def embeddable, do: [:account, :token, :transaction, :transaction_request, :user]
 
   # The fields returned by `embeddable/0` are embedded regardless of the request.
   # These fields must be one of the schema's association names.
-  def always_embed(), do: [:token]
+  def always_embed, do: [:token]
 
   def consume_for_user(conn, %{"idempotency_token" => idempotency_token} = attrs)
       when idempotency_token != nil do

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_controller.ex
@@ -19,7 +19,6 @@ defmodule EWalletAPI.V1.TransactionRequestController do
     |> respond(conn)
   end
 
-  defp respond(nil, conn), do: handle_error(conn, :transaction_request_not_found)
   defp respond({:error, error}, conn) when is_atom(error), do: handle_error(conn, error)
 
   defp respond({:error, changeset}, conn) do

--- a/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
@@ -311,7 +311,7 @@ defmodule EWalletDB.TransactionConsumption do
     state_transition(consumption, @failed, transfer.uuid)
   end
 
-  @spec expired?(%TransactionConsumption{}) :: true | false
+  @spec expired?(%TransactionConsumption{}) :: boolean()
   def expired?(consumption) do
     consumption.status == @expired
   end
@@ -320,7 +320,7 @@ defmodule EWalletDB.TransactionConsumption do
     Enum.member?([@confirmed, @rejected], consumption.status)
   end
 
-  @spec finalized?(%TransactionConsumption{}) :: true | false
+  @spec finalized?(%TransactionConsumption{}) :: boolean()
   def finalized?(consumption) do
     Enum.member?([@rejected, @confirmed, @failed, @expired], consumption.status)
   end


### PR DESCRIPTION
Issue/Task Number:

# Overview

Describe what your Pull Request is about in a few sentences. This is a global description that should tell people what your PR is all about. Don't go too much into details here.

# Changes

- Types and 5 other issues added to the ignore file. I think `account.ex` and `user.ex` issues are both related to arc_ecto issues.
- Lots of dead code removed
- Preloader can return a list of changeset which was ignored previously (it shouldn't happen but it has to be handled)  

# Implementation Details

Couldn't address dependency issues with avatar upload.

# Usage


# Impact

No special requirement.


# Other

What's left is:

If someone can run dialyzer and let me know if the issues in `transaction_consumption_controller.ex` which uses `EWallet.Web.Embedder` macro are causing the same problems? As said in Gitter, I once rewrote the `embed` function requiring `embeddable` and `always_embed` functions. This could be implemented as a behaviour too and probably solving the dialyzer issues.

`apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex:59: The test ['token',...] == 'nil' can never evaluate to 'true'
apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex:59: The test ['account' | 'token' | 'transaction' | 'transaction_request' | 'user',...] == 'nil' can never evaluate to 'true'
apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex:59: The test ['token',...] == 'nil' can never evaluate to 'true'
apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex:59: The test ['account' | 'token' | 'transaction' | 'transaction_request' | 'user',...] == 'nil' can never evaluate to 'true'
`

These two with `add_error` we understand already.
`apps/ewallet_db/lib/ewallet_db/validator.ex:19: The call 'Elixir.Ecto.Changeset':add_error(Vchangeset@1::any(),Vattrs@1::maybe_improper_list() | map(),#{#<111>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big']), #<108>(8, 1, 'integer', ['unsigned', 'big']), #<121>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<111>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<109>(8, 1, 'integer', ['unsigned', 'big']), #<117>(8, 1, 'integer', ['unsigned', 'big']), #<115>(8, 1, 'integer', ['unsigned', 'big']), #<116>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<98>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<112>(8, 1, 'integer', ['unsigned', 'big']), #<114>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<115>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big']), #<116>(8, 1, 'integer', ['unsigned', 'big'])}#,[{'validation','only_one_required'},...]) breaks the contract (t(),atom(),'Elixir.String':t(),'Elixir.Keyword':t()) -> t()
apps/ewallet_db/lib/ewallet_db/validator.ex:27: The call 'Elixir.Ecto.Changeset':add_error(Vchangeset@1::any(),Vattrs@1::maybe_improper_list() | map(),#{#<99>(8, 1, 'integer', ['unsigned', 'big']), #<97>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big']), #<39>(8, 1, 'integer', ['unsigned', 'big']), #<116>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<97>(8, 1, 'integer', ['unsigned', 'big']), #<108>(8, 1, 'integer', ['unsigned', 'big']), #<108>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<98>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<98>(8, 1, 'integer', ['unsigned', 'big']), #<108>(8, 1, 'integer', ['unsigned', 'big']), #<97>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big']), #<107>(8, 1, 'integer', ['unsigned', 'big'])}#,[{'validation','required_exclusive'},...]) breaks the contract (t(),atom(),'Elixir.String':t(),'Elixir.Keyword':t()) -> t()
apps/ewallet_db/lib/ewallet_db/validator.ex:67: The call 'Elixir.Ecto.Changeset':add_error(Vchangeset@1::any(),Vattrs@1::maybe_improper_list() | map(),#{#<111>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big']), #<108>(8, 1, 'integer', ['unsigned', 'big']), #<121>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<111>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<109>(8, 1, 'integer', ['unsigned', 'big']), #<117>(8, 1, 'integer', ['unsigned', 'big']), #<115>(8, 1, 'integer', ['unsigned', 'big']), #<116>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<98>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<32>(8, 1, 'integer', ['unsigned', 'big']), #<112>(8, 1, 'integer', ['unsigned', 'big']), #<114>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<115>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<110>(8, 1, 'integer', ['unsigned', 'big']), #<116>(8, 1, 'integer', ['unsigned', 'big'])}#,[{'validation','only_one_required'},...]) breaks the contract (t(),atom(),'Elixir.String':t(),'Elixir.Keyword':t()) -> t()`



