### PR TITLE
Improve amounts displayed in insufficient funds error

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -900,9 +900,9 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                  "messages" => nil,
                  "code" => "transaction:insufficient_funds",
                  "description" =>
-                   "The specified wallet (#{meta.account_wallet.address}) does not contain enough funds. Available: 0.0 #{
+                   "The specified wallet (#{meta.account_wallet.address}) does not contain enough funds. Available: 0 #{
                      meta.token.id
-                   } - Attempted debit: 100000.0 #{meta.token.id}"
+                   } - Attempted debit: 100000 #{meta.token.id}"
                }
              }
 

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -368,7 +368,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
     end
 
     test "returns transaction:insufficient_funds when the sending address does not have enough funds" do
-      token = insert(:token)
+      token = insert(:token, subunit_to_unit: 100)
       wallet_1 = insert(:wallet)
       wallet_2 = insert(:wallet)
 
@@ -378,7 +378,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
           "from_address" => wallet_1.address,
           "to_address" => wallet_2.address,
           "token_id" => token.id,
-          "amount" => 1_000_000
+          "amount" => 1_234_567
         })
 
       assert response["success"] == false
@@ -386,9 +386,9 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       assert response["data"] == %{
                "code" => "transaction:insufficient_funds",
                "description" =>
-                 "The specified wallet (#{wallet_1.address}) does not contain enough funds. Available: 0.0 #{
+                 "The specified wallet (#{wallet_1.address}) does not contain enough funds. Available: 0 #{
                    token.id
-                 } - Attempted debit: 10000.0 #{token.id}",
+                 } - Attempted debit: 12345.67 #{token.id}",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transfer_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transfer_controller_test.exs
@@ -187,8 +187,8 @@ defmodule AdminAPI.V1.AdminAuth.TransferControllerTest do
                  "code" => "transaction:insufficient_funds",
                  "description" =>
                    "The specified wallet (#{wallet1.address}) does not " <>
-                     "contain enough funds. Available: 0.0 #{token.id} - " <>
-                     "Attempted debit: 100000.0 #{token.id}",
+                     "contain enough funds. Available: 0 #{token.id} - " <>
+                     "Attempted debit: 100000 #{token.id}",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -517,8 +517,8 @@ defmodule AdminAPI.V1.AdminAuth.TransferControllerTest do
                  "code" => "transaction:insufficient_funds",
                  "description" =>
                    "The specified wallet (#{user_wallet.address})" <>
-                     " does not contain enough funds. Available: 0.0 " <>
-                     "#{token.id} - Attempted debit: 1000.0 " <> "#{token.id}",
+                     " does not contain enough funds. Available: 0 " <>
+                     "#{token.id} - Attempted debit: 1000 " <> "#{token.id}",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
@@ -900,9 +900,9 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                  "messages" => nil,
                  "code" => "transaction:insufficient_funds",
                  "description" =>
-                   "The specified wallet (#{meta.account_wallet.address}) does not contain enough funds. Available: 0.0 #{
+                   "The specified wallet (#{meta.account_wallet.address}) does not contain enough funds. Available: 0 #{
                      meta.token.id
-                   } - Attempted debit: 100000.0 #{meta.token.id}"
+                   } - Attempted debit: 100000 #{meta.token.id}"
                }
              }
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -385,9 +385,9 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
       assert response["data"] == %{
                "code" => "transaction:insufficient_funds",
                "description" =>
-                 "The specified wallet (#{wallet_1.address}) does not contain enough funds. Available: 0.0 #{
+                 "The specified wallet (#{wallet_1.address}) does not contain enough funds. Available: 0 #{
                    token.id
-                 } - Attempted debit: 10000.0 #{token.id}",
+                 } - Attempted debit: 10000 #{token.id}",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transfer_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transfer_controller_test.exs
@@ -187,8 +187,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransferControllerTest do
                  "code" => "transaction:insufficient_funds",
                  "description" =>
                    "The specified wallet (#{wallet1.address}) does not " <>
-                     "contain enough funds. Available: 0.0 #{token.id} - " <>
-                     "Attempted debit: 100000.0 #{token.id}",
+                     "contain enough funds. Available: 0 #{token.id} - " <>
+                     "Attempted debit: 100000 #{token.id}",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -517,8 +517,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransferControllerTest do
                  "code" => "transaction:insufficient_funds",
                  "description" =>
                    "The specified wallet (#{user_wallet.address})" <>
