### PR TITLE
Allow transaction_request to be created with only token_id and type

### DIFF
--- a/apps/ewallet/lib/ewallet/gates/transaction_request_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_request_gate.ex
@@ -94,11 +94,9 @@ defmodule EWallet.TransactionRequestGate do
           {:ok, TransactionRequest.t()} | {:error, Atom.t()}
   def create(
         %User{} = user,
-        %{
-          "address" => address
-        } = attrs
+        attrs
       ) do
-    with {:ok, wallet} <- WalletFetcher.get(user, address) do
+    with {:ok, wallet} <- WalletFetcher.get(user, attrs["address"]) do
       create(wallet, attrs)
     else
       error -> error
@@ -109,8 +107,6 @@ defmodule EWallet.TransactionRequestGate do
         %Wallet{} = wallet,
         %{
           "type" => _,
-          "correlation_id" => _,
-          "amount" => _,
           "token_id" => token_id
         } = attrs
       ) do

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -66,9 +66,56 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
       response =
         client_request("/me.create_transaction_request", %{
           type: "send",
+          token_id: token.id
+        })
+
+      request = TransactionRequest |> Repo.all() |> Enum.at(0)
+
+      assert response == %{
+               "success" => true,
+               "version" => "1",
+               "data" => %{
+                 "object" => "transaction_request",
+                 "amount" => nil,
+                 "address" => wallet.address,
+                 "correlation_id" => nil,
+                 "id" => request.id,
+                 "formatted_id" => request.id,
+                 "socket_topic" => "transaction_request:#{request.id}",
+                 "token_id" => token.id,
+                 "token" => token |> TokenSerializer.serialize() |> stringify_keys(),
+                 "allow_amount_override" => true,
+                 "require_confirmation" => false,
+                 "consumption_lifetime" => nil,
+                 "metadata" => %{},
+                 "encrypted_metadata" => %{},
+                 "expiration_date" => nil,
+                 "expiration_reason" => nil,
+                 "expired_at" => nil,
+                 "max_consumptions" => nil,
+                 "max_consumptions_per_user" => nil,
+                 "current_consumptions_count" => 0,
+                 "type" => "send",
+                 "status" => "valid",
+                 "user_id" => user.id,
+                 "user" => user |> UserSerializer.serialize() |> stringify_keys(),
+                 "account_id" => nil,
+                 "account" => nil,
+                 "created_at" => Date.to_iso8601(request.inserted_at),
+                 "updated_at" => Date.to_iso8601(request.updated_at)
+               }
+             }
+    end
+
+    test "creates a transaction request with nil address" do
+      user = get_test_user()
+      token = insert(:token)
+      wallet = User.get_primary_wallet(user)
+
+      response =
+        client_request("/me.create_transaction_request", %{
+          type: "send",
           token_id: token.id,
-          correlation_id: nil,
-          amount: nil,
           address: nil
         })
 


### PR DESCRIPTION
Issue/Task Number: T429

# Overview

Only `type` and `token_id` should be required to create transaction requests. However, currently some functions expect to see `correlation_id`, `amount` and `address` in the arguments. This PR removes those unnecessary checks.

# Changes

- Modify the min params test for transaction request gate.
- Remove unneeded params check in `TransactionRequestGate` functions