### PR TITLE
Update address format to align with OIP-3

### DIFF
--- a/apps/admin_api/test/admin_api/v1/channels/address_channel_test.exs
+++ b/apps/admin_api/test/admin_api/v1/channels/address_channel_test.exs
@@ -23,7 +23,7 @@ defmodule AdminAPI.V1.WalletChannelTest do
       {res, code} =
         "test"
         |> socket(%{auth: %{authenticated: true, account: account}})
-        |> subscribe_and_join(WalletChannel, "address:123")
+        |> subscribe_and_join(WalletChannel, "address:none000000000000")
 
       assert res == :error
       assert code == :channel_not_found

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -656,7 +656,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
     test "returns :address_not_found when address is not provided" do
       response =
         admin_user_request("/wallet.get_transaction_consumptions", %{
-          "address" => "fake",
+          "address" => "fake-0000-0000-0000",
           "sort_by" => "created",
           "sort_dir" => "asc"
         })

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -433,7 +433,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
         admin_user_request("/transaction.create", %{
           "idempotency_token" => "123",
           "from_address" => wallet_1.address,
-          "to_address" => "fake",
+          "to_address" => "fake-0000-0000-0000",
           "token_id" => token.id,
           "amount" => 1_000_000
         })
@@ -455,7 +455,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       response =
         admin_user_request("/transaction.create", %{
           "idempotency_token" => "123",
-          "from_address" => "fake",
+          "from_address" => "fake-0000-0000-0000",
           "to_address" => wallet_2.address,
           "token_id" => token.id,
           "amount" => 1_000_000

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
@@ -244,7 +244,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
           token_id: token.id,
           correlation_id: nil,
           amount: nil,
-          address: "fake"
+          address: "FAKE-0000-0000-0000"
         })
 
       assert response == %{

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transfer_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transfer_controller_test.exs
@@ -202,7 +202,7 @@ defmodule AdminAPI.V1.AdminAuth.TransferControllerTest do
       response =
         admin_user_request("/transfer", %{
           idempotency_token: UUID.generate(),
-          from_address: "00000000-0000-0000-0000-000000000000",
+          from_address: "fake-0000-0000-0000",
           to_address: wallet.address,
           token_id: token.id,
           amount: 100_000,
@@ -229,7 +229,7 @@ defmodule AdminAPI.V1.AdminAuth.TransferControllerTest do
         admin_user_request("/transfer", %{
           idempotency_token: UUID.generate(),
           from_address: wallet.address,
-          to_address: "00000000-0000-0000-0000-000000000000",
+          to_address: "fake-0000-0000-0000",
           token_id: token.id,
           amount: 100_000,
           metadata: %{}

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/wallet_controller_test.exs
@@ -517,10 +517,9 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
                "description" =>
-                 "Invalid parameter provided `account_id`, `user_id` can't all be blank. `address` can't be blank. `identifier` can't be blank.",
+                 "Invalid parameter provided `account_id`, `user_id` can't all be blank. `identifier` can't be blank.",
                "messages" => %{
                  "account_id, user_id" => ["required_exclusive"],
-                 "address" => ["required"],
                  "identifier" => ["required"]
                },
                "object" => "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/wallet_controller_test.exs
@@ -22,14 +22,14 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
     end
 
     test "returns a list of wallets according to search_term, sort_by and sort_direction" do
-      insert(:wallet, %{address: "XYZ1"})
-      insert(:wallet, %{address: "XYZ3"})
-      insert(:wallet, %{address: "XYZ2"})
-      insert(:wallet, %{address: "ZZZ1"})
+      insert(:wallet, %{address: "aaaa111111111111"})
+      insert(:wallet, %{address: "aaaa333333333333"})
+      insert(:wallet, %{address: "aaaa222222222222"})
+      insert(:wallet, %{address: "bbbb111111111111"})
 
       attrs = %{
         # Search is case-insensitive
-        "search_term" => "xYz",
+        "search_term" => "aAa",
         "sort_by" => "address",
         "sort_dir" => "desc"
       }
@@ -39,9 +39,9 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
       assert response["success"]
       assert Enum.count(wallets) == 3
-      assert Enum.at(wallets, 0)["address"] == "XYZ3"
-      assert Enum.at(wallets, 1)["address"] == "XYZ2"
-      assert Enum.at(wallets, 2)["address"] == "XYZ1"
+      assert Enum.at(wallets, 0)["address"] == "aaaa333333333333"
+      assert Enum.at(wallets, 1)["address"] == "aaaa222222222222"
+      assert Enum.at(wallets, 2)["address"] == "aaaa111111111111"
     end
   end
 
@@ -76,10 +76,30 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
     test "returns a list of wallets according to sort_by and sort_direction" do
       account = insert(:account)
-      insert(:wallet, %{account: account, address: "XYZ1", identifier: "secondary_1"})
-      insert(:wallet, %{account: account, address: "XYZ3", identifier: "secondary_2"})
-      insert(:wallet, %{account: account, address: "XYZ2", identifier: "secondary_3"})
-      insert(:wallet, %{account: account, address: "ZZZ1", identifier: "secondary_4"})
+
+      insert(:wallet, %{
+        account: account,
+        address: "aaaa111111111111",
+        identifier: "secondary_1"
+      })
+
+      insert(:wallet, %{
+        account: account,
+        address: "aaaa333333333333",
+        identifier: "secondary_2"
+      })
+
+      insert(:wallet, %{
+        account: account,
+        address: "aaaa222222222222",
+        identifier: "secondary_3"
+      })
+
+      insert(:wallet, %{
+        account: account,
+        address: "bbbb111111111111",
+        identifier: "secondary_4"
+      })
 
       attrs = %{
         "id" => account.id,
@@ -93,10 +113,10 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
       assert response["success"]
       assert Enum.count(wallets) == 4
-      assert Enum.at(wallets, 0)["address"] == "ZZZ1"
-      assert Enum.at(wallets, 1)["address"] == "XYZ3"
-      assert Enum.at(wallets, 2)["address"] == "XYZ2"
-      assert Enum.at(wallets, 3)["address"] == "XYZ1"
+      assert Enum.at(wallets, 0)["address"] == "bbbb111111111111"
+      assert Enum.at(wallets, 1)["address"] == "aaaa333333333333"
+      assert Enum.at(wallets, 2)["address"] == "aaaa222222222222"
+      assert Enum.at(wallets, 3)["address"] == "aaaa111111111111"
 
       Enum.each(wallets, fn wallet ->
         assert wallet["account_id"] == account.id
@@ -129,10 +149,10 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
     test "returns a list of wallets according to sort_by and sort_direction" do
       user = insert(:user)
-      insert(:wallet, %{user: user, address: "XYZ1", identifier: "secondary_1"})
-      insert(:wallet, %{user: user, address: "XYZ3", identifier: "secondary_2"})
-      insert(:wallet, %{user: user, address: "XYZ2", identifier: "secondary_3"})
-      insert(:wallet, %{user: user, address: "ZZZ1", identifier: "secondary_4"})
+      insert(:wallet, %{user: user, address: "aaaa111111111111", identifier: "secondary_1"})
+      insert(:wallet, %{user: user, address: "aaaa333333333333", identifier: "secondary_2"})
+      insert(:wallet, %{user: user, address: "aaaa222222222222", identifier: "secondary_3"})
+      insert(:wallet, %{user: user, address: "bbbb111111111111", identifier: "secondary_4"})
 
       attrs = %{
         "id" => user.id,
@@ -145,10 +165,10 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
       assert response["success"]
       assert Enum.count(wallets) == 4
-      assert Enum.at(wallets, 0)["address"] == "ZZZ1"
-      assert Enum.at(wallets, 1)["address"] == "XYZ3"
-      assert Enum.at(wallets, 2)["address"] == "XYZ2"
-      assert Enum.at(wallets, 3)["address"] == "XYZ1"
+      assert Enum.at(wallets, 0)["address"] == "bbbb111111111111"
+      assert Enum.at(wallets, 1)["address"] == "aaaa333333333333"
+      assert Enum.at(wallets, 2)["address"] == "aaaa222222222222"
+      assert Enum.at(wallets, 3)["address"] == "aaaa111111111111"
 
       Enum.each(wallets, fn wallet ->
         assert wallet["user_id"] == user.id
@@ -301,7 +321,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
     end
 
     test "returns 'wallet:address_not_found' if the given ID was not found" do
-      response = admin_user_request("/wallet.get", %{"address" => "wrong_address"})
+      response = admin_user_request("/wallet.get", %{"address" => "FAKE-0000-0000-0000"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
@@ -656,7 +656,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
     test "returns :address_not_found when address is not provided" do
       response =
         admin_user_request("/wallet.get_transaction_consumptions", %{
-          "address" => "fake",
+          "address" => "fake-0000-0000-0000",
           "sort_by" => "created",
           "sort_dir" => "asc"
         })

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -432,7 +432,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
         provider_request("/transaction.create", %{
           "idempotency_token" => "123",
           "from_address" => wallet_1.address,
-          "to_address" => "fake",
+          "to_address" => "fake-0000-0000-0000",
           "token_id" => token.id,
           "amount" => 1_000_000
         })
@@ -454,7 +454,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
       response =
         provider_request("/transaction.create", %{
           "idempotency_token" => "123",
-          "from_address" => "fake",
+          "from_address" => "fake-0000-0000-0000",
           "to_address" => wallet_2.address,
           "token_id" => token.id,
           "amount" => 1_000_000

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
@@ -244,7 +244,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
           token_id: token.id,
           correlation_id: nil,
           amount: nil,
-          address: "fake"
+          address: "fake-0000-0000-0000"
         })
 
       assert response == %{

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transfer_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transfer_controller_test.exs
@@ -202,7 +202,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransferControllerTest do
       response =
         provider_request("/transfer", %{
           idempotency_token: UUID.generate(),
-          from_address: "00000000-0000-0000-0000-000000000000",
+          from_address: "fake-0000-0000-0000",
           to_address: wallet.address,
           token_id: token.id,
           amount: 100_000,
@@ -229,7 +229,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransferControllerTest do
         provider_request("/transfer", %{
           idempotency_token: UUID.generate(),
           from_address: wallet.address,
-          to_address: "00000000-0000-0000-0000-000000000000",
+          to_address: "fake-0000-0000-0000",
           token_id: token.id,
           amount: 100_000,
           metadata: %{}

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
@@ -517,10 +517,9 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
                "description" =>
-                 "Invalid parameter provided `account_id`, `user_id` can't all be blank. `address` can't be blank. `identifier` can't be blank.",
+                 "Invalid parameter provided `account_id`, `user_id` can't all be blank. `identifier` can't be blank.",
                "messages" => %{
                  "account_id, user_id" => ["required_exclusive"],
-                 "address" => ["required"],
                  "identifier" => ["required"]
                },
                "object" => "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
@@ -22,14 +22,14 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
     end
 
     test "returns a list of wallets according to search_term, sort_by and sort_direction" do
-      insert(:wallet, %{address: "XYZ1"})
-      insert(:wallet, %{address: "XYZ3"})
-      insert(:wallet, %{address: "XYZ2"})
-      insert(:wallet, %{address: "ZZZ1"})
+      insert(:wallet, %{address: "aaaa111111111111"})
+      insert(:wallet, %{address: "aaaa333333333333"})
+      insert(:wallet, %{address: "aaaa222222222222"})
+      insert(:wallet, %{address: "bbbb111111111111"})
 
       attrs = %{
         # Search is case-insensitive
-        "search_term" => "xYz",
+        "search_term" => "aAa",
         "sort_by" => "address",
         "sort_dir" => "desc"
       }
@@ -39,9 +39,9 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       assert response["success"]
       assert Enum.count(wallets) == 3
-      assert Enum.at(wallets, 0)["address"] == "XYZ3"
-      assert Enum.at(wallets, 1)["address"] == "XYZ2"
-      assert Enum.at(wallets, 2)["address"] == "XYZ1"
+      assert Enum.at(wallets, 0)["address"] == "aaaa333333333333"
+      assert Enum.at(wallets, 1)["address"] == "aaaa222222222222"
+      assert Enum.at(wallets, 2)["address"] == "aaaa111111111111"
     end
   end
 
@@ -76,10 +76,30 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
     test "returns a list of wallets according to sort_by and sort_direction" do
       account = insert(:account)
-      insert(:wallet, %{account: account, address: "XYZ1", identifier: "secondary_1"})
-      insert(:wallet, %{account: account, address: "XYZ3", identifier: "secondary_2"})
-      insert(:wallet, %{account: account, address: "XYZ2", identifier: "secondary_3"})
-      insert(:wallet, %{account: account, address: "ZZZ1", identifier: "secondary_4"})
+
+      insert(:wallet, %{
+        account: account,
+        address: "aaaa111111111111",
+        identifier: "secondary_1"
+      })
+
+      insert(:wallet, %{
+        account: account,
+        address: "aaaa333333333333",
+        identifier: "secondary_2"
+      })
+
+      insert(:wallet, %{
+        account: account,
+        address: "aaaa222222222222",
+        identifier: "secondary_3"
+      })
+
+      insert(:wallet, %{
+        account: account,
+        address: "bbbb111111111111",
+        identifier: "secondary_4"
+      })
 
       attrs = %{
         "id" => account.id,
@@ -93,10 +113,10 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       assert response["success"]
       assert Enum.count(wallets) == 4
-      assert Enum.at(wallets, 0)["address"] == "ZZZ1"
-      assert Enum.at(wallets, 1)["address"] == "XYZ3"
-      assert Enum.at(wallets, 2)["address"] == "XYZ2"
-      assert Enum.at(wallets, 3)["address"] == "XYZ1"
+      assert Enum.at(wallets, 0)["address"] == "bbbb111111111111"
+      assert Enum.at(wallets, 1)["address"] == "aaaa333333333333"
+      assert Enum.at(wallets, 2)["address"] == "aaaa222222222222"
+      assert Enum.at(wallets, 3)["address"] == "aaaa111111111111"
 
       Enum.each(wallets, fn wallet ->
         assert wallet["account_id"] == account.id
@@ -129,10 +149,10 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
     test "returns a list of wallets according to sort_by and sort_direction" do
       user = insert(:user)
-      insert(:wallet, %{user: user, address: "XYZ1", identifier: "secondary_1"})
-      insert(:wallet, %{user: user, address: "XYZ3", identifier: "secondary_2"})
-      insert(:wallet, %{user: user, address: "XYZ2", identifier: "secondary_3"})
-      insert(:wallet, %{user: user, address: "ZZZ1", identifier: "secondary_4"})
+      insert(:wallet, %{user: user, address: "aaaa111111111111", identifier: "secondary_1"})
+      insert(:wallet, %{user: user, address: "aaaa333333333333", identifier: "secondary_2"})
+      insert(:wallet, %{user: user, address: "aaaa222222222222", identifier: "secondary_3"})
+      insert(:wallet, %{user: user, address: "bbbb111111111111", identifier: "secondary_4"})
 
       attrs = %{
         "id" => user.id,
@@ -145,10 +165,10 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       assert response["success"]
       assert Enum.count(wallets) == 4
-      assert Enum.at(wallets, 0)["address"] == "ZZZ1"
-      assert Enum.at(wallets, 1)["address"] == "XYZ3"
-      assert Enum.at(wallets, 2)["address"] == "XYZ2"
-      assert Enum.at(wallets, 3)["address"] == "XYZ1"
+      assert Enum.at(wallets, 0)["address"] == "bbbb111111111111"
+      assert Enum.at(wallets, 1)["address"] == "aaaa333333333333"
+      assert Enum.at(wallets, 2)["address"] == "aaaa222222222222"
+      assert Enum.at(wallets, 3)["address"] == "aaaa111111111111"
 
       Enum.each(wallets, fn wallet ->
         assert wallet["user_id"] == user.id
@@ -301,7 +321,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
     end
 
     test "returns 'wallet:address_not_found' if the given ID was not found" do
-      response = provider_request("/wallet.get", %{"address" => "wrong_address"})
+      response = provider_request("/wallet.get", %{"address" => "fake-0000-0000-0000"})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/ewallet/test/ewallet/fetchers/address_record_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/address_record_fetcher_test.exs
@@ -36,7 +36,7 @@ defmodule EWallet.AddressRecordFetcherTest do
 
       res =
         AddressRecordFetcher.fetch(%{
-          "from_address" => "123",
+          "from_address" => "none-0000-0000-0000",
           "to_address" => User.get_primary_wallet(inserted_user).address,
           "token_id" => inserted_token.id
         })
@@ -51,7 +51,7 @@ defmodule EWallet.AddressRecordFetcherTest do
       res =
         AddressRecordFetcher.fetch(%{
           "from_address" => User.get_primary_wallet(inserted_user).address,
-          "to_address" => "123",
+          "to_address" => "none-0000-0000-0000",
           "token_id" => inserted_token.id
         })
 

--- a/apps/ewallet/test/ewallet/fetchers/wallet_credit_debit_assigner_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/wallet_credit_debit_assigner_test.exs
@@ -62,7 +62,7 @@ defmodule EWallet.WalletCreditDebitAssignerTest do
       {res, code} =
         WalletCreditDebitAssigner.assign(%{
           account: meta.account,
-          account_address: "invalid_address",
+          account_address: "none-0000-0000-0000",
           user: meta.user,
           user_address: nil,
           type: TransactionGate.debit_type()
@@ -110,7 +110,7 @@ defmodule EWallet.WalletCreditDebitAssignerTest do
           account: meta.account,
           account_address: nil,
           user: meta.user,
-          user_address: "invalid_address",
+          user_address: "none-0000-0000-0000",
           type: TransactionGate.debit_type()
         })
 

--- a/apps/ewallet/test/ewallet/fetchers/wallet_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/wallet_fetcher_test.exs
@@ -25,7 +25,7 @@ defmodule EWallet.WalletFetcherTest do
     end
 
     test "returns 'user_wallet_not_found' if the address is not found", meta do
-      {:error, error} = WalletFetcher.get(meta.user, "fake")
+      {:error, error} = WalletFetcher.get(meta.user, "fake-0000-0000-0000")
       assert error == :user_wallet_not_found
     end
 
@@ -36,7 +36,7 @@ defmodule EWallet.WalletFetcherTest do
     end
 
     test "returns 'account_wallet_not_found' if the address is not found", meta do
-      {:error, error} = WalletFetcher.get(meta.account, "fake")
+      {:error, error} = WalletFetcher.get(meta.account, "fake-0000-0000-0000")
       assert error == :account_wallet_not_found
     end
 

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -179,7 +179,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
           "idempotency_token" => "123",
           "token_id" => nil,
           "account_id" => meta.account.id,
-          "address" => "fake"
+          "address" => "fake-0000-0000-0000"
         })
 
       assert res == {:error, :account_wallet_not_found}
@@ -321,7 +321,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
           "idempotency_token" => "123",
           "token_id" => nil,
           "provider_user_id" => meta.sender.provider_user_id,
-          "address" => "fake"
+          "address" => "fake-0000-0000-0000"
         })
 
       assert res == {:error, :user_wallet_not_found}
@@ -385,7 +385,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
           "metadata" => nil,
           "idempotency_token" => "123",
           "token_id" => nil,
-          "address" => "fake"
+          "address" => "fake-0000-0000-0000"
         })
 
       assert res == {:error, :wallet_not_found}
@@ -1324,7 +1324,7 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
           "formatted_transaction_request_id" => meta.request.id,
           "correlation_id" => nil,
           "amount" => nil,
-          "address" => "fake",
+          "address" => "fake-0000-0000-0000",
           "metadata" => nil,
           "idempotency_token" => "123",
           "token_id" => nil

--- a/apps/ewallet/test/ewallet/gates/transaction_request_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_request_gate_test.exs
@@ -98,7 +98,7 @@ defmodule EWallet.TransactionRequestGateTest do
           "correlation_id" => "123",
           "amount" => 1_000,
           "account_id" => meta.account.id,
-          "address" => "fake"
+          "address" => "fake-0000-0000-0000"
         })
 
       assert res == {:error, :account_wallet_not_found}
@@ -218,7 +218,7 @@ defmodule EWallet.TransactionRequestGateTest do
           "correlation_id" => "123",
           "amount" => 1_000,
           "provider_user_id" => meta.user.provider_user_id,
-          "address" => "fake"
+          "address" => "fake-0000-0000-0000"
         })
 
       assert res == {:error, :user_wallet_not_found}
@@ -274,7 +274,7 @@ defmodule EWallet.TransactionRequestGateTest do
           "token_id" => meta.token.id,
           "correlation_id" => "123",
           "amount" => 1_000,
-          "address" => "fake"
+          "address" => "fake-0000-0000-0000"
         })
 
       assert res == {:error, :wallet_not_found}
@@ -348,7 +348,7 @@ defmodule EWallet.TransactionRequestGateTest do
           "token_id" => meta.token.id,
           "correlation_id" => nil,
           "amount" => nil,
-          "address" => "fake"
+          "address" => "fake-0000-0000-0000"
         })
 
       assert error == :user_wallet_not_found

--- a/apps/ewallet_api/test/ewallet_api/v1/channels/address_channel_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/channels/address_channel_test.exs
@@ -36,7 +36,7 @@ defmodule EWalletAPI.V1.WalletChannelTest do
       {res, code} =
         "test"
         |> socket(%{auth: %{authenticated: true, user: user}})
-        |> subscribe_and_join(WalletChannel, "address:123")
+        |> subscribe_and_join(WalletChannel, "address:none000000000000")
 
       assert res == :error
       assert code == :channel_not_found

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -190,7 +190,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
           token_id: token.id,
           correlation_id: nil,
           amount: nil,
-          address: "fake"
+          address: "fake000000000000"
         })
 
       assert response == %{

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transfer_controller_test.exs
@@ -178,7 +178,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
       response =
         client_request("/me.transfer", %{
           idempotency_token: UUID.generate(),
-          from_address: "00000000-0000-0000-0000-000000000000",
+          from_address: "none000000000000",
           to_address: wallet.address,
           token_id: token.id,
           amount: 100_000
@@ -231,7 +231,7 @@ defmodule EWalletAPI.V1.TransferControllerTest do
         client_request("/me.transfer", %{
           idempotency_token: UUID.generate(),
           from_address: wallet.address,
-          to_address: "00000000-0000-0000-0000-000000000000",
+          to_address: "none000000000000",
           token_id: token.id,
           amount: 100_000
         })

--- a/apps/ewallet_db/lib/ewallet_db/types/wallet_address.ex
+++ b/apps/ewallet_db/lib/ewallet_db/types/wallet_address.ex
@@ -1,0 +1,151 @@
+defmodule EWalletDB.Types.WalletAddress do
+  @moduledoc """
+  A custom Ecto type that handles wallet addresses. A wallet address is a string
+  that consists of 4 case-insensitive letters followed by a 12-digit integer.
+  All non-alphanumerics are stripped and ignored.
+
+  Although this custom type is a straight-forward string primitive, it validates
+  the given wallet address before allowing the value to be casted. Hence it gives
+  a better assurance that the value stored by this type follows a consistent format.
+
+  This module also provides a helper macro `wallet_address/1` for setting up
+  a schema field that autogenerates the wallet address.
+  """
+  @behaviour Ecto.Type
+  alias Ecto.Schema
+
+  # 4-char letters, 12-digit integers
+  @type t :: <<_::16>>
+
+  # The alphabets to use for randoming the wallet address
+  @alphabets "abcdefghijklmnopqrstuvwxyz"
+
+  # The numbers to use for randoming the wallet address
+  @numbers "0123456789"
+
+  # The defaults to use to define the field.
+  @default_opts [
+    # The string to use as the 4-letter at the beginning of the address.
+    prefix: nil,
+    # The function to use for autogenerating the value.
+    autogenerate: nil
+  ]
+
+  @doc """
+  Returns the underlying Ecto primitive type.
+  """
+  def type, do: :string
+
+  @doc """
+  Casts the given input to the schema struct.
+
+  Returns `{:ok, value}` on successful casting where `value` is a string of 3-character symbol,
+  an underscore and 26-character ULID string. Returns `:error` on failure.
+  """
+  @spec cast(String.t()) :: {:ok, String.t()} | :error
+  def cast(address) do
+    address =
+      address
+      |> String.replace(~r/[^A-Za-z0-9]/, "")
+      |> String.downcase()
+
+    case String.match?(address, ~r/^[a-z0-9]{4}[0-9]{12}$/) do
+      true -> {:ok, address}
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Transforms the value after loaded from the database.
+  """
+  @spec load(String.t()) :: {:ok, String.t()}
+  def load(value), do: {:ok, value}
+
+  @doc """
+  Prepares the value for saving to database.
+  """
+  @spec dump(String.t()) :: {:ok, String.t()}
+  def dump(value), do: {:ok, value}
+
+  @doc """
+  Defines a wallet address field on a schema.
+
+  ## Example
+  defmodule WalletSchema do
+    use EWalletDB.Types.WalletAddress
+
+    schema "wallet" do
+      wallet_address(:address)
+    end
+  end
+  """
+  defmacro wallet_address(field_name, opts \\ []) do
+    opts = Keyword.merge(@default_opts, opts)
+    type = __MODULE__
+
+    quote bind_quoted: binding() do
+      autogen_fn = opts[:autogenerate] || {type, :autogenerate, [opts[:prefix]]}
+
+      Schema.field(field_name, type, [])
+      Module.put_attribute(__MODULE__, :ecto_autogenerate, {field_name, autogen_fn})
+    end
+  end
+
+  @doc """
+  Generates a new wallet address with the format `aaaa000000000000`,
+  where `a` is a random a-z letter and `0` is a random 1-digit integer.
+
+  Returns `{:ok, address}`.
+  """
+  @spec generate() :: {:ok, String.t()}
+  def generate do
+    prefix = random(4, @alphabets)
+    generate(prefix)
+  end
+
+  @doc """
+  Generates a new wallet address. Accepts up to 4-letter prefix,
+  uses it as the address's prefix and randomize the rest with integers.
+
+  Returns `{:ok, address}` on success.
+  Returns `:error` if more than 4 letters or invalid characters are given.
+  """
+  @spec generate(String.t() | nil) :: String.t() | :error
+  def generate(prefix) when byte_size(prefix) <= 4 do
+    case String.match?(prefix, ~r/^[a-z0-9]*$/) do
+      true ->
+        random_length = 16 - String.length(prefix)
+        {:ok, prefix <> random(random_length, @numbers)}
+
+      false ->
+        :error
+    end
+  end
+
+  def generate(nil), do: generate()
+
+  def generate(_), do: :error
+
+  defp random(output_length, pool) when is_binary(pool) do
+    random(output_length, String.split(pool, "", trim: true))
+  end
+
+  defp random(output_length, pool) do
+    1..output_length
+    |> Enum.reduce([], fn _, acc -> [Enum.random(pool) | acc] end)
+    |> Enum.join("")
+  end
+
+  # Callback invoked by autogenerate fields.
+  @doc false
+  def autogenerate(prefix) do
+    {:ok, address} = generate(prefix)
+    address
+  end
+
+  defmacro __using__(_) do
+    quote do
+      import EWalletDB.Types.WalletAddress, only: [wallet_address: 1, wallet_address: 2]
+    end
+  end
+end

--- a/apps/ewallet_db/lib/ewallet_db/wallet.ex
+++ b/apps/ewallet_db/lib/ewallet_db/wallet.ex
@@ -15,6 +15,8 @@ defmodule EWalletDB.Wallet do
   @primary "primary"
   @secondary "secondary"
 
+  @genesis_address "gnis000000000000"
+
   def genesis, do: @genesis
   def burn, do: @burn
   def primary, do: @primary
@@ -158,7 +160,7 @@ defmodule EWalletDB.Wallet do
   Returns the genesis wallet.
   """
   def get_genesis do
-    case get(@genesis) do
+    case get(@genesis_address) do
       nil ->
         {:ok, genesis} = insert_genesis()
         genesis
@@ -172,12 +174,14 @@ defmodule EWalletDB.Wallet do
   Inserts a genesis.
   """
   def insert_genesis do
-    changeset = changeset(%Wallet{}, %{address: @genesis, name: @genesis, identifier: @genesis})
+    changeset =
+      changeset(%Wallet{}, %{address: @genesis_address, name: @genesis, identifier: @genesis})
+
     opts = [on_conflict: :nothing, conflict_target: :address]
 
     case Repo.insert(changeset, opts) do
       {:ok, _wallet} ->
-        {:ok, get(@genesis)}
+        {:ok, get(@genesis_address)}
 
       {:error, changeset} ->
         {:error, changeset}

--- a/apps/ewallet_db/lib/ewallet_db/wallet.ex
+++ b/apps/ewallet_db/lib/ewallet_db/wallet.ex
@@ -93,6 +93,7 @@ defmodule EWalletDB.Wallet do
 
   defp shared_changeset(changeset) do
     changeset
+    |> validate_immutable(:address)
     |> unique_constraint(:address)
     |> assoc_constraint(:account)
     |> assoc_constraint(:user)

--- a/apps/ewallet_db/priv/repo/migrations/20180627073155_update_genesis_address_in_wallet.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180627073155_update_genesis_address_in_wallet.exs
@@ -1,0 +1,88 @@
+defmodule EWalletDB.Repo.Migrations.UpdateGenesisAddressInWallet do
+  use Ecto.Migration
+  import Ecto.Query
+  alias Ecto.{DateTime, UUID}
+  alias EWalletDB.Repo
+
+  @old_address "genesis"
+  @new_address "gnis000000000000"
+
+  def up do
+    case get_wallet_metadatas(@old_address) do
+      {encrypted_metadata, metadata} ->
+        insert("wallet", @new_address, encrypted_metadata, metadata)
+
+        update("transaction", :from, @old_address, @new_address)
+        update("transaction", :to, @old_address, @new_address)
+        update("transaction_consumption", :wallet_address, @old_address, @new_address)
+        update("transaction_request", :wallet_address, @old_address, @new_address)
+
+        delete("wallet", :address, @old_address)
+
+      _ ->
+        :noop
+    end
+  end
+
+  def down do
+    case get_wallet_metadatas(@new_address) do
+      {encrypted_metadata, metadata} ->
+        insert("wallet", @old_address, encrypted_metadata, metadata)
+
+        update("transaction", :from, @new_address, @old_address)
+        update("transaction", :to, @new_address, @old_address)
+        update("transaction_consumption", :wallet_address, @new_address, @old_address)
+        update("transaction_request", :wallet_address, @new_address, @old_address)
+
+        delete("wallet", :address, @new_address)
+
+      _ ->
+        :noop
+    end
+  end
+
+  defp get_wallet_metadatas(address) do
+    query = from(w in "wallet",
+                 select: {w.encrypted_metadata, w.metadata},
+                 where: w.address == ^address,
+                 limit: 1)
+
+    Repo.one(query)
+  end
+
+  defp insert("wallet", address, encrypted_metadata, metadata) do
+    attrs =
+      %{
+        uuid: UUID.bingenerate(),
+        address: address,
+        name: "genesis",
+        identifier: "genesis",
+        inserted_at: DateTime.autogenerate(),
+        updated_at: DateTime.autogenerate(),
+        encrypted_metadata: encrypted_metadata,
+        metadata: metadata
+      }
+
+    insert("wallet", attrs)
+  end
+
+  defp insert(table, attrs) do
+    {1, nil} = Repo.insert_all(table, [attrs])
+  end
+
+  defp update(table, field_name, from_value, to_value) do
+    update_args = Keyword.new([{field_name, to_value}])
+
+    query =
+      from(t in table,
+           where: field(t, ^field_name) == ^from_value,
+           update: [set: ^update_args])
+
+    {_, nil} = Repo.update_all(query, [])
+  end
+
+  defp delete(table, field_name, value) do
+    delete_query = from(w in table, where: field(w, ^field_name) == ^value)
+    {1, nil} = Repo.delete_all(delete_query)
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/types/wallet_address_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/types/wallet_address_test.exs
@@ -1,0 +1,99 @@
+defmodule EWalletDB.Types.WalletAddressTest do
+  use EWalletDB.SchemaCase
+  alias EWalletDB.Types.WalletAddress
+  alias EWalletDB.Wallet
+
+  describe "cast/1" do
+    test "casts input to lower case" do
+      assert WalletAddress.cast("ABCD-123456789012") == {:ok, "abcd123456789012"}
+    end
+
+    test "strips all non-alphanumerics" do
+      assert WalletAddress.cast("abcd%1234/5678_9012") == {:ok, "abcd123456789012"}
+    end
+
+    test "accepts inputs with all integers" do
+      assert WalletAddress.cast("1234123456789012") == {:ok, "1234123456789012"}
+    end
+
+    test "returns error if any of the 12 latter characters consist of non-integers" do
+      assert WalletAddress.cast("abcd-1234-5678-901X") == :error
+      assert WalletAddress.cast("abcd-1234-5XX8-9012") == :error
+    end
+
+    test "returns error if the input has invalid length" do
+      assert WalletAddress.cast("abcd1234") == :error
+      assert WalletAddress.cast("abcd1234567890123") == :error
+    end
+  end
+
+  describe "load/1" do
+    # The wallet address is stored as string in the database,
+    # so no transformation needed.
+    test "returns the same string" do
+      assert WalletAddress.load("abcd123456789012") == {:ok, "abcd123456789012"}
+    end
+  end
+
+  describe "dump/1" do
+    # The wallet address should have already been casted via `cast/1`
+    # to a uniformed format. So no transformation needed.
+    test "returns the same string" do
+      assert WalletAddress.dump("abcd123456789012") == {:ok, "abcd123456789012"}
+    end
+  end
+
+  describe "wallet_address/2" do
+    test "populates the schema with a valid wallet address" do
+      {:ok, wallet} =
+        :wallet
+        |> params_for(address: nil)
+        |> Wallet.insert()
+
+      assert String.match?(wallet.address, ~r/^[a-z]{4}[0-9]{12}$/)
+    end
+
+    test "uses the given wallet address if provided" do
+      {:ok, wallet} =
+        :wallet
+        |> params_for(address: "test-1234-5678-9012")
+        |> Wallet.insert()
+
+      assert wallet.address == "test123456789012"
+    end
+  end
+
+  describe "generate/1" do
+    test "returns {:ok, address}" do
+      {:ok, address} = WalletAddress.generate()
+      assert String.match?(address, ~r/^[a-z]{4}[0-9]{12}$/)
+    end
+
+    test "returns {:ok, address} when prefix is provided" do
+      {:ok, address} = WalletAddress.generate("abcd")
+      assert String.match?(address, ~r/^abcd[0-9]{12}$/)
+    end
+
+    test "returns {:ok, address} when prefix less than 4 characters are provided" do
+      {:ok, address} = WalletAddress.generate("ab")
+      assert String.match?(address, ~r/^ab[0-9]{2}[0-9]{12}$/)
+    end
+
+    test "returns {:ok, address} when the prefix contains numbers" do
+      {:ok, address} = WalletAddress.generate("9999")
+      assert String.match?(address, ~r/^9999[0-9]{12}$/)
+    end
+
+    test "returns :error if prefix contains invalid character" do
+      assert WalletAddress.generate("abc%") == :error
+      assert WalletAddress.generate("____") == :error
+    end
+  end
+
+  describe "autogenerate/1" do
+    test "returns a wallet address ID" do
+      address = WalletAddress.autogenerate("abcd")
+      assert String.match?(address, ~r/^abcd[0-9]{12}$/)
+    end
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/wallet_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/wallet_test.exs
@@ -10,11 +10,19 @@ defmodule EWalletDB.WalletTest do
   describe "Wallet.insert/1" do
     test_insert_ok(Wallet, :address, "an_address")
 
+    test "generates a wallet address if not given" do
+      {res, wallet} =
+        :wallet
+        |> params_for(address: nil)
+        |> Wallet.insert()
+
+        assert res == :ok
+        assert String.length(wallet.address) > 0
+    end
+
     test_insert_generate_uuid(Wallet, :uuid)
-    test_insert_generate_uuid(Wallet, :address)
     test_insert_generate_timestamps(Wallet)
 
-    test_insert_prevent_blank(Wallet, :address)
     test_insert_prevent_all_blank(Wallet, [:account, :user])
     test_insert_prevent_duplicate(Wallet, :address)
     test_default_metadata_fields(Wallet, "wallet")

--- a/apps/ewallet_db/test/ewallet_db/wallet_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/wallet_test.exs
@@ -1,6 +1,7 @@
 defmodule EWalletDB.WalletTest do
   use EWalletDB.SchemaCase
   alias EWalletDB.{Wallet, Account, User}
+  alias EWalletDB.Types.WalletAddress
 
   describe "Wallet factory" do
     test_has_valid_factory(Wallet)
@@ -8,7 +9,8 @@ defmodule EWalletDB.WalletTest do
   end
 
   describe "Wallet.insert/1" do
-    test_insert_ok(Wallet, :address, "an_address")
+    test_insert_generate_uuid(Wallet, :uuid)
+    test_insert_generate_timestamps(Wallet)
 
     test "generates a wallet address if not given" do
       {res, wallet} =
@@ -16,15 +18,14 @@ defmodule EWalletDB.WalletTest do
         |> params_for(address: nil)
         |> Wallet.insert()
 
-        assert res == :ok
-        assert String.length(wallet.address) > 0
+      assert res == :ok
+      assert String.length(wallet.address) > 0
     end
 
-    test_insert_generate_uuid(Wallet, :uuid)
-    test_insert_generate_timestamps(Wallet)
+    test_insert_ok(Wallet, :address, "abcd999999999999")
 
     test_insert_prevent_all_blank(Wallet, [:account, :user])
-    test_insert_prevent_duplicate(Wallet, :address)
+    test_insert_prevent_duplicate(Wallet, :address, "aaaa123456789012")
     test_default_metadata_fields(Wallet, "wallet")
 
     test "allows insert if provided a user without account_uuid" do
@@ -119,24 +120,26 @@ defmodule EWalletDB.WalletTest do
 
   describe "get/1" do
     test "returns an existing wallet using an address" do
-      :wallet
-      |> params_for(%{address: "wallet_address1234"})
-      |> Wallet.insert()
+      {:ok, inserted} =
+        :wallet
+        |> params_for()
+        |> Wallet.insert()
 
-      wallet = Wallet.get("wallet_address1234")
-      assert wallet.address == "wallet_address1234"
+      wallet = Wallet.get(inserted.address)
+      assert wallet.address == inserted.address
     end
 
     test "returns nil if the wallet address does not exist" do
-      assert Wallet.get("nonexisting_address") == nil
+      {:ok, address} = WalletAddress.generate()
+      assert Wallet.get(address) == nil
     end
   end
 
   describe "get_genesis/0" do
     test "inserts the genesis address if not existing" do
-      assert Wallet.get("genesis") == nil
+      assert Wallet.get("gnis000000000000") == nil
       genesis = Wallet.get_genesis()
-      assert Wallet.get("genesis") == genesis
+      assert Wallet.get("gnis000000000000") == genesis
     end
 
     test "returns the existing genesis address if present" do

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -26,6 +26,7 @@ defmodule EWalletDB.Factory do
   }
 
   alias EWalletDB.Helpers.Crypto
+  alias EWalletDB.Types.WalletAddress
   alias Ecto.UUID
   alias ExULID.ULID
 
@@ -60,9 +61,11 @@ defmodule EWalletDB.Factory do
   end
 
   def wallet_factory do
+    {:ok, address} = WalletAddress.generate()
+
     %Wallet{
-      address: sequence("address"),
-      name: sequence("name"),
+      address: address,
+      name: sequence("Wallet name"),
       identifier: Wallet.primary(),
       user: insert(:user),
       metadata: %{}

--- a/apps/local_ledger_db/mix.exs
+++ b/apps/local_ledger_db/mix.exs
@@ -37,6 +37,7 @@ defmodule LocalLedgerDB.Mixfile do
     [
       {:postgrex, ">= 0.0.0"},
       {:ecto, "~> 2.1.6"},
+      {:poison, "~> 3.1"},
       {:cloak, "~> 0.7.0-alpha"},
       {:ex_machina, "~> 2.2", only: :test},
 

--- a/apps/local_ledger_db/priv/repo/migrations/20180627100553_update_genesis_address_in_wallet.exs
+++ b/apps/local_ledger_db/priv/repo/migrations/20180627100553_update_genesis_address_in_wallet.exs
@@ -1,0 +1,82 @@
+defmodule LocalLedgerDB.Repo.Migrations.UpdateGenesisAddressInWallet do
+  use Ecto.Migration
+  import Ecto.Query
+  alias Ecto.{DateTime, UUID}
+  alias LocalLedgerDB.Repo
+
+  @old_address "genesis"
+  @new_address "gnis000000000000"
+
+  def up do
+    case get_wallet_metadatas(@old_address) do
+      {encrypted_metadata, metadata} ->
+        insert("wallet", @new_address, encrypted_metadata, metadata)
+
+        update("entry", :wallet_address, @old_address, @new_address)
+        update("cached_balance", :wallet_address, @old_address, @new_address)
+
+        delete("wallet", :address, @old_address)
+
+      _ ->
+        :noop
+    end
+  end
+
+  def down do
+    case get_wallet_metadatas(@new_address) do
+      {encrypted_metadata, metadata} ->
+        insert("wallet", @old_address, encrypted_metadata, metadata)
+
+        update("entry", :wallet_address, @new_address, @old_address)
+        update("cached_balance", :wallet_address, @new_address, @old_address)
+
+        delete("wallet", :address, @new_address)
+
+      _ ->
+        :noop
+    end
+  end
+
+  defp get_wallet_metadatas(address) do
+    query = from(w in "wallet",
+                 select: {w.encrypted_metadata, w.metadata},
+                 where: w.address == ^address,
+                 limit: 1)
+
+    Repo.one(query)
+  end
+
+  defp insert("wallet", address, encrypted_metadata, metadata) do
+    attrs =
+      %{
+        uuid: UUID.bingenerate(),
+        address: address,
+        inserted_at: DateTime.autogenerate(),
+        updated_at: DateTime.autogenerate(),
+        encrypted_metadata: encrypted_metadata,
+        metadata: metadata
+      }
+
+    insert("wallet", attrs)
+  end
+
+  defp insert(table, attrs) do
+    {1, nil} = Repo.insert_all(table, [attrs])
+  end
+
+  defp update(table, field_name, from_value, to_value) do
+    update_args = Keyword.new([{field_name, to_value}])
+
+    query =
+      from(t in table,
+           where: field(t, ^field_name) == ^from_value,
+           update: [set: ^update_args])
+
+    {_, nil} = Repo.update_all(query, [])
+  end
+
+  defp delete(table, field_name, value) do
+    delete_query = from(w in table, where: field(w, ^field_name) == ^value)
+    {1, nil} = Repo.delete_all(delete_query)
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T357

# Overview

This PR updates address format to align with [OIP-3](https://github.com/omisego/OIP/issues/3).

# Changes

- Add new Ecto type `EWalletDB.Types.WalletAddress`
- Change `EWalletDB.Wallet` to use `EWalletDB.Types.WalletAddress` instead of plain string
- `EWalletDB.Wallet` autogenerates the address if one is not given
- `EWalletDB.Wallet`'s address is immutable once set

# Implementation Details

- Mainly the added logic is in `EWalletDB.Types.WalletAddress` and implemented as a [custom Ecto type](https://hexdocs.pm/ecto/Ecto.Type.html).
- Address is saved in database with non-alphanumerics stripped so that it's consistent for searching and manipulating. Each provider can add non-alphanumerics separators or send them over unstripped as they wish.
- No migrations were added since the old addresses are still usable and its not ideal to change the addresses of existing wallets.

# Usage

Try `/account.create`, `/account.all`, `/account.get`, `/account.update`, etc.

# Impact

Only code changes.
