### PR TITLE
Database seed for acceptance testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ To learn more about all the environment variables available for production deplo
 
 ## Running the tests
 
+### Unit tests
+
 Before we start the application, let's try running the tests. Create the test databases:
 
 ```
@@ -226,6 +228,10 @@ Finished in 4.5 seconds
 ```
 
 All the tests should pass. If some tests are failing, double-check you have install all the dependencies. If you keep getting the failures, you can get in touch with us on [Gitter](https://gitter.im/omisego/ewallet)!
+
+### Acceptance tests
+
+Check [this file](/docs/tests/e2e.md) for all informations about acceptance tests.
 
 ## Migrating the development database
 

--- a/apps/ewallet/lib/ewallet/seeders/cli_seeder.ex
+++ b/apps/ewallet/lib/ewallet/seeders/cli_seeder.ex
@@ -34,7 +34,7 @@ defmodule EWallet.Seeder.CLI do
   Press Enter to start seeding or `Ctrl+C` twice to exit.
   """
 
-  def run(srcs) do
+  def run(srcs, assume_yes) do
     mods = Seeder.gather_seeds(srcs)
     reporters = Seeder.gather_reporters(srcs)
 
@@ -43,8 +43,10 @@ defmodule EWallet.Seeder.CLI do
       |> Seeder.argsline_for()
       |> process_argsline()
 
-    _ = IO.puts("\n-----\n")
-    _ = IO.gets(@confirm_message)
+    unless assume_yes do
+      _ = IO.puts("\n-----\n")
+      _ = IO.gets(@confirm_message)
+    end
 
     args = run_seeds(mods, args)
     run_reporters(reporters, args)

--- a/apps/ewallet/lib/mix/tasks/omg.seed.ex
+++ b/apps/ewallet/lib/mix/tasks/omg.seed.ex
@@ -57,11 +57,11 @@ defmodule Mix.Tasks.Omg.Seed do
   end
 
   defp seed_spec(["--test" | _t]) do
-    case System.get_env("E2E_ENABLED") do
-      "true" ->
+    case Regex.match?(~r/^(t(rue)?|y(es)?|on|1)$/, System.get_env("E2E_ENABLED")) do
+      true ->
         [{:ewallet_db, :seeds_test}]
 
-      _ ->
+      false ->
         IO.puts(@e2e_disabled_warning)
         []
     end

--- a/apps/ewallet/lib/mix/tasks/omg.seed.ex
+++ b/apps/ewallet/lib/mix/tasks/omg.seed.ex
@@ -60,6 +60,7 @@ defmodule Mix.Tasks.Omg.Seed do
     case System.get_env("E2E_ENABLED") do
       "true" ->
         [{:ewallet_db, :seeds_test}]
+
       _ ->
         IO.puts(@e2e_disabled_warning)
         []

--- a/apps/ewallet/lib/mix/tasks/omg.seed.ex
+++ b/apps/ewallet/lib/mix/tasks/omg.seed.ex
@@ -14,15 +14,19 @@ defmodule Mix.Tasks.Omg.Seed do
   @shortdoc "Create initial seed data"
   @start_apps [:logger, :crypto, :ssl, :postgrex, :ecto, :cloak]
   @repo_apps [:ewallet_db, :local_ledger_db]
+  @e2e_disabled_warning """
+  Test seeds can only be ran if the environment variable `E2E_ENABLED` is set to `true`
+  """
 
   def run(args) do
     spec = seed_spec(args)
+    assume_yes = assume_yes?(args)
 
     Enum.each(@start_apps, &Application.ensure_all_started/1)
     Logger.configure(level: :info)
 
     Enum.each(@repo_apps, &ensure_started/1)
-    CLI.run(spec)
+    CLI.run(spec, assume_yes)
   end
 
   #
@@ -52,7 +56,27 @@ defmodule Mix.Tasks.Omg.Seed do
     seed_spec(t) ++ [{:ewallet_db, :seeds_sample}]
   end
 
+  defp seed_spec(["--test" | _t]) do
+    case System.get_env("E2E_ENABLED") do
+      "true" ->
+        [{:ewallet_db, :seeds_test}]
+      _ ->
+        IO.puts(@e2e_disabled_warning)
+        []
+    end
+  end
+
   defp seed_spec([_ | t]) do
     seed_spec(t)
   end
+
+  defp assume_yes?([]), do: false
+
+  defp assume_yes?(["-y" | _t]), do: true
+
+  defp assume_yes?(["--yes" | _t]), do: true
+
+  defp assume_yes?(["--assume_yes" | _t]), do: true
+
+  defp assume_yes?([_ | t]), do: assume_yes?(t)
 end

--- a/apps/ewallet/test/ewallet/web/search_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/search_parser_test.exs
@@ -163,9 +163,10 @@ defmodule EWallet.Web.SearchParserTest do
         |> SearchParser.to_query(attrs, [:name])
         |> Repo.all()
 
-      assert Enum.count(result) == 2
-      assert Enum.at(result, 0).name == "Name Match 1"
-      assert Enum.at(result, 1).name == "Name Match 2"
+      names = Enum.map(result, fn account -> account.name end)
+      assert Enum.count(names) == 2
+      assert Enum.member?(names, "Name Match 1")
+      assert Enum.member?(names, "Name Match 2")
     end
 
     test "returns records that the given term matches in different fields" do

--- a/apps/ewallet_db/priv/repo/reporters/seeds_test.exs
+++ b/apps/ewallet_db/priv/repo/reporters/seeds_test.exs
@@ -1,0 +1,27 @@
+defmodule EWalletDB.Repo.Reporters.SeedsReporter do
+  def run(writer, _args) do
+
+    writer.heading("Setting up test data for the OmiseGO eWallet Server")
+    writer.print("""
+    ```
+    ###############################################################################
+    #                                                                             #
+    #         ██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗           #
+    #         ██║    ██║██╔══██╗██╔══██╗████╗  ██║██║████╗  ██║██╔════╝           #
+    #         ██║ █╗ ██║███████║██████╔╝██╔██╗ ██║██║██╔██╗ ██║██║  ███╗          #
+    #         ██║███╗██║██╔══██║██╔══██╗██║╚██╗██║██║██║╚██╗██║██║   ██║          #
+    #         ╚███╔███╔╝██║  ██║██║  ██║██║ ╚████║██║██║ ╚████║╚██████╔╝          #
+    #         ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═══╝ ╚═════╝            #
+    #                                                                             #
+    ###############################################################################
+    #                                                                             #
+    #  Seeded the minimum amount of data needed to run the acceptance tests.      #
+    #  BE CAREFUL, admins were generated using a simple password that is          #
+    #  included in the source code.                                               #
+    #  These seeds should only run in a test environment.                         #
+    #                                                                             #
+    ###############################################################################
+    ```
+    """)
+  end
+end

--- a/apps/ewallet_db/priv/repo/seeds_test/00_account.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/00_account.exs
@@ -1,0 +1,40 @@
+defmodule EWalletDB.Repo.Seeds.AccountSeed do
+  alias EWalletDB.Account
+
+  @seed_data %{
+    name: "master_account",
+    description: "Master Account",
+    parent_id: nil,
+  }
+
+  def seed do
+    [
+      run_banner: "Seeding the master account",
+      argsline: [],
+    ]
+  end
+
+  def run(writer, _args) do
+    case Account.get_master_account() do
+      nil ->
+        case Account.insert(@seed_data) do
+          {:ok, account} ->
+            writer.success("""
+              Name : #{account.name}
+              ID   : #{account.id}
+            """)
+          {:error, changeset} ->
+            writer.error("  The master account could not be inserted:")
+            writer.print_errors(changeset)
+          _ ->
+            writer.error("  The master account could not be inserted:")
+            writer.error("  Unknown error.")
+        end
+      %Account{} = account ->
+        writer.warn("""
+          Name : #{account.name}
+          ID   : #{account.id}
+        """)
+    end
+  end
+end

--- a/apps/ewallet_db/priv/repo/seeds_test/00_account.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/00_account.exs
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file
 defmodule EWalletDB.Repo.Seeds.AccountSeed do
   alias EWalletDB.Account
 

--- a/apps/ewallet_db/priv/repo/seeds_test/00_role.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/00_role.exs
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file
 defmodule EWalletDB.Repo.Seeds.RoleSeed do
   alias EWalletDB.Role
 

--- a/apps/ewallet_db/priv/repo/seeds_test/00_role.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/00_role.exs
@@ -1,0 +1,45 @@
+defmodule EWalletDB.Repo.Seeds.RoleSeed do
+  alias EWalletDB.Role
+
+  @seed_data [
+    %{name: "admin", display_name: "Admin"},
+    %{name: "viewer", display_name: "Viewer"},
+  ]
+
+  def seed do
+    [
+      run_banner: "Seeding roles",
+      argsline: [],
+    ]
+  end
+
+  def run(writer, _args) do
+    Enum.each @seed_data, fn data ->
+      run_with(writer, data)
+    end
+  end
+
+  defp run_with(writer, data) do
+    case Role.get_by_name(data.name) do
+      nil ->
+        case Role.insert(data) do
+          {:ok, role} ->
+            writer.success("""
+              Name         : #{role.name}
+              Display name : #{role.display_name}
+            """)
+          {:error, changeset} ->
+            writer.error("  Role #{data.name} could not be inserted:")
+            writer.print_errors(changeset)
+          _ ->
+            writer.error("  Role #{data.name} could not be inserted:")
+            writer.error("  Unknown error.")
+        end
+      %Role{} = role ->
+        writer.warn("""
+          Name         : #{role.name}
+          Display name : #{role.display_name}
+        """)
+    end
+  end
+end

--- a/apps/ewallet_db/priv/repo/seeds_test/01_user.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/01_user.exs
@@ -1,0 +1,55 @@
+defmodule EWalletDB.Repo.Seeds.UserSeed do
+  alias EWalletDB.User
+
+  @seed_data [
+    %{
+      email: System.get_env("E2E_TEST_ADMIN_EMAIL") || "test_admin@example.com",
+      password: System.get_env("E2E_TEST_ADMIN_PASSWORD") || "password",
+      metadata: %{},
+    },
+    %{
+      email: System.get_env("E2E_TEST_ADMIN_1_EMAIL") || "test_admin@example.com",
+      password: System.get_env("E2E_TEST_ADMIN_1_PASSWORD") || "password",
+      metadata: %{},
+    },
+  ]
+
+  def seed do
+    [
+      run_banner: "Seeding the 2 test admins",
+      argsline: [],
+    ]
+  end
+
+  def run(writer, _args) do
+    Enum.each @seed_data, fn data ->
+      run_with(writer, data)
+    end
+  end
+
+  def run_with(writer, data) do
+    case User.get_by_email(data.email) do
+      nil ->
+        case User.insert(data) do
+          {:ok, user} ->
+            writer.success("""
+              ID       : #{user.id}
+              Email    : #{user.email}
+              Password : <hidden>
+            """)
+          {:error, changeset} ->
+            writer.error("  Admin Panel user #{data.email} could not be inserted:")
+            writer.print_errors(changeset)
+          _ ->
+            writer.error("  Admin Panel user #{data.email} could not be inserted:")
+            writer.error("  Unknown error.")
+        end
+      %User{} = user ->
+        writer.warn("""
+          ID       : #{user.id}
+          Email    : #{user.email}
+          Password : <hidden>
+        """)
+    end
+  end
+end

--- a/apps/ewallet_db/priv/repo/seeds_test/01_user.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/01_user.exs
@@ -8,7 +8,7 @@ defmodule EWalletDB.Repo.Seeds.UserSeed do
       metadata: %{},
     },
     %{
-      email: System.get_env("E2E_TEST_ADMIN_1_EMAIL") || "test_admin@example.com",
+      email: System.get_env("E2E_TEST_ADMIN_1_EMAIL") || "test_admin_1@example.com",
       password: System.get_env("E2E_TEST_ADMIN_1_PASSWORD") || "password",
       metadata: %{},
     },

--- a/apps/ewallet_db/priv/repo/seeds_test/02_membership.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/02_membership.exs
@@ -1,0 +1,51 @@
+defmodule EWalletDB.Repo.Seeds.MembershipSeed do
+  alias EWalletDB.{Account, Membership, Role, User}
+  alias EWallet.Web.Preloader
+
+  @seed_data %{
+    admin_email: System.get_env("E2E_TEST_ADMIN_EMAIL") || "test_admin@example.com",
+  }
+
+  def seed do
+    [
+      run_banner: "Seeding the admin membership",
+      argsline: [],
+    ]
+  end
+
+  def run(writer, args) do
+    admin_email = @seed_data[:admin_email]
+
+    user = User.get_by_email(admin_email)
+    account = Account.get_master_account()
+    role = Role.get_by_name("admin")
+
+    case Membership.get_by_user_and_account(user, account) do
+      nil ->
+        case Membership.assign(user, account, role) do
+        {:ok, membership} ->
+            membership = Preloader.preload(membership, [:user, :account, :role])
+            writer.success("""
+              Email        : #{membership.user.email}
+              Account Name : #{membership.account.name}
+              Account ID   : #{membership.account.id}
+              Role         : #{membership.role.name}
+            """)
+        {:error, changeset} ->
+            writer.error("  Admin Panel user #{admin_email} could not be assigned:")
+            writer.print_errors(changeset)
+        _ ->
+            writer.error("  Admin Panel user #{admin_email} could not be assigned:")
+            writer.error("  Unknown error.")
+        end
+      %Membership{} = membership ->
+        membership = Preloader.preload(membership, [:user, :account, :role])
+        writer.warn("""
+          Email        : #{membership.user.email}
+          Account Name : #{membership.account.name}
+          Account ID   : #{membership.account.id}
+          Role         : #{membership.role.name}
+        """)
+    end
+  end
+end

--- a/apps/ewallet_db/priv/repo/seeds_test/02_membership.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/02_membership.exs
@@ -24,7 +24,7 @@ defmodule EWalletDB.Repo.Seeds.MembershipSeed do
       nil ->
         case Membership.assign(user, account, role) do
         {:ok, membership} ->
-            membership = Preloader.preload(membership, [:user, :account, :role])
+            {:ok, membership} = Preloader.preload_one(membership, [:user, :account, :role])
             writer.success("""
               Email        : #{membership.user.email}
               Account Name : #{membership.account.name}
@@ -39,7 +39,7 @@ defmodule EWalletDB.Repo.Seeds.MembershipSeed do
             writer.error("  Unknown error.")
         end
       %Membership{} = membership ->
-        membership = Preloader.preload(membership, [:user, :account, :role])
+        {:ok, membership} = Preloader.preload_one(membership, [:user, :account, :role])
         writer.warn("""
           Email        : #{membership.user.email}
           Account Name : #{membership.account.name}

--- a/apps/ewallet_db/priv/repo/seeds_test/02_membership.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/02_membership.exs
@@ -13,7 +13,7 @@ defmodule EWalletDB.Repo.Seeds.MembershipSeed do
     ]
   end
 
-  def run(writer, args) do
+  def run(writer, _args) do
     admin_email = @seed_data[:admin_email]
 
     user = User.get_by_email(admin_email)

--- a/docs/setup/env.md
+++ b/docs/setup/env.md
@@ -89,3 +89,11 @@ Nothing else to set, files will be stored at the root of the project in `public/
 
 -   `GCS_BUCKET`: Your GCS bucket.
 -   `GCS_CREDENTIALS`: A JSON containing your GCS credentials.
+
+### E2E Tests
+
+- `E2E_ENABLED`: Allows to run `mix seed --test --yes` to generate test data
+- `E2E_TEST_ADMIN_EMAIL`: The email of the first test admin
+- `E2E_TEST_ADMIN_PASSWORD`: The password of the first test admin
+- `E2E_TEST_ADMIN_1_EMAIL`: The email of the second test admin
+- `E2E_TEST_ADMIN_1_PASSWORD`: The password of the second test admin

--- a/docs/tests/e2e.md
+++ b/docs/tests/e2e.md
@@ -1,0 +1,15 @@
+# e2e
+
+We offer [acceptance tests](https://github.com/omisego/e2e) written using [Robot Framework](http://robotframework.org/).
+These tests rely on initial seeded data which are 2 admins and a base account.
+
+
+## Environment setup
+
+In order to generate the sample data needed for the tests you will need to run:
+
+`mix seed --test --yes`
+
+`--yes` option allows to skip all prompted confirmations which is ideal when ran on an automation server.
+
+You will need to add a few environment variables before running the seed, check [this file](/docs/setup/env.md#e2e-tests) for more informations


### PR DESCRIPTION
Issue/Task Number: 393

# Overview

This PR adds a new option to the `mix seed` command in order to generate the needed data to run acceptance tests

# Changes

- Add `mix seed --test --yes` command

# Implementation Details

- `--test` seeds 2 admins and a base account
- `--yes` skips all prompts
- Add a few environment variables to limit the use of this seed

# Usage

To run the test seed in local, use:
`E2E_ENABLED=true mix seed --test --yes`