-                     " does not contain enough funds. Available: 0.0 " <>
-                     "#{token.id} - Attempted debit: 1000.0 " <> "#{token.id}",
+                     " does not contain enough funds. Available: 0 " <>
+                     "#{token.id} - Attempted debit: 1000 " <> "#{token.id}",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/ewallet/lib/ewallet/formatters/amount_formatter.ex
+++ b/apps/ewallet/lib/ewallet/formatters/amount_formatter.ex
@@ -3,18 +3,19 @@ defmodule EWallet.AmountFormatter do
   A string formatter for amounts
   """
   def format(amount, subunit_to_unit) do
-    float_amount = amount / subunit_to_unit
-
-    float_amount
-    |> float_to_binary(to_decimals(subunit_to_unit))
+    subunit_to_unit
+    |> to_decimals()
+    |> float_to_binary(amount / subunit_to_unit)
     |> String.replace_trailing(".0", "")
   end
 
-  defp float_to_binary(value, decimals) do
+  defp float_to_binary(decimals, value) do
     :erlang.float_to_binary(value, [:compact, {:decimals, decimals}])
   end
 
   defp to_decimals(subunit_to_unit) do
-    Kernel.trunc(:math.log10(subunit_to_unit))
+    subunit_to_unit
+    |> :math.log10()
+    |> Kernel.trunc()
   end
 end

--- a/apps/ewallet/lib/ewallet/formatters/amount_formatter.ex
+++ b/apps/ewallet/lib/ewallet/formatters/amount_formatter.ex
@@ -1,0 +1,20 @@
+defmodule EWallet.AmountFormatter do
+  @moduledoc """
+  A string formatter for amounts
+  """
+  def format(amount, subunit_to_unit) do
+    float_amount = amount / subunit_to_unit
+
+    float_amount
+    |> float_to_binary(to_decimals(subunit_to_unit))
+    |> String.replace_trailing(".0", "")
+  end
+
+  defp float_to_binary(value, decimals) do
+    :erlang.float_to_binary(value, [:compact, {:decimals, decimals}])
+  end
+
+  defp to_decimals(subunit_to_unit) do
+    Kernel.trunc(:math.log10(subunit_to_unit))
+  end
+end

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -5,6 +5,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
   import Ecto.Changeset, only: [traverse_errors: 2]
   alias Ecto.Changeset
   alias EWallet.Web.V1.ErrorSerializer
+  alias EWallet.AmountFormatter
   alias EWalletDB.Token
 
   @errors %{
@@ -250,8 +251,8 @@ defmodule EWallet.Web.V1.ErrorHandler do
 
       data = %{
         "address" => address,
-        "current_amount" => float_to_binary(current_amount / token.subunit_to_unit),
-        "amount_to_debit" => float_to_binary(amount_to_debit / token.subunit_to_unit),
+        "current_amount" => AmountFormatter.format(current_amount, token.subunit_to_unit),
+        "amount_to_debit" => AmountFormatter.format(amount_to_debit, token.subunit_to_unit),
         "token_id" => token.id
       }
 
@@ -339,10 +340,6 @@ defmodule EWallet.Web.V1.ErrorHandler do
 
   defp stringify_field({key, _}) do
     "`" <> to_string(key) <> "`"
-  end
-
-  defp float_to_binary(value) do
-    :erlang.float_to_binary(value, [:compact, {:decimals, 1}])
   end
 
   defp error_fields(changeset) do

--- a/apps/ewallet/test/ewallet/formatters/amount_formatter_test.exs
+++ b/apps/ewallet/test/ewallet/formatters/amount_formatter_test.exs
@@ -1,0 +1,24 @@
+defmodule EWallet.AmountFormatterTest do
+  use ExUnit.Case
+  alias EWallet.AmountFormatter
+
+  describe "format/2" do
+    test "formats correctly given an amount and a subunit_to_unit" do
+      res = AmountFormatter.format(123, 100)
+
+      assert res == "1.23"
+    end
+
+    test "formats correctly given a subunit_to_unit bigger than amount" do
+      res = AmountFormatter.format(123, 10_000)
+
+      assert res == "0.0123"
+    end
+
+    test "formats correctly given an amount with trailing zeros" do
+      res = AmountFormatter.format(1_000_000, 10)
+
+      assert res == "100000"
+    end
+  end
+end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -163,8 +163,8 @@ defmodule EWalletAPI.V1.TransferControllerTest do
                  "code" => "transaction:insufficient_funds",
                  "description" =>
                    "The specified wallet (#{wallet1.address}) does not " <>
-                     "contain enough funds. Available: 0.0 #{token.id} - " <>
-                     "Attempted debit: 100000.0 #{token.id}",
+                     "contain enough funds. Available: 0 #{token.id} - " <>
+                     "Attempted debit: 100000 #{token.id}",
                  "messages" => nil,
                  "object" => "error"
                }


### PR DESCRIPTION
Issue/Task Number: T449

# Overview

This PR improves the display amount in `insufficient_funds` errors.
There was 2 issues in the current implementation:
- trailing zeros (ie: 10000.0)
- decimals limited to 1 (ie: 1234.5), so we were missing accuracy if the subunit_to_unit was bigger than 10

# Changes

- Created a `AmountFormatter` that takes care of formatting amount for display
- The number of decimals is now dynamic depending on the subunit_to_unit given
- The string is formatted so if it ends with '.0' it's truncated
