### PR TITLE
Rename constraint names to align with latest table schemas

### DIFF
--- a/apps/ewallet_db/priv/repo/migrations/20180626055050_update_constraint_names.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180626055050_update_constraint_names.exs
@@ -1,0 +1,45 @@
+defmodule EWalletDB.Repo.Migrations.UpdateConstraintNames do
+  use Ecto.Migration
+
+  @renames [
+    # {table, from_constraint, to_constraint},
+    {:account, "account_parent_id_fkey", "account_parent_uuid_fkey"},
+    {:api_key, "api_key_account_id_fkey", "api_key_account_uuid_fkey"},
+    {:auth_token, "auth_token_user_id_fkey", "auth_token_user_uuid_fkey"},
+    {:forget_password_request, "forget_password_request_user_id_fkey", "forget_password_request_user_uuid_fkey"},
+    {:key, "key_account_id_fkey", "key_account_uuid_fkey"},
+    {:membership, "membership_account_id_fkey", "membership_account_uuid_fkey"},
+    {:membership, "membership_user_id_fkey", "membership_user_uuid_fkey"},
+    {:membership, "membership_role_id_fkey", "membership_role_uuid_fkey"},
+    {:mint, "mint_account_id_fkey", "mint_account_uuid_fkey"},
+    {:token, "minted_token_pkey", "token_pkey"},
+    {:transaction, "transfer_pkey", "transaction_pkey"},
+    {:transaction, "transfer_exchange_account_uuid_fkey", "transaction_exchange_account_uuid_fkey"},
+    {:transaction_consumption, "transaction_request_consumption_pkey", "transaction_consumption_pkey"},
+    {:transaction_consumption, "transaction_request_consumption_account_id_fkey", "transaction_consumption_account_uuid_fkey"},
+    {:transaction_consumption, "transaction_request_consumption_user_id_fkey", "transaction_consumption_user_uuid_fkey"},
+    {:transaction_consumption, "transaction_request_consumption_transaction_request_id_fkey", "transaction_consumption_transaction_request_uuid_fkey"},
+    {:transaction_request, "transaction_request_user_id_fkey", "transaction_request_user_uuid_fkey"},
+    {:transaction_request, "transaction_request_account_id_fkey", "transaction_request_account_uuid_fkey"},
+    {:user, "user_invite_id_fkey", "user_invite_uuid_fkey"},
+    {:wallet, "balance_pkey", "wallet_pkey"},
+    {:wallet, "balance_account_id_fkey", "wallet_account_uuid_fkey"},
+    {:wallet, "balance_user_id_fkey", "wallet_user_uuid_fkey"}
+  ]
+
+  def up do
+    Enum.each(@renames, fn {table, from, to} ->
+      rename_constraint(table, from, to)
+    end)
+  end
+
+  def down do
+    Enum.each(@renames, fn {table, from, to} ->
+      rename_constraint(table, to, from)
+    end)
+  end
+
+  defp rename_constraint(table, from_constraint, to_constraint) do
+    execute ~s/ALTER TABLE "#{table}" RENAME CONSTRAINT "#{from_constraint}" TO "#{to_constraint}"/
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T330

# Overview

Fixes quite a few constraint names that were out of sync due to columns being renamed over time.

# Changes

- Add a new DB migration that aligns the constraint names with the latest table column names

# Implementation Details

I decided to use `execute()` with raw SQLs due to readability and not having to depend on column properties.

This `ALTER TABLE ... RENAME CONSTRAINT ...` is available since postgres 9.1 released in 2011 so it should be safe enough.

All constraints in LocalLedgerDB looks correct so there's no migration for that.

# Usage

Run `mix ecto.migrate`.

To check all the constraint names, run the following SQL:

```sql
SELECT
    tc.constraint_name,
    tc.table_name || '.' || kcu.column_name AS table_column
FROM 
    information_schema.table_constraints AS tc 
    JOIN information_schema.key_column_usage AS kcu
      ON tc.constraint_name = kcu.constraint_name
    JOIN information_schema.constraint_column_usage AS ccu
      ON ccu.constraint_name = tc.constraint_name;

-- Thanks to https://gist.github.com/PickledDragon/dd41f4e72b428175354d
```

# Impact

Run `mix ecto.migrate` after deploy.
