### PR TITLE
Admin transaction requests

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -3,6 +3,7 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   alias EWallet.Web.Embedder
   @behaviour EWallet.Web.Embedder
   import AdminAPI.V1.ErrorHandler
+  alias EWallet.Web.{SearchParser, SortParser, Paginator, Preloader}
 
   alias EWallet.{
     Web.V1.Event,
@@ -11,7 +12,7 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
     TransactionConsumptionFetcher
   }
 
-  alias EWalletDB.{Account, TransactionConsumption}
+  alias EWalletDB.{Account, User, TransactionConsumption}
 
   # The fields that are allowed to be embedded.
   # These fields must be one of the schema's association names.
@@ -20,6 +21,59 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   # The fields returned by `embeddable/0` are embedded regardless of the request.
   # These fields must be one of the schema's association names.
   def always_embed, do: [:token]
+
+  @mapped_fields %{"created_at" => "inserted_at"}
+  @preload_fields [:account, :user, :wallet, :token, :transaction_request, :transfer]
+  @search_fields [:id, :status, :correlation_id, :idempotency_token]
+  @sort_fields [
+    :id,
+    :status,
+    :correlation_id,
+    :idempotency_token,
+    :inserted_at,
+    :updated_at,
+    :approved_at,
+    :rejected_at,
+    :confirmed_at,
+    :failed_at,
+    :expired_at
+  ]
+
+  def all_for_account(conn, %{"account_id" => account_id} = attrs) do
+    with %Account{} = account <- Account.get(account_id) || {:error, :account_id_not_found} do
+      :account_uuid
+      |> TransactionConsumption.query_all_for(account.uuid)
+      |> SearchParser.search_with_terms(attrs, @search_fields)
+      |> do_all(conn, attrs)
+    else
+      error -> respond(error, conn)
+    end
+  end
+
+  def all_for_account(conn, %{}) do
+    handle_error(conn, :invalid_parameter, "Parameter 'account_id' is required.")
+  end
+
+  def all_for_user(conn, %{"user_id" => user_id} = attrs) do
+    with %User{} = user <- User.get(user_id) || {:error, :user_id_not_found} do
+      :user_uuid
+      |> TransactionConsumption.query_all_for(user.uuid)
+      |> SearchParser.search_with_terms(attrs, @search_fields)
+      |> do_all(conn, attrs)
+    else
+      error -> respond(error, conn)
+    end
+  end
+
+  def all_for_user(conn, %{}) do
+    handle_error(conn, :invalid_parameter, "Parameter 'user_id' is required.")
+  end
+
+  def all(conn, attrs) do
+    TransactionConsumption
+    |> SearchParser.to_query(attrs, @search_fields)
+    |> do_all(conn, attrs)
+  end
 
   def get(conn, %{"id" => id}) do
     id
@@ -41,6 +95,14 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   def approve(conn, attrs), do: confirm(conn, get_actor(conn.assigns), attrs, true)
   def reject(conn, attrs), do: confirm(conn, get_actor(conn.assigns), attrs, false)
 
+  def do_all(query, conn, attrs) do
+    query
+    |> Preloader.to_query(@preload_fields)
+    |> SortParser.to_query(attrs, @sort_fields, @mapped_fields)
+    |> Paginator.paginate_attrs(attrs)
+    |> respond_multiple(conn)
+  end
+
   defp get_actor(%{admin_user: _admin_user}) do
     # To do -> change this to actually check if the user has admin rights over the
     # owner of the consumption
@@ -58,6 +120,17 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   end
 
   defp confirm(conn, _entity, _attrs, _approved), do: handle_error(conn, :invalid_parameter)
+
+  # Respond with a list of transaction consumptions
+  defp respond_multiple(%Paginator{} = paged_transaction_consumptions, conn) do
+    render(conn, :transaction_consumptions, %{
+      transaction_consumptions: paged_transaction_consumptions
+    })
+  end
+
+  defp respond_multiple({:error, code, description}, conn) do
+    handle_error(conn, code, description)
+  end
 
   defp respond({:error, error}, conn) when is_atom(error), do: handle_error(conn, error)
 

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -7,7 +7,8 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   alias EWallet.{
     Web.V1.Event,
     TransactionConsumptionConsumerGate,
-    TransactionConsumptionConfirmerGate
+    TransactionConsumptionConfirmerGate,
+    TransactionConsumptionFetcher
   }
 
   alias EWalletDB.{Account, TransactionConsumption}
@@ -19,6 +20,12 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   # The fields returned by `embeddable/0` are embedded regardless of the request.
   # These fields must be one of the schema's association names.
   def always_embed, do: [:token]
+
+  def get(conn, %{"id" => id}) do
+    id
+    |> TransactionConsumptionFetcher.get()
+    |> respond(conn)
+  end
 
   def consume(conn, %{"idempotency_token" => idempotency_token} = attrs)
       when idempotency_token != nil do

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
@@ -1,16 +1,19 @@
 defmodule AdminAPI.V1.TransactionRequestController do
   use AdminAPI, :controller
   import AdminAPI.V1.ErrorHandler
+  alias EWallet.Web.{SearchParser, SortParser, Paginator, Preloader}
 
   alias EWallet.{
     TransactionRequestGate,
     TransactionRequestFetcher
   }
 
+  alias EWalletDB.TransactionRequest
+
   @mapped_fields %{"created_at" => "inserted_at"}
   @preload_fields [:user, :account, :token, :wallet]
