### PR TITLE
Allow API keys to be disabled/enabled

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -88,6 +88,7 @@ defmodule AdminAPI.V1.Router do
 
     post("/api_key.all", APIKeyController, :all)
     post("/api_key.create", APIKeyController, :create)
+    post("/api_key.update", APIKeyController, :update)
     post("/api_key.delete", APIKeyController, :delete)
 
     post("/settings.all", SettingsController, :get_settings)

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -1071,6 +1071,22 @@ paths:
           $ref: "#/components/responses/APIKeyResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
+  /api_key.update:
+    post:
+      tags:
+        - API Access
+      summary: Update an API key
+      operationId: api_key_update
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/APIKeyUpdateBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/APIKeyResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
   /api_key.delete:
     post:
       tags:
@@ -2744,6 +2760,8 @@ components:
           type: string
         owner_app:
           type: string
+        expired:
+          type: boolean
         account_id:
           type: string
         created_at:
@@ -2761,6 +2779,7 @@ components:
         - id
         - key
         - owner_app
+        - expired
         - account_id
         - created_at
         - updated_at
@@ -2784,6 +2803,7 @@ components:
             id: "api_01ce844d5w9e81snekr5kprvem"
             key: "jZKpGKgwy5LJTWwXqSD4jVWYDdnTKHlRYkaNB6SqsaQ"
             owner_app: "admin_api"
+            expired: false
             account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
             created_at: "2018-01-01T00:00:00Z"
             updated_at: "2018-01-01T10:00:00Z"
@@ -2816,6 +2836,7 @@ components:
                 id: "api_01ce844d5w9e81snekr5kprvem"
                 key: "jZKpGKgwy5LJTWwXqSD4jVWYDdnTKHlRYkaNB6SqsaQ"
                 owner_app: "admin_api"
+                expired: false
                 account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
                 created_at: "2018-01-01T00:00:00Z"
                 updated_at: "2018-01-01T10:00:00Z"
@@ -4140,6 +4161,23 @@ components:
               search_term: ""
               sort_by: "created_at"
               sort_dir: "asc"
+    APIKeyUpdateBody:
+      description: The parameters to use for updating an API key
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              id:
+                type: string
+              expired:
+                type: boolean
+            required:
+              - id
+              - expired
+            example:
+              id: "key_01ce83yphmq6vt4qnmn3ykwcw6"
+              expired: true
     APIKeyDeleteBody:
       description: The parameters to use for deleting an API key
       required: true

--- a/apps/admin_api/test/admin_api/v1/views/api_key_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/api_key_view_test.exs
@@ -16,6 +16,7 @@ defmodule AdminAPI.V1.APIKeyViewTest do
           key: api_key.key,
           account_id: api_key.account.id,
           owner_app: api_key.owner_app,
+          expired: false,
           created_at: Date.to_iso8601(api_key.inserted_at),
           updated_at: Date.to_iso8601(api_key.updated_at),
           deleted_at: Date.to_iso8601(api_key.deleted_at)
@@ -51,6 +52,7 @@ defmodule AdminAPI.V1.APIKeyViewTest do
               key: api_key1.key,
               account_id: api_key1.account.id,
               owner_app: api_key1.owner_app,
+              expired: false,
               created_at: Date.to_iso8601(api_key1.inserted_at),
               updated_at: Date.to_iso8601(api_key1.updated_at),
               deleted_at: Date.to_iso8601(api_key1.deleted_at)
@@ -61,6 +63,7 @@ defmodule AdminAPI.V1.APIKeyViewTest do
               key: api_key2.key,
               account_id: api_key2.account.id,
               owner_app: api_key2.owner_app,
+              expired: false,
               created_at: Date.to_iso8601(api_key2.inserted_at),
               updated_at: Date.to_iso8601(api_key2.updated_at),
               deleted_at: Date.to_iso8601(api_key2.deleted_at)

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/api_key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/api_key_serializer.ex
@@ -21,6 +21,7 @@ defmodule EWallet.Web.V1.APIKeySerializer do
       key: api_key.key,
       account_id: api_key.account.id,
       owner_app: api_key.owner_app,
+      expired: api_key.expired,
       created_at: Date.to_iso8601(api_key.inserted_at),
       updated_at: Date.to_iso8601(api_key.updated_at),
       deleted_at: Date.to_iso8601(api_key.deleted_at)

--- a/apps/ewallet_db/lib/ewallet_db/api_key.ex
+++ b/apps/ewallet_db/lib/ewallet_db/api_key.ex
@@ -28,7 +28,7 @@ defmodule EWalletDB.APIKey do
       type: UUID
     )
 
-    field(:expired, :boolean)
+    field(:expired, :boolean, default: false)
     timestamps()
     soft_delete()
   end
@@ -39,6 +39,12 @@ defmodule EWalletDB.APIKey do
     |> validate_required([:key, :owner_app, :account_uuid])
     |> unique_constraint(:key)
     |> assoc_constraint(:account)
+  end
+
+  defp update_changeset(%APIKey{} = key, attrs) do
+    key
+    |> cast(attrs, [:expired])
+    |> validate_required([:expired])
   end
 
   @doc """
@@ -68,6 +74,15 @@ defmodule EWalletDB.APIKey do
     %APIKey{}
     |> changeset(attrs)
     |> Repo.insert()
+  end
+
+  @doc """
+  Updates an API key with the provided attributes.
+  """
+  def update(%APIKey{} = api_key, attrs) do
+    api_key
+    |> update_changeset(attrs)
+    |> Repo.update()
   end
 
   defp get_master_account_uuid do


### PR DESCRIPTION
Issue/Task Number: T323

# Overview

Add an `/api_key.update` endpoint to allow admin to enable/disable keys.

# Changes

- Add `/api_key.update`
- Update OpenAPI spec

# Usage

Call `/api_key.update` with an `id` and `expired` set to `true` or `false`.

See OpenAPI spec for more info.