### PR TITLE
Remove token from Wallet

### DIFF
--- a/apps/ewallet_db/lib/ewallet_db/wallet.ex
+++ b/apps/ewallet_db/lib/ewallet_db/wallet.ex
@@ -7,7 +7,7 @@ defmodule EWalletDB.Wallet do
   import EWalletDB.Validator
   alias Ecto.UUID
   alias ExULID.ULID
-  alias EWalletDB.{Repo, Account, Wallet, Token, User}
+  alias EWalletDB.{Repo, Account, Wallet, User}
 
   @genesis "genesis"
   @burn "burn"
@@ -23,7 +23,6 @@ defmodule EWalletDB.Wallet do
   @cast_attrs [
     :address,
     :account_uuid,
-    :token_uuid,
     :user_uuid,
     :metadata,
     :encrypted_metadata,
@@ -44,14 +43,6 @@ defmodule EWalletDB.Wallet do
       :user,
       User,
       foreign_key: :user_uuid,
-      references: :uuid,
-      type: UUID
-    )
-
-    belongs_to(
-      :token,
-      Token,
-      foreign_key: :token_uuid,
       references: :uuid,
       type: UUID
     )
@@ -101,7 +92,6 @@ defmodule EWalletDB.Wallet do
     changeset
     |> unique_constraint(:address)
     |> assoc_constraint(:account)
-    |> assoc_constraint(:token)
     |> assoc_constraint(:user)
     |> unique_constraint(:unique_account_name, name: :wallet_account_uuid_name_index)
     |> unique_constraint(:unique_user_name, name: :wallet_user_uuid_name_index)

--- a/apps/ewallet_db/priv/repo/migrations/20180620100944_remove_token_uuid_from_wallets.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180620100944_remove_token_uuid_from_wallets.exs
@@ -1,0 +1,15 @@
+defmodule EWalletDB.Repo.Migrations.RemoveTokenUUIDFromWallets do
+  use Ecto.Migration
+
+  def up do
+    alter table(:wallet) do
+      remove :token_uuid
+    end
+  end
+
+  def down do
+    alter table(:wallet) do
+      add :token_uuid, references(:token, column: :uuid, type: :uuid)
+    end
+  end
+end

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -55,7 +55,6 @@ defmodule EWalletDB.Factory do
       name: sequence("name"),
       identifier: Wallet.primary(),
       user: insert(:user),
-      token: nil,
       metadata: %{}
     }
   end


### PR DESCRIPTION
Issue/Task Number: T432

# Overview

Wallets were originally supposed to potentially belong to a token where newly minted tokens would go. This behavior has been changed (it goes to the master account now) but we never removed `token_uuid` from `Wallet` which is now leading to confusion.

# Changes

- Generate migration to remove `token_uuid` from `wallet` table