-  @search_fields [:id, :type, :correlation_id, :require_confirmation, :]
-  @sort_fields [:id, :status, :from, :to, :inserted_at, :updated_at]
+  @search_fields [:id, :status, :type, :correlation_id, :expiration_reason]
+  @sort_fields [:id, :status, :type, :correlation_id, :inserted_at, :expired_at]
 
   def all(conn, attrs) do
     TransactionRequest

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
@@ -8,8 +8,8 @@ defmodule AdminAPI.V1.TransactionRequestController do
   }
 
   @mapped_fields %{"created_at" => "inserted_at"}
-  @preload_fields [:from_token, :to_token]
-  @search_fields [:id, :idempotency_token, :status, :from, :to]
+  @preload_fields [:user, :account, :token, :wallet]
+  @search_fields [:id, :type, :correlation_id, :require_confirmation, :]
   @sort_fields [:id, :status, :from, :to, :inserted_at, :updated_at]
 
   def all(conn, attrs) do
@@ -21,15 +21,15 @@ defmodule AdminAPI.V1.TransactionRequestController do
     |> respond_multiple(conn)
   end
 
-  def create(conn, attrs) do
-    attrs
-    |> TransactionRequestGate.create()
-    |> respond(conn)
-  end
-
   def get(conn, %{"formatted_id" => formatted_id}) do
     formatted_id
     |> TransactionRequestFetcher.get()
+    |> respond(conn)
+  end
+
+  def create(conn, attrs) do
+    attrs
+    |> TransactionRequestGate.create()
     |> respond(conn)
   end
 

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
@@ -36,7 +36,7 @@ defmodule AdminAPI.V1.TransactionRequestController do
     |> respond(conn)
   end
 
-  # Respond with a list of transactions
+  # Respond with a list of transaction requests
   defp respond_multiple(%Paginator{} = paged_transaction_requests, conn) do
     render(conn, :transaction_requests, %{transaction_requests: paged_transaction_requests})
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
@@ -7,6 +7,20 @@ defmodule AdminAPI.V1.TransactionRequestController do
     TransactionRequestFetcher
   }
 
+  @mapped_fields %{"created_at" => "inserted_at"}
+  @preload_fields [:from_token, :to_token]
+  @search_fields [:id, :idempotency_token, :status, :from, :to]
+  @sort_fields [:id, :status, :from, :to, :inserted_at, :updated_at]
+
+  def all(conn, attrs) do
+    TransactionRequest
+    |> Preloader.to_query(@preload_fields)
+    |> SearchParser.to_query(attrs, @search_fields)
+    |> SortParser.to_query(attrs, @sort_fields, @mapped_fields)
+    |> Paginator.paginate_attrs(attrs)
+    |> respond_multiple(conn)
+  end
+
   def create(conn, attrs) do
     attrs
     |> TransactionRequestGate.create()
@@ -17,6 +31,15 @@ defmodule AdminAPI.V1.TransactionRequestController do
     formatted_id
     |> TransactionRequestFetcher.get()
     |> respond(conn)
+  end
+
+  # Respond with a list of transactions
+  defp respond_multiple(%Paginator{} = paged_transaction_requests, conn) do
+    render(conn, :transaction_requests, %{transaction_requests: paged_transaction_requests})
+  end
+
+  defp respond_multiple({:error, code, description}, conn) do
+    handle_error(conn, code, description)
   end
 
   defp respond({:error, error}, conn) when is_atom(error), do: handle_error(conn, error)

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -30,30 +30,24 @@ defmodule AdminAPI.V1.Router do
     # Transaction endpoints
     post("/transaction.all", TransactionController, :all)
     post("/transaction.get", TransactionController, :get)
-
-
-
+    post("/transaction.create", TransactionController, :create)
+    post("/user.credit_wallet", TransferController, :credit)
+    post("/user.debit_wallet", TransferController, :debit)
+    post("/transfer", TransferController, :transfer)
 
     post("/transaction_request.all", TransactionRequestController, :all)
+    post("/transaction_request.create", TransactionRequestController, :create)
+    post("/transaction_request.get", TransactionRequestController, :get)
+    post("/transaction_request.consume", TransactionConsumptionController, :consume)
 
     post("/transaction_request.get_consumptions", TransactionRequestController, :all)
     post("/account.get_consumptions", TransactionRequestController, :all)
     post("/user.get_consumptions", TransactionRequestController, :all)
     post("/wallet.get_consumptions", TransactionRequestController, :all)
-    post("/transaction_consumption.get", TransactionConsumptionController, :approve)
 
-
-
-    post("/transaction_request.create", TransactionRequestController, :create)
-    post("/transaction_request.get", TransactionRequestController, :get)
+    post("/transaction_consumption.get", TransactionConsumptionController, :get)
     post("/transaction_consumption.approve", TransactionConsumptionController, :approve)
     post("/transaction_consumption.reject", TransactionConsumptionController, :reject)
-
-    post("/transaction.create", TransactionController, :create)
-    post("/user.credit_wallet", TransferController, :credit)
-    post("/user.debit_wallet", TransferController, :debit)
-    post("/transfer", TransferController, :transfer)
-    post("/transaction_request.consume", TransactionConsumptionController, :consume)
 
     # Category endpoints
     post("/category.all", CategoryController, :all)

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -35,12 +35,11 @@ defmodule AdminAPI.V1.Router do
 
 
     post("/transaction_request.all", TransactionRequestController, :all)
-    post("/transaction_request.get_consumptions", TransactionRequestController, :all)
 
+    post("/transaction_request.get_consumptions", TransactionRequestController, :all)
     post("/account.get_consumptions", TransactionRequestController, :all)
     post("/user.get_consumptions", TransactionRequestController, :all)
     post("/wallet.get_consumptions", TransactionRequestController, :all)
-
     post("/transaction_consumption.get", TransactionConsumptionController, :approve)
 
 

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -40,11 +40,27 @@ defmodule AdminAPI.V1.Router do
     post("/transaction_request.get", TransactionRequestController, :get)
     post("/transaction_request.consume", TransactionConsumptionController, :consume)
 
-    post("/transaction_request.get_consumptions", TransactionRequestController, :all)
-    post("/account.get_consumptions", TransactionRequestController, :all)
-    post("/user.get_consumptions", TransactionRequestController, :all)
-    post("/wallet.get_consumptions", TransactionRequestController, :all)
+    post(
+      "/account.get_transaction_consumptions",
+      TransactionConsumptionController,
+      :all_for_account
+    )
 
+    post("/user.get_transaction_consumptions", TransactionConsumptionController, :all_for_user)
+
+    post(
+      "/wallet.get_transaction_consumptions",
+      TransactionConsumptionController,
+      :all_for_wallet
+    )
+
+    post(
+      "/transaction_request.get_transaction_consumptions",
+      TransactionConsumptionController,
+      :all_for_transaction_request
+    )
+
+    post("/transaction_consumption.all", TransactionConsumptionController, :all)
     post("/transaction_consumption.get", TransactionConsumptionController, :get)
     post("/transaction_consumption.approve", TransactionConsumptionController, :approve)
     post("/transaction_consumption.reject", TransactionConsumptionController, :reject)

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -31,6 +31,20 @@ defmodule AdminAPI.V1.Router do
     post("/transaction.all", TransactionController, :all)
     post("/transaction.get", TransactionController, :get)
 
+
+
+
+    post("/transaction_request.all", TransactionRequestController, :all)
+    post("/transaction_request.get_consumptions", TransactionRequestController, :all)
+
+    post("/account.get_consumptions", TransactionRequestController, :all)
+    post("/user.get_consumptions", TransactionRequestController, :all)
+    post("/wallet.get_consumptions", TransactionRequestController, :all)
+
+    post("/transaction_consumption.get", TransactionConsumptionController, :approve)
+
+
+
     post("/transaction_request.create", TransactionRequestController, :create)
     post("/transaction_request.get", TransactionRequestController, :get)
     post("/transaction_consumption.approve", TransactionConsumptionController, :approve)

--- a/apps/admin_api/lib/admin_api/v1/views/transaction_consumption_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/transaction_consumption_view.ex
@@ -13,4 +13,12 @@ defmodule AdminAPI.V1.TransactionConsumptionView do
     |> TransactionConsumptionSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
+  def render("transaction_consumptions.json", %{
+        transaction_consumptions: transaction_consumptions
+      }) do
+    transaction_consumptions
+    |> TransactionConsumptionSerializer.serialize()
+    |> ResponseSerializer.serialize(success: true)
+  end
 end

--- a/apps/admin_api/lib/admin_api/v1/views/transaction_request_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/transaction_request_view.ex
@@ -13,4 +13,10 @@ defmodule AdminAPI.V1.TransactionRequestView do
     |> TransactionRequestSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
+  def render("transaction_requests.json", %{transaction_requests: transaction_requests}) do
+    transaction_requests
+    |> TransactionRequestSerializer.serialize()
+    |> ResponseSerializer.serialize(success: true)
+  end
 end

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -904,6 +904,23 @@ paths:
   ############################
   #   TRANSACTION REQUESTS   #
   ############################
+  # Endpoint to list all transaction requests
+  /transaction_requests.all:
+    post:
+      tags:
+        - TransactionRequest
+      summary: Get the list of transaction requests
+      operationId: transaction_requests_all
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/TransactionRequestAllBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/TransactionRequestsResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
   # Endpoint to create a transaction request
   /transaction_request.create:
     post:
@@ -955,6 +972,109 @@ paths:
           $ref: "#/components/responses/TransactionConsumptionResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
+
+  ############################
+  # TRANSACTION CONSUMPTIONS #
+  ############################
+  /account.get_consumptions:
+    post:
+      tags:
+        - Account
+      summary: Get the list of transaction consumptions for an account
+      operationId: transaction_consumptions_all_for_account
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/TransactionConsumptionAllForAccountBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/TransactionConsumptionsResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+  /user.get_consumptions:
+    post:
+      tags:
+        - User
+      summary: Get the list of transaction consumptions for a user
+      operationId: transaction_consumptions_all_for_user
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/TransactionConsumptionAllForUserBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/TransactionConsumptionsResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+  /wallet.get_consumptions:
+    post:
+      tags:
+        - Wallet
+      summary: Get the list of transaction consumptions for a wallet
+      operationId: transaction_consumptions_all_for_wallet
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/TransactionConsumptionAllForWalletBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/TransactionConsumptionsResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+  /transaction_request.get_consumptions:
+    post:
+      tags:
+        - TransactionRequest
+      summary: Get the list of transaction consumptions for a transaction request
+      operationId: transaction_consumptions_all_for_transaction_request
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/TransactionConsumptionAllForTransactionRequestBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/TransactionConsumptionsResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+  # Endpoint to list all consumptions
+  /transaction_consumptions.all:
+    post:
+      tags:
+        - TransactionConsumption
+      summary: Get the list of transaction consumptions
+      operationId: transaction_consumptions_all
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/TransactionConsumptionAllBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/TransactionConsumptionsResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+  # Endpoint to get a consumption
+  /transaction_consumption.get:
+    post:
+      tags:
+        - TransactionConsumption
+      summary: Get a consumption.
+      description: This is a server call only.
+      operationId: transaction_consumption_get
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/GetConsumptionRequestBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/TransactionConsumptionResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
   # Endpoint to approve a consumption
   /transaction_consumption.approve:
     post:
@@ -965,6 +1085,7 @@ paths:
       operationId: transaction_consumption_approve
       security:
         - ProviderAuth: []
+        - AdminAuth: []
       requestBody:
         $ref: '#/components/requestBodies/ConsumptionConfirmationRequestBody'
       responses:
@@ -2364,6 +2485,60 @@ components:
     ######################################
     #     TRANSACTION REQUEST SCHEMAS    #
     ######################################
+    TransactionRequestsResponseSchema:
+      description: "The response schema for a list of transaction requests"
+      allOf:
+      - $ref: '#/components/schemas/BaseResponseSchema'
+      - type: object
+        properties:
+          data:
+            type: object
+            allOf:
+              - $ref: '#/components/schemas/PaginatedListSchema'
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TransactionRequestSchema'
+        required:
+          - data
+        example:
+          version: "1"
+          success: true
+          data:
+            object: "list"
+            data:
+              - object: "transaction_request"
+                id: "txr_01cbfg8mafdnbthgb9e68nd9y9"
+                formatted_id: "data|txr_01cbfg8mafdnbthgb9e68nd9y9"
+                socket_topic: "transaction_request:txr_01cbfg8mafdnbthgb9e68nd9y9"
+                type: "send"
+                amount: 100
+                status: "valid"
+                correlation_id: "123"
+                token_id: "tok_OMG_01cbffwvj6ma9a9gg1tb24880q"
+                token: null
+                address: "3a560be5-15d1-4463-9ec2-02bc8ded7120"
+                user_id: "usr_01cbfg922kzmhvw04xvqn17qbd"
+                account_id: "acc_01cbfg9b5hn05rszm3na8jac7f"
+                require_confirmation: true
+                max_consumptions: 3
+                max_consumptions_per_user: null
+                consumption_lifetime: 1000
+                expiration_reason: null
+                allow_amount_override: false
+                metadata: {}
+                encrypted_metadata: {}
+                expiration_date: "2018-01-01T00:00:00Z"
+                expired_at: "2018-01-01T00:00:00Z"
+                created_at: "2018-01-01T00:00:00Z"
+                updated_at: "2018-01-01T00:00:00Z"
+            pagination:
+              per_page: 10
+              current_page: 1
+              is_first_page: true
+              is_last_page: true
     # Schema for transaction request response body
     TransactionRequestSchema:
       description: "The response schema for a transaction request"
@@ -2482,6 +2657,68 @@ components:
             expired_at: "2018-01-01T00:00:00Z"
             created_at: "2018-01-01T00:00:00Z"
             updated_at: "2018-01-01T00:00:00Z"
+
+
+    ######################################
+    #     TRANSACTION REQUEST SCHEMAS    #
+    ######################################
+    TransactionConsumptionsResponseSchema:
+      description: "The response schema for a list of transaction consumptions"
+      allOf:
+      - $ref: '#/components/schemas/BaseResponseSchema'
+      - type: object
+        properties:
+          data:
+            type: object
+            allOf:
+              - $ref: '#/components/schemas/PaginatedListSchema'
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TransactionConsumptionSchema'
+        required:
+          - data
+        example:
+          version: "1"
+          success: true
+          data:
+            object: "list"
+            data:
+              - object: "transaction_consumption"
+                id: "txc_01cbfg9qtdken61agxhx6wvj9h"
+                socket_topic: "transaction_consumption:txc_01cbfg9qtdken61agxhx6wvj9h"
+                status: "confirmed"
+                amount: 100
+                token_id: "tok_OMG_01cbffwvj6ma9a9gg1tb24880q"
+                token: {}
+                correlation_id: "7e9c0be5-15d1-4463-9ec2-02bc8ded7120"
+                idempotency_token: "7831c0be5-15d1-4463-9ec2-02bc8ded7120"
+                transaction_id: "txn_01cbfga8g0dgwcfc7xh6ks1njt"
+                transaction: {}
+                user_id: "usr_01cbfgak47ng6x72vbwjca6j4v"
+                user: {}
+                account_id: "acc_01cbfgatsanznvzffqsekta5f0"
+                account: {}
+                transaction_request_id: "txr_01cbfgb66cby8wp5wpq6n4pm0h"
+                transaction_request: {}
+                address: "5555cer3-15d1-4463-9ec2-02bc8ded7120"
+                metadata: {}
+                encrypted_metadata: {}
+                expiration_date: null
+                created_at: "2018-01-01T00:00:00Z"
+                updated_at: "2018-01-01T00:00:00Z"
+                approved_at: "2018-01-01T00:00:00Z"
+                rejected_at: null
+                confirmed_at: "2018-01-01T00:00:00Z"
+                failed_at: null
+                expired_at: null
+            pagination:
+              per_page: 10
+              current_page: 1
+              is_first_page: true
+              is_last_page: true
     # Schema for transaction request consumption response body
     TransactionConsumptionSchema:
       description: "The schema for a transaction request consumption"
@@ -4009,6 +4246,35 @@ components:
               amount: 100
               correlation_id: "123"
               address: "2ae52683-68d8-4af6-94d7-5ed4c34ecf1a"
+    TransactionRequestAllBody:
+      description: The parameters to use for listing the transaction requests
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              page:
+                type: integer
+                minimum: 1
+              per_page:
+                type: integer
+                minimum: 1
+              search_term:
+                type: string
+              search_terms:
+                type: object
+              sort_by:
+                type: string
+              sort_dir:
+                type: string
+                enum: ["asc", "desc"]
+            example:
+              page: 1
+              per_page: 10
+              search_term: ""
+              search_terms: {}
+              sort_by: "created_at"
+              sort_dir: "desc"
     GetTransactionRequestBody:
       description: Get a transaction request using the specified ID.
       required: true
@@ -4065,6 +4331,171 @@ components:
               address: "2ae52683-68d8-4af6-94d7-5ed4c34ecf1a"
               metadata: {}
               encrypted_metadata: {}
+    TransactionConsumptionAllBody:
+      description: The parameters to use for listing the consumptions
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              page:
+                type: integer
+                minimum: 1
+              per_page:
+                type: integer
+                minimum: 1
+              search_term:
+                type: string
+              search_terms:
+                type: object
+              sort_by:
+                type: string
+              sort_dir:
+                type: string
+                enum: ["asc", "desc"]
+            example:
+              page: 1
+              per_page: 10
+              search_term: ""
+              sort_by: "created_at"
+              sort_dir: "desc"
+    TransactionConsumptionAllForAccountBody:
+      description: The parameters to use for listing the consumptions for an account
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              account_id:
+                type: string
+              page:
+                type: integer
+                minimum: 1
+              per_page:
+                type: integer
+                minimum: 1
+              search_terms:
+                type: object
+              sort_by:
+                type: string
+              sort_dir:
+                type: string
+                enum: ["asc", "desc"]
+            required:
+              - account_id
+            example:
+              account_id: "acc_01ca2p8jqans5aty5gj5etmjcf"
+              page: 1
+              per_page: 10
+              search_terms: {}
+              sort_by: "created_at"
+              sort_dir: "desc"
+    TransactionConsumptionAllForUserBody:
+      description: The parameters to use for listing the consumptions for a user
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              user_id:
+                type: string
+              page:
+                type: integer
+                minimum: 1
+              per_page:
+                type: integer
+                minimum: 1
+              search_terms:
+                type: object
+              sort_by:
+                type: string
+              sort_dir:
+                type: string
+                enum: ["asc", "desc"]
+            required:
+              - user_id
+            example:
+              user_id: "usr_02cbfg6v9thrc3sd9m1v4gazjv"
+              page: 1
+              per_page: 10
+              search_terms: {}
+              sort_by: "created_at"
+              sort_dir: "desc"
+    TransactionConsumptionAllForWalletBody:
+      description: The parameters to use for listing the consumptions for a wallet
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              address:
+                type: string
+              page:
+                type: integer
+                minimum: 1
+              per_page:
+                type: integer
+                minimum: 1
+              search_terms:
+                type: object
+              sort_by:
+                type: string
+              sort_dir:
+                type: string
+                enum: ["asc", "desc"]
+            required:
+              - address
+            example:
+              address: "232454354"
+              page: 1
+              per_page: 10
+              search_terms: {}
+              sort_by: "created_at"
+              sort_dir: "desc"
+    TransactionConsumptionAllForTransactionRequestBody:
+      description: The parameters to use for listing the consumptions for a transaction request
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              transaction_request_id:
+                type: string
+              page:
+                type: integer
+                minimum: 1
+              per_page:
+                type: integer
+                minimum: 1
+              search_terms:
+                type: object
+              sort_by:
+                type: string
+              sort_dir:
+                type: string
+                enum: ["asc", "desc"]
+            required:
+              - transaction_request_id
+            example:
+              transaction_request_id: "txr_01cbfg8mafdnbthgb9e68nd9y9"
+              page: 1
+              per_page: 10
+              search_terms: {}
+              sort_by: "created_at"
+              sort_dir: "desc"
+    GetConsumptionRequestBody:
+      description: Get a consumption using the specified ID.
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              id:
+                type: string
+            required:
+              - id
+            example:
+              id: "txc_01abfg5m2ee06kzm8tbysfmmw5"
     ConsumptionConfirmationRequestBody:
       description: Approve or reject a consumption using the specified ID.
       required: true
@@ -4336,6 +4767,7 @@ components:
         application/vnd.omisego.v1+json:
           schema:
             $ref: '#/components/schemas/MultipleWalletsSchema'
+
     ######################################
     #        TRANSACTION RESPONSES       #
     ######################################
@@ -4355,6 +4787,12 @@ components:
     ######################################
     #   TRANSACTION REQUEST RESPONSES    #
     ######################################
+    TransactionRequestsResponse:
+      description: "Returns a list of transaction requests"
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            $ref: '#/components/schemas/TransactionRequestsResponseSchema'
     # Schema for transaction request response body
     TransactionRequestResponse:
       description: Transaction request response
@@ -4362,9 +4800,19 @@ components:
         application/vnd.omisego.v1+json:
           schema:
             $ref: '#/components/schemas/TransactionRequestSchema'
+
+    ######################################
+    # TRANSACTION CONSUMPTIONS RESPONSES #
+    ######################################
+    TransactionConsumptionsResponse:
+      description: "Returns a list of transaction consumptions"
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            $ref: '#/components/schemas/TransactionConsumptionsResponseSchema'
     # Schema for transaction request response body
     TransactionConsumptionResponse:
-      description: Transaction request consumption response
+      description: "Transaction request consumption response"
       content:
         application/vnd.omisego.v1+json:
           schema:

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -33,8 +33,390 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
     }
   end
 
+  describe "/transaction_consumption.all" do
+    setup do
+      user = get_test_user()
+      account = Account.get_master_account()
+
+      tc_1 = insert(:transaction_consumption, user_uuid: user.uuid, status: "pending")
+      tc_2 = insert(:transaction_consumption, account_uuid: account.uuid, status: "pending")
+      tc_3 = insert(:transaction_consumption, account_uuid: account.uuid, status: "confirmed")
+
+      %{
+        user: user,
+        tc_1: tc_1,
+        tc_2: tc_2,
+        tc_3: tc_3
+      }
+    end
+
+    test "returns all the transaction_consumptions", meta do
+      response =
+        admin_user_request("/transaction_consumption.all", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      transfers = [
+        meta.tc_1,
+        meta.tc_2,
+        meta.tc_3
+      ]
+
+      assert length(response["data"]["data"]) == length(transfers)
+
+      # All transfers made during setup should exist in the response
+      assert Enum.all?(transfers, fn transfer ->
+               Enum.any?(response["data"]["data"], fn data ->
+                 transfer.id == data["id"]
+               end)
+             end)
+    end
+
+    test "returns all the transaction_consumptions for a specific status", meta do
+      response =
+        admin_user_request("/transaction_consumption.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "pending"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_1.id,
+               meta.tc_2.id
+             ]
+    end
+
+    test "returns all transaction_consumptions filtered", meta do
+      response =
+        admin_user_request("/transaction_consumption.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_1.id,
+               meta.tc_2.id
+             ]
+    end
+
+    test "returns all transaction_consumptions sorted and paginated", meta do
+      response =
+        admin_user_request("/transaction_consumption.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_1.id,
+               meta.tc_2.id
+             ]
+    end
+  end
+
+  describe "/account.get_transaction_consumptions" do
+    setup do
+      user = get_test_user()
+      account = Account.get_master_account()
+
+      tc_1 = insert(:transaction_consumption, user_uuid: user.uuid, status: "pending")
+      tc_2 = insert(:transaction_consumption, account_uuid: account.uuid, status: "pending")
+      tc_3 = insert(:transaction_consumption, account_uuid: account.uuid, status: "confirmed")
+
+      %{
+        user: user,
+        account: account,
+        tc_1: tc_1,
+        tc_2: tc_2,
+        tc_3: tc_3
+      }
+    end
+
+    test "returns :invalid_parameter when account_id is not provided" do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Parameter 'account_id' is required.",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "success" => false,
+               "version" => "1"
+             }
+    end
+
+    test "returns :account_id_not_found when user_id is not provided" do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => "fake",
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "messages" => nil,
+                 "object" => "error",
+                 "code" => "account:id_not_found",
+                 "description" => "There is no account corresponding to the provided id"
+               }
+             }
+    end
+
+    test "returns all the transaction_consumptions for an account", meta do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => meta.account.id,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      transfers = [
+        meta.tc_2,
+        meta.tc_3
+      ]
+
+      assert length(response["data"]["data"]) == 2
+
+      # All transfers made during setup should exist in the response
+      assert Enum.all?(transfers, fn transfer ->
+               Enum.any?(response["data"]["data"], fn data ->
+                 transfer.id == data["id"]
+               end)
+             end)
+    end
+
+    test "returns all the transaction_consumptions for a specific status", meta do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => meta.account.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "pending"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 1
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id
+             ]
+    end
+
+    test "ignores the search_term parameter", meta do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => meta.account.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all transaction_consumptions sorted and paginated", meta do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => meta.account.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+  end
+
+  describe "/user.get_transaction_consumptions" do
+    setup do
+      user = get_test_user()
+      account = Account.get_master_account()
+
+      tc_1 = insert(:transaction_consumption, account_uuid: account.uuid, status: "pending")
+      tc_2 = insert(:transaction_consumption, user_uuid: user.uuid, status: "pending")
+      tc_3 = insert(:transaction_consumption, user_uuid: user.uuid, status: "confirmed")
+
+      %{
+        user: user,
+        account: account,
+        tc_1: tc_1,
+        tc_2: tc_2,
+        tc_3: tc_3
+      }
+    end
+
+    test "returns :invalid_parameter when user_id is not provided" do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Parameter 'user_id' is required.",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "success" => false,
+               "version" => "1"
+             }
+    end
+
+    test "returns :user_id_not_found when user_id is not provided" do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => "fake",
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "messages" => nil,
+                 "object" => "error",
+                 "code" => "user:id_not_found",
+                 "description" => "There is no user corresponding to the provided id"
+               }
+             }
+    end
+
+    test "returns all the transaction_consumptions for a user", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => meta.user.id,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert length(response["data"]["data"]) == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all the transaction_consumptions for a specific status", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => meta.user.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "pending"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 1
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id
+             ]
+    end
+
+    test "ignores the search_term parameter", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => meta.user.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all transaction_consumptions sorted and paginated", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => meta.user.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+  end
+
   describe "/transaction_consumption.get" do
-    test "returns the transaction request" do
+    test "returns the transaction consumption" do
       transaction_consumption = insert(:transaction_consumption)
 
       response =

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -33,6 +33,39 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
     }
   end
 
+  describe "/transaction_consumption.get" do
+    test "returns the transaction request" do
+      transaction_consumption = insert(:transaction_consumption)
+
+      response =
+        admin_user_request("/transaction_consumption.get", %{
+          id: transaction_consumption.id
+        })
+
+      assert response["success"] == true
+      assert response["data"]["id"] == transaction_consumption.id
+    end
+
+    test "returns an error when the request ID is not found" do
+      response =
+        admin_user_request("/transaction_consumption.get", %{
+          id: "123"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction_consumption:transaction_consumption_not_found",
+                 "description" =>
+                   "There is no transaction consumption corresponding to the provided ID.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+  end
+
   describe "/transaction_request.consume" do
     test "consumes the request and transfers the appropriate amount of tokens", meta do
       transaction_request =

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
@@ -3,6 +3,107 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
   alias EWalletDB.{Repo, TransactionRequest, User, Account}
   alias EWallet.Web.{Date, V1.TokenSerializer, V1.UserSerializer}
 
+  describe "/transaction_request.all" do
+    setup do
+      user = get_test_user()
+      account = Account.get_master_account()
+
+      tr_1 = insert(:transaction_request, user_uuid: user.uuid, status: "valid")
+      tr_2 = insert(:transaction_request, account_uuid: account.uuid, status: "valid")
+      tr_3 = insert(:transaction_request, account_uuid: account.uuid, status: "expired")
+
+      %{
+        user: user,
+        tr_1: tr_1,
+        tr_2: tr_2,
+        tr_3: tr_3
+      }
+    end
+
+    test "returns all the transaction_requests", meta do
+      response =
+        admin_user_request("/transaction_request.all", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      transfers = [
+        meta.tr_1,
+        meta.tr_2,
+        meta.tr_3
+      ]
+
+      assert length(response["data"]["data"]) == length(transfers)
+
+      # All transfers made during setup should exist in the response
+      assert Enum.all?(transfers, fn transfer ->
+               Enum.any?(response["data"]["data"], fn data ->
+                 transfer.id == data["id"]
+               end)
+             end)
+    end
+
+    test "returns all the transaction_requests for a specific status", meta do
+      response =
+        admin_user_request("/transaction_request.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "valid"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tr_1.id,
+               meta.tr_2.id
+             ]
+    end
+
+    test "returns all transaction_requests filtered", meta do
+      response =
+        admin_user_request("/transaction_request.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "valid"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tr_1.id,
+               meta.tr_2.id
+             ]
+    end
+
+    test "returns all transaction_requests sorted and paginated", meta do
+      response =
+        admin_user_request("/transaction_request.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tr_1.id,
+               meta.tr_2.id
+             ]
+    end
+  end
+
   describe "/transaction_request.create" do
     test "creates a transaction request with all the params" do
       user = get_test_user()
@@ -235,7 +336,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
                "data" => %{
                  "code" => "transaction_request:transaction_request_not_found",
                  "description" =>
-                   "There is no transaction request corresponding to the provided address",
+                   "There is no transaction request corresponding to the provided ID.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
@@ -3,6 +3,10 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
   alias EWalletDB.{Repo, TransactionRequest, User, Account}
   alias EWallet.Web.{Date, V1.TokenSerializer, V1.UserSerializer}
 
+  describe "/transaction_request.all" do
+
+  end
+
   describe "/transaction_request.create" do
     test "creates a transaction request with all the params" do
       user = get_test_user()

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
@@ -53,7 +53,6 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
           }
         })
 
-
       assert response["data"]["data"] |> length() == 2
 
       assert Enum.map(response["data"]["data"], fn t ->
@@ -337,7 +336,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
                "data" => %{
                  "code" => "transaction_request:transaction_request_not_found",
                  "description" =>
-                   "There is no transaction request corresponding to the provided address",
+                   "There is no transaction request corresponding to the provided ID.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
@@ -4,7 +4,105 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
   alias EWallet.Web.{Date, V1.TokenSerializer, V1.UserSerializer}
 
   describe "/transaction_request.all" do
+    setup do
+      user = get_test_user()
+      account = Account.get_master_account()
 
+      tr_1 = insert(:transaction_request, user_uuid: user.uuid, status: "valid")
+      tr_2 = insert(:transaction_request, account_uuid: account.uuid, status: "valid")
+      tr_3 = insert(:transaction_request, account_uuid: account.uuid, status: "expired")
+
+      %{
+        user: user,
+        tr_1: tr_1,
+        tr_2: tr_2,
+        tr_3: tr_3
+      }
+    end
+
+    test "returns all the transaction_requests", meta do
+      response =
+        provider_request("/transaction_request.all", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      transfers = [
+        meta.tr_1,
+        meta.tr_2,
+        meta.tr_3
+      ]
+
+      assert length(response["data"]["data"]) == length(transfers)
+
+      # All transfers made during setup should exist in the response
+      assert Enum.all?(transfers, fn transfer ->
+               Enum.any?(response["data"]["data"], fn data ->
+                 transfer.id == data["id"]
+               end)
+             end)
+    end
+
+    test "returns all the transaction_requests for a specific status", meta do
+      response =
+        provider_request("/transaction_request.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "valid"
+          }
+        })
+
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tr_1.id,
+               meta.tr_2.id
+             ]
+    end
+
+    test "returns all transaction_requests filtered", meta do
+      response =
+        provider_request("/transaction_request.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "valid"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tr_1.id,
+               meta.tr_2.id
+             ]
+    end
+
+    test "returns all transaction_requests sorted and paginated", meta do
+      response =
+        provider_request("/transaction_request.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tr_1.id,
+               meta.tr_2.id
+             ]
+    end
   end
 
   describe "/transaction_request.create" do

--- a/apps/ewallet/lib/ewallet/web/search_parser.ex
+++ b/apps/ewallet/lib/ewallet/web/search_parser.ex
@@ -44,6 +44,17 @@ defmodule EWallet.Web.SearchParser do
 
   def to_query(queryable, _, _, _), do: queryable
 
+  @spec search_with_terms(Ecto.Queryable.t(), map(), [atom()]) :: Ecto.Queryable.t()
+  @spec search_with_terms(Ecto.Queryable.t(), map(), [atom()], map()) :: Ecto.Queryable.t()
+  def search_with_terms(queryable, terms, fields, mapping \\ %{})
+
+  def search_with_terms(queryable, %{"search_terms" => terms}, fields, mapping)
+      when terms != nil do
+    to_query(queryable, %{"search_terms" => terms}, fields, mapping)
+  end
+
+  def search_with_terms(queryable, _, _, _), do: queryable
+
   defp map_field(original, mapping) do
     case mapping[original] do
       nil -> original

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -63,7 +63,11 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     transaction_request_not_found: %{
       code: "transaction_request:transaction_request_not_found",
-      description: "There is no transaction request corresponding to the provided address"
+      description: "There is no transaction request corresponding to the provided ID."
+    },
+    transaction_consumption_not_found: %{
+      code: "transaction_consumption:transaction_consumption_not_found",
+      description: "There is no transaction consumption corresponding to the provided ID."
     },
     same_address: %{
       code: "transaction:same_address",

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
@@ -3,18 +3,23 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
   Serializes transaction request consumption data into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.Date
+  alias EWallet.Web.{Date, Paginator}
 
   alias EWallet.Web.V1.{
     AccountSerializer,
     TokenSerializer,
     TransactionSerializer,
     TransactionRequestSerializer,
-    UserSerializer
+    UserSerializer,
+    PaginatorSerializer
   }
 
   alias EWalletDB.TransactionConsumption
   alias EWalletDB.Helpers.{Assoc, Preloader}
+
+  def serialize(%Paginator{} = paginator) do
+    PaginatorSerializer.serialize(paginator, &serialize/1)
+  end
 
   def serialize(%TransactionConsumption{} = consumption) do
     consumption =

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
@@ -7,12 +7,17 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
   alias EWallet.Web.V1.{
     AccountSerializer,
     TokenSerializer,
-    UserSerializer
+    UserSerializer,
+    PaginatorSerializer
   }
 
-  alias EWallet.Web.Date
+  alias EWallet.Web.{Date, Paginator}
   alias EWalletDB.Helpers.{Assoc, Preloader}
   alias EWalletDB.TransactionRequest
+
+  def serialize(%Paginator{} = paginator) do
+    PaginatorSerializer.serialize(paginator, &serialize/1)
+  end
 
   def serialize(%TransactionRequest{} = transaction_request) do
     transaction_request =

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -278,7 +278,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                "data" => %{
                  "code" => "transaction_request:transaction_request_not_found",
                  "description" =>
-                   "There is no transaction request corresponding to the provided address",
+                   "There is no transaction request corresponding to the provided ID.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_consumption.ex
@@ -237,6 +237,10 @@ defmodule EWalletDB.TransactionConsumption do
     end
   end
 
+  @spec query_all_for(Atom.t() | String.t(), any()) :: Ecto.Query.t()
+  def query_all_for(field_name, value),
+    do: where(TransactionConsumption, [t], field(t, ^field_name) == ^value)
+
   @doc """
   Get all confirmed transaction consumptions.
   """


### PR DESCRIPTION
Issue/Task Number: T365

# Overview

This PR adds the missing endpoints to deal with transaction requests and consumptions. They can also be used to do long-polling of the pending consumptions for accounts/users/wallets or transaction requests (by sending `search_terms: {status: "pending"}`.

# Changes

- Added `/transaction_request.all`
- Added `/account.get_transaction_consumptions`
- Added `/user.get_transaction_consumptions`
- Added `/wallet.get_transaction_consumptions`
- Added `/transaction_request.get_transaction_consumptions`
- Added `/transaction_consumptions.all`
- Added `/transaction_consumptions.get`

To get only pending ones, the four endpoints using `/entity.get_transaction_consumptions` need the param `search_terms` to be passed with `{status: "pending"}`.

# Implementation Details

Due to the way the `SearchParser` is implemented, it is not possible to reliably use both `search_term` and filter per account/user/whatever (because of the way the queries are built with `OR` in the search parser, can't find a way to have `(X) AND (A OR B)` without using Ecto Dynamic Queries and basically rewriting the whole Searcher and updating all the controllers. Instead, I just prevent the use of `search_term`, so when using those endpoints, only `search_terms` will work.

# Usage

See OpenAPI spec.