### PR TITLE
Fixes transaction request and consumptions

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -9,7 +9,8 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
     Web.V1.Event,
     TransactionConsumptionConsumerGate,
     TransactionConsumptionConfirmerGate,
-    TransactionConsumptionFetcher
+    TransactionConsumptionFetcher,
+    UserFetcher
   }
 
   alias EWalletDB.{Account, User, TransactionRequest, TransactionConsumption, Wallet}
@@ -54,27 +55,31 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
     handle_error(conn, :invalid_parameter, "Parameter 'account_id' is required.")
   end
 
-  def all_for_user(conn, %{"user_id" => user_id} = attrs) do
-    with %User{} = user <- User.get(user_id) || {:error, :user_id_not_found} do
+  def all_for_user(conn, attrs) do
+    with {:ok, %User{} = user} <- UserFetcher.get(attrs) do
       :user_uuid
       |> TransactionConsumption.query_all_for(user.uuid)
       |> SearchParser.search_with_terms(attrs, @search_fields)
       |> do_all(conn, attrs)
     else
-      error -> respond(error, conn)
-    end
-  end
+      {:error, :invalid_parameter} ->
+        handle_error(
+          conn,
+          :invalid_parameter,
+          "Parameter 'user_id' or 'provider_user_id' is required."
+        )
 
-  def all_for_user(conn, _) do
-    handle_error(conn, :invalid_parameter, "Parameter 'user_id' is required.")
+      error ->
+        respond(error, conn)
+    end
   end
 
   def all_for_transaction_request(
         conn,
-        %{"transaction_request_id" => transaction_request_id} = attrs
+        %{"formatted_transaction_request_id" => formatted_transaction_request_id} = attrs
       ) do
     with %TransactionRequest{} = transaction_request <-
-           TransactionRequest.get(transaction_request_id) ||
+           TransactionRequest.get(formatted_transaction_request_id) ||
              {:error, :transaction_request_not_found} do
       :transaction_request_uuid
       |> TransactionConsumption.query_all_for(transaction_request.uuid)
@@ -86,7 +91,11 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   end
 
   def all_for_transaction_request(conn, _) do
-    handle_error(conn, :invalid_parameter, "Parameter 'transaction_request_id' is required.")
+    handle_error(
+      conn,
+      :invalid_parameter,
+      "Parameter 'formatted_transaction_request_id' is required."
+    )
   end
 
   def all_for_wallet(conn, %{"address" => address} = attrs) do

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -56,7 +56,7 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   end
 
   def all_for_user(conn, attrs) do
-    with {:ok, %User{} = user} <- UserFetcher.get(attrs) do
+    with {:ok, %User{} = user} <- UserFetcher.fetch(attrs) do
       :user_uuid
       |> TransactionConsumption.query_all_for(user.uuid)
       |> SearchParser.search_with_terms(attrs, @search_fields)

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -736,7 +736,7 @@ paths:
   /user.get_transactions:
     post:
       tags:
-        - Transaction
+        - User
       summary: Get the list of transactions for the given user
       operationId: get_all_transactions_for_user
       requestBody:
@@ -976,7 +976,7 @@ paths:
   ############################
   # TRANSACTION CONSUMPTIONS #
   ############################
-  /account.get_consumptions:
+  /account.get_transaction_consumptions:
     post:
       tags:
         - Account
@@ -992,7 +992,7 @@ paths:
           $ref: "#/components/responses/TransactionConsumptionsResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
-  /user.get_consumptions:
+  /user.get_transaction_consumptions:
     post:
       tags:
         - User
@@ -1008,7 +1008,7 @@ paths:
           $ref: "#/components/responses/TransactionConsumptionsResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
-  /wallet.get_consumptions:
+  /wallet.get_transaction_consumptions:
     post:
       tags:
         - Wallet
@@ -1024,7 +1024,7 @@ paths:
           $ref: "#/components/responses/TransactionConsumptionsResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
-  /transaction_request.get_consumptions:
+  /transaction_request.get_transaction_consumptions:
     post:
       tags:
         - TransactionRequest
@@ -4459,7 +4459,7 @@ components:
         application/vnd.omisego.v1+json:
           schema:
             properties:
-              transaction_request_id:
+              formatted_transaction_request_id:
                 type: string
               page:
                 type: integer
@@ -4475,9 +4475,9 @@ components:
                 type: string
                 enum: ["asc", "desc"]
             required:
-              - transaction_request_id
+              - formatted_transaction_request_id
             example:
-              transaction_request_id: "txr_01cbfg8mafdnbthgb9e68nd9y9"
+              formatted_transaction_request_id: "txr_01cbfg8mafdnbthgb9e68nd9y9"
               page: 1
               per_page: 10
               search_terms: {}

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -295,7 +295,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       }
     end
 
-    test "returns :invalid_parameter when user_id is not provided" do
+    test "returns :invalid_parameter when user_id or provider_user_id is not provided" do
       response =
         admin_user_request("/user.get_transaction_consumptions", %{
           "sort_by" => "created",
@@ -305,7 +305,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'user_id' is required.",
+                 "description" => "Parameter 'user_id' or 'provider_user_id' is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -314,7 +314,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
              }
     end
 
-    test "returns :user_id_not_found when user_id is not provided" do
+    test "returns :user_id_not_found when user_id is not valid" do
       response =
         admin_user_request("/user.get_transaction_consumptions", %{
           "user_id" => "fake",
@@ -334,10 +334,50 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
              }
     end
 
-    test "returns all the transaction_consumptions for a user", meta do
+    test "returns :provider_user_id_not_found when provider_user_id is not valid" do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "provider_user_id" => "fake",
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "messages" => nil,
+                 "object" => "error",
+                 "code" => "user:provider_user_id_not_found",
+                 "description" =>
+                   "There is no user corresponding to the provided provider_user_id"
+               }
+             }
+    end
+
+    test "returns all the transaction_consumptions for a user when given a user_id", meta do
       response =
         admin_user_request("/user.get_transaction_consumptions", %{
           "user_id" => meta.user.id,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert length(response["data"]["data"]) == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all the transaction_consumptions for a user when given a provider_user_id",
+         meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "provider_user_id" => meta.user.provider_user_id,
           "sort_by" => "created",
           "sort_dir" => "asc"
         })
@@ -444,7 +484,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       }
     end
 
-    test "returns :invalid_parameter when transaction_request_id is not provided" do
+    test "returns :invalid_parameter when formatted_transaction_request_id is not provided" do
       response =
         admin_user_request("/transaction_request.get_transaction_consumptions", %{
           "sort_by" => "created",
@@ -454,7 +494,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'transaction_request_id' is required.",
+                 "description" => "Parameter 'formatted_transaction_request_id' is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -463,10 +503,10 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
              }
     end
 
-    test "returns :transaction_request_id_not_found when transaction_request_id is not provided" do
+    test "returns :transaction_request_id_not_found when formatted_transaction_request_id is not valid" do
       response =
         admin_user_request("/transaction_request.get_transaction_consumptions", %{
-          "transaction_request_id" => "fake",
+          "formatted_transaction_request_id" => "fake",
           "sort_by" => "created",
           "sort_dir" => "asc"
         })
@@ -487,7 +527,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
     test "returns all the transaction_consumptions for a transaction_request", meta do
       response =
         admin_user_request("/transaction_request.get_transaction_consumptions", %{
-          "transaction_request_id" => meta.transaction_request.id,
+          "formatted_transaction_request_id" => meta.transaction_request.id,
           "sort_by" => "created",
           "sort_dir" => "asc"
         })
@@ -505,7 +545,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
     test "returns all the transaction_consumptions for a specific status", meta do
       response =
         admin_user_request("/transaction_request.get_transaction_consumptions", %{
-          "transaction_request_id" => meta.transaction_request.id,
+          "formatted_transaction_request_id" => meta.transaction_request.id,
           "sort_by" => "created_at",
           "sort_dir" => "asc",
           "search_terms" => %{
@@ -525,7 +565,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
     test "ignores the search_term parameter", meta do
       response =
         admin_user_request("/transaction_request.get_transaction_consumptions", %{
-          "transaction_request_id" => meta.transaction_request.id,
+          "formatted_transaction_request_id" => meta.transaction_request.id,
           "sort_by" => "created_at",
           "sort_dir" => "asc",
           "search_term" => "pending"
@@ -544,7 +584,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
     test "returns all transaction_consumptions sorted and paginated", meta do
       response =
         admin_user_request("/transaction_request.get_transaction_consumptions", %{
-          "transaction_request_id" => meta.transaction_request.id,
+          "formatted_transaction_request_id" => meta.transaction_request.id,
           "sort_by" => "created_at",
           "sort_dir" => "asc",
           "per_page" => 2,

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
@@ -33,6 +33,760 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
     }
   end
 
+  describe "/transaction_consumption.all" do
+    setup do
+      user = get_test_user()
+      account = Account.get_master_account()
+
+      tc_1 = insert(:transaction_consumption, user_uuid: user.uuid, status: "pending")
+      tc_2 = insert(:transaction_consumption, account_uuid: account.uuid, status: "pending")
+      tc_3 = insert(:transaction_consumption, account_uuid: account.uuid, status: "confirmed")
+
+      %{
+        user: user,
+        tc_1: tc_1,
+        tc_2: tc_2,
+        tc_3: tc_3
+      }
+    end
+
+    test "returns all the transaction_consumptions", meta do
+      response =
+        admin_user_request("/transaction_consumption.all", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      transfers = [
+        meta.tc_1,
+        meta.tc_2,
+        meta.tc_3
+      ]
+
+      assert length(response["data"]["data"]) == length(transfers)
+
+      # All transfers made during setup should exist in the response
+      assert Enum.all?(transfers, fn transfer ->
+               Enum.any?(response["data"]["data"], fn data ->
+                 transfer.id == data["id"]
+               end)
+             end)
+    end
+
+    test "returns all the transaction_consumptions for a specific status", meta do
+      response =
+        admin_user_request("/transaction_consumption.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "pending"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_1.id,
+               meta.tc_2.id
+             ]
+    end
+
+    test "returns all transaction_consumptions filtered", meta do
+      response =
+        admin_user_request("/transaction_consumption.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_1.id,
+               meta.tc_2.id
+             ]
+    end
+
+    test "returns all transaction_consumptions sorted and paginated", meta do
+      response =
+        admin_user_request("/transaction_consumption.all", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_1.id,
+               meta.tc_2.id
+             ]
+    end
+  end
+
+  describe "/account.get_transaction_consumptions" do
+    setup do
+      user = get_test_user()
+      account = Account.get_master_account()
+
+      tc_1 = insert(:transaction_consumption, user_uuid: user.uuid, status: "pending")
+      tc_2 = insert(:transaction_consumption, account_uuid: account.uuid, status: "pending")
+      tc_3 = insert(:transaction_consumption, account_uuid: account.uuid, status: "confirmed")
+
+      %{
+        user: user,
+        account: account,
+        tc_1: tc_1,
+        tc_2: tc_2,
+        tc_3: tc_3
+      }
+    end
+
+    test "returns :invalid_parameter when account_id is not provided" do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Parameter 'account_id' is required.",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "success" => false,
+               "version" => "1"
+             }
+    end
+
+    test "returns :account_id_not_found when user_id is not provided" do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => "fake",
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "messages" => nil,
+                 "object" => "error",
+                 "code" => "account:id_not_found",
+                 "description" => "There is no account corresponding to the provided id"
+               }
+             }
+    end
+
+    test "returns all the transaction_consumptions for an account", meta do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => meta.account.id,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      transfers = [
+        meta.tc_2,
+        meta.tc_3
+      ]
+
+      assert length(response["data"]["data"]) == 2
+
+      # All transfers made during setup should exist in the response
+      assert Enum.all?(transfers, fn transfer ->
+               Enum.any?(response["data"]["data"], fn data ->
+                 transfer.id == data["id"]
+               end)
+             end)
+    end
+
+    test "returns all the transaction_consumptions for a specific status", meta do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => meta.account.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "pending"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 1
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id
+             ]
+    end
+
+    test "ignores the search_term parameter", meta do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => meta.account.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all transaction_consumptions sorted and paginated", meta do
+      response =
+        admin_user_request("/account.get_transaction_consumptions", %{
+          "account_id" => meta.account.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+  end
+
+  describe "/user.get_transaction_consumptions" do
+    setup do
+      user = get_test_user()
+      account = Account.get_master_account()
+
+      tc_1 = insert(:transaction_consumption, account_uuid: account.uuid, status: "pending")
+      tc_2 = insert(:transaction_consumption, user_uuid: user.uuid, status: "pending")
+      tc_3 = insert(:transaction_consumption, user_uuid: user.uuid, status: "confirmed")
+
+      %{
+        user: user,
+        account: account,
+        tc_1: tc_1,
+        tc_2: tc_2,
+        tc_3: tc_3
+      }
+    end
+
+    test "returns :invalid_parameter when user_id or provider_user_id is not provided" do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Parameter 'user_id' or 'provider_user_id' is required.",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "success" => false,
+               "version" => "1"
+             }
+    end
+
+    test "returns :user_id_not_found when user_id is not valid" do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => "fake",
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "messages" => nil,
+                 "object" => "error",
+                 "code" => "user:id_not_found",
+                 "description" => "There is no user corresponding to the provided id"
+               }
+             }
+    end
+
+    test "returns :provider_user_id_not_found when provider_user_id is not valid" do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "provider_user_id" => "fake",
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "messages" => nil,
+                 "object" => "error",
+                 "code" => "user:provider_user_id_not_found",
+                 "description" =>
+                   "There is no user corresponding to the provided provider_user_id"
+               }
+             }
+    end
+
+    test "returns all the transaction_consumptions for a user when given a user_id", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => meta.user.id,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert length(response["data"]["data"]) == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all the transaction_consumptions for a user when given a provider_user_id",
+         meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "provider_user_id" => meta.user.provider_user_id,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert length(response["data"]["data"]) == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all the transaction_consumptions for a specific status", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => meta.user.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "pending"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 1
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id
+             ]
+    end
+
+    test "ignores the search_term parameter", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => meta.user.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all transaction_consumptions sorted and paginated", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "user_id" => meta.user.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+  end
+
+  describe "/transaction_request.get_transaction_consumptions" do
+    setup do
+      account = insert(:account)
+      transaction_request = insert(:transaction_request)
+
+      tc_1 = insert(:transaction_consumption, account_uuid: account.uuid, status: "pending")
+
+      tc_2 =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: transaction_request.uuid,
+          status: "pending"
+        )
+
+      tc_3 =
+        insert(
+          :transaction_consumption,
+          transaction_request_uuid: transaction_request.uuid,
+          status: "confirmed"
+        )
+
+      %{
+        transaction_request: transaction_request,
+        tc_1: tc_1,
+        tc_2: tc_2,
+        tc_3: tc_3
+      }
+    end
+
+    test "returns :invalid_parameter when formatted_transaction_request_id is not provided" do
+      response =
+        admin_user_request("/transaction_request.get_transaction_consumptions", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Parameter 'formatted_transaction_request_id' is required.",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "success" => false,
+               "version" => "1"
+             }
+    end
+
+    test "returns :transaction_request_id_not_found when formatted_transaction_request_id is not valid" do
+      response =
+        admin_user_request("/transaction_request.get_transaction_consumptions", %{
+          "formatted_transaction_request_id" => "fake",
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction_request:transaction_request_not_found",
+                 "messages" => nil,
+                 "object" => "error",
+                 "description" =>
+                   "There is no transaction request corresponding to the provided ID."
+               }
+             }
+    end
+
+    test "returns all the transaction_consumptions for a transaction_request", meta do
+      response =
+        admin_user_request("/transaction_request.get_transaction_consumptions", %{
+          "formatted_transaction_request_id" => meta.transaction_request.id,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert length(response["data"]["data"]) == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all the transaction_consumptions for a specific status", meta do
+      response =
+        admin_user_request("/transaction_request.get_transaction_consumptions", %{
+          "formatted_transaction_request_id" => meta.transaction_request.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "pending"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 1
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id
+             ]
+    end
+
+    test "ignores the search_term parameter", meta do
+      response =
+        admin_user_request("/transaction_request.get_transaction_consumptions", %{
+          "formatted_transaction_request_id" => meta.transaction_request.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all transaction_consumptions sorted and paginated", meta do
+      response =
+        admin_user_request("/transaction_request.get_transaction_consumptions", %{
+          "formatted_transaction_request_id" => meta.transaction_request.id,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+  end
+
+  describe "/wallet.get_transaction_consumptions" do
+    setup do
+      account = insert(:account)
+      wallet = insert(:wallet)
+
+      tc_1 = insert(:transaction_consumption, account_uuid: account.uuid, status: "pending")
+
+      tc_2 =
+        insert(
+          :transaction_consumption,
+          wallet_address: wallet.address,
+          status: "pending"
+        )
+
+      tc_3 =
+        insert(
+          :transaction_consumption,
+          wallet_address: wallet.address,
+          status: "confirmed"
+        )
+
+      %{
+        wallet: wallet,
+        tc_1: tc_1,
+        tc_2: tc_2,
+        tc_3: tc_3
+      }
+    end
+
+    test "returns :invalid_parameter when address is not provided" do
+      response =
+        admin_user_request("/wallet.get_transaction_consumptions", %{
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "data" => %{
+                 "code" => "client:invalid_parameter",
+                 "description" => "Parameter 'address' is required.",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "success" => false,
+               "version" => "1"
+             }
+    end
+
+    test "returns :address_not_found when address is not provided" do
+      response =
+        admin_user_request("/wallet.get_transaction_consumptions", %{
+          "address" => "fake",
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "wallet:wallet_not_found",
+                 "messages" => nil,
+                 "object" => "error",
+                 "description" => "There is no wallet corresponding to the provided address"
+               }
+             }
+    end
+
+    test "returns all the transaction_consumptions for a wallet", meta do
+      response =
+        admin_user_request("/wallet.get_transaction_consumptions", %{
+          "address" => meta.wallet.address,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert length(response["data"]["data"]) == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all the transaction_consumptions for a specific status", meta do
+      response =
+        admin_user_request("/wallet.get_transaction_consumptions", %{
+          "address" => meta.wallet.address,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_terms" => %{
+            "status" => "pending"
+          }
+        })
+
+      assert response["data"]["data"] |> length() == 1
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id
+             ]
+    end
+
+    test "ignores the search_term parameter", meta do
+      response =
+        admin_user_request("/wallet.get_transaction_consumptions", %{
+          "address" => meta.wallet.address,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "search_term" => "pending"
+        })
+
+      assert response["data"]["data"] |> length() == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+
+    test "returns all transaction_consumptions sorted and paginated", meta do
+      response =
+        admin_user_request("/wallet.get_transaction_consumptions", %{
+          "address" => meta.wallet.address,
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 2,
+          "page" => 1
+        })
+
+      assert response["data"]["data"] |> length() == 2
+      transaction_1 = Enum.at(response["data"]["data"], 0)
+      transaction_2 = Enum.at(response["data"]["data"], 1)
+      assert transaction_2["created_at"] > transaction_1["created_at"]
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
+    end
+  end
+
+  describe "/transaction_consumption.get" do
+    test "returns the transaction consumption" do
+      transaction_consumption = insert(:transaction_consumption)
+
+      response =
+        admin_user_request("/transaction_consumption.get", %{
+          id: transaction_consumption.id
+        })
+
+      assert response["success"] == true
+      assert response["data"]["id"] == transaction_consumption.id
+    end
+
+    test "returns an error when the request ID is not found" do
+      response =
+        admin_user_request("/transaction_consumption.get", %{
+          id: "123"
+        })
+
+      assert response == %{
+               "success" => false,
+               "version" => "1",
+               "data" => %{
+                 "code" => "transaction_consumption:transaction_consumption_not_found",
+                 "description" =>
+                   "There is no transaction consumption corresponding to the provided ID.",
+                 "messages" => nil,
+                 "object" => "error"
+               }
+             }
+    end
+  end
+
   describe "/transaction_request.consume" do
     test "consumes the request and transfers the appropriate amount of tokens", meta do
       transaction_request =

--- a/apps/ewallet/lib/ewallet/fetchers/user_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/user_fetcher.ex
@@ -4,8 +4,8 @@ defmodule EWallet.UserFetcher do
   """
   alias EWalletDB.{User}
 
-  @spec get(String.t()) :: {:ok, User.t()} | {:error, Atom.t()}
-  def get(%{"user_id" => user_id}) do
+  @spec fetch(String.t()) :: {:ok, User.t()} | {:error, Atom.t()}
+  def fetch(%{"user_id" => user_id}) do
     with %User{} = user <- User.get(user_id) || :user_id_not_found do
       {:ok, user}
     else
@@ -13,8 +13,8 @@ defmodule EWallet.UserFetcher do
     end
   end
 
-  @spec get(String.t()) :: {:ok, User.t()} | {:error, Atom.t()}
-  def get(%{"provider_user_id" => provider_user_id}) do
+  @spec fetch(String.t()) :: {:ok, User.t()} | {:error, Atom.t()}
+  def fetch(%{"provider_user_id" => provider_user_id}) do
     with %User{} = user <-
            User.get_by_provider_user_id(provider_user_id) || :provider_user_id_not_found do
       {:ok, user}
@@ -23,5 +23,5 @@ defmodule EWallet.UserFetcher do
     end
   end
 
-  def get(_), do: {:error, :invalid_parameter}
+  def fetch(_), do: {:error, :invalid_parameter}
 end

--- a/apps/ewallet/lib/ewallet/fetchers/user_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/user_fetcher.ex
@@ -1,0 +1,27 @@
+defmodule EWallet.UserFetcher do
+  @moduledoc """
+  Handles the retrieval of users from the eWallet database.
+  """
+  alias EWalletDB.{User}
+
+  @spec get(String.t()) :: {:ok, User.t()} | {:error, Atom.t()}
+  def get(%{"user_id" => user_id}) do
+    with %User{} = user <- User.get(user_id) || :user_id_not_found do
+      {:ok, user}
+    else
+      error -> {:error, error}
+    end
+  end
+
+  @spec get(String.t()) :: {:ok, User.t()} | {:error, Atom.t()}
+  def get(%{"provider_user_id" => provider_user_id}) do
+    with %User{} = user <-
+           User.get_by_provider_user_id(provider_user_id) || :provider_user_id_not_found do
+      {:ok, user}
+    else
+      error -> {:error, error}
+    end
+  end
+
+  def get(_), do: {:error, :invalid_parameter}
+end

--- a/apps/ewallet/test/ewallet/fetchers/user_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/user_fetcher_test.exs
@@ -10,27 +10,27 @@ defmodule EWallet.UserFetcherTest do
 
   describe "get/1" do
     test "retrieves a user from its id", meta do
-      {:ok, user} = UserFetcher.get(%{"user_id" => meta.user.id})
+      {:ok, user} = UserFetcher.fetch(%{"user_id" => meta.user.id})
       assert user == meta.user
     end
 
     test "retrieves a user from its provider_user_id", meta do
-      {:ok, user} = UserFetcher.get(%{"provider_user_id" => meta.user.provider_user_id})
+      {:ok, user} = UserFetcher.fetch(%{"provider_user_id" => meta.user.provider_user_id})
       assert user == meta.user
     end
 
     test "Raise user_id_not_found if the user_id doesn't exist" do
-      {:error, error} = UserFetcher.get(%{"user_id" => "fake"})
+      {:error, error} = UserFetcher.fetch(%{"user_id" => "fake"})
       assert error == :user_id_not_found
     end
 
     test "Raise provider_user_id_not_found if the user_id doesn't exist" do
-      {:error, error} = UserFetcher.get(%{"provider_user_id" => "fake"})
+      {:error, error} = UserFetcher.fetch(%{"provider_user_id" => "fake"})
       assert error == :provider_user_id_not_found
     end
 
     test "Raise invalid_parameter if no user_id or provider_user_id" do
-      {:error, error} = UserFetcher.get(%{})
+      {:error, error} = UserFetcher.fetch(%{})
       assert error == :invalid_parameter
     end
   end

--- a/apps/ewallet/test/ewallet/fetchers/user_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/user_fetcher_test.exs
@@ -1,0 +1,37 @@
+defmodule EWallet.UserFetcherTest do
+  use EWallet.LocalLedgerCase, async: true
+  alias EWallet.UserFetcher
+  alias EWalletDB.{User}
+
+  setup do
+    {:ok, user} = :user |> params_for() |> User.insert()
+    %{user: user}
+  end
+
+  describe "get/1" do
+    test "retrieves a user from its id", meta do
+      {:ok, user} = UserFetcher.get(%{"user_id" => meta.user.id})
+      assert user == meta.user
+    end
+
+    test "retrieves a user from its provider_user_id", meta do
+      {:ok, user} = UserFetcher.get(%{"provider_user_id" => meta.user.provider_user_id})
+      assert user == meta.user
+    end
+
+    test "Raise user_id_not_found if the user_id doesn't exist" do
+      {:error, error} = UserFetcher.get(%{"user_id" => "fake"})
+      assert error == :user_id_not_found
+    end
+
+    test "Raise provider_user_id_not_found if the user_id doesn't exist" do
+      {:error, error} = UserFetcher.get(%{"provider_user_id" => "fake"})
+      assert error == :provider_user_id_not_found
+    end
+
+    test "Raise invalid_parameter if no user_id or provider_user_id" do
+      {:error, error} = UserFetcher.get(%{})
+      assert error == :invalid_parameter
+    end
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T453

# Overview

This PR is a follow up of [this one](https://github.com/omisego/ewallet/pull/268).
A few things were wrong and they are fixed in this PR

# Changes

- Added a new `UserFetcher` in order to fetch a user from a `provider_user_id` or a `user_id`
- Added support for both `provider_user_id` and `user_id` on `user.get_transaction_consumptions`
- Fixed swagger
- Duplicated tests for server_auth
- Renamed `transaction_request_id` to `formatted_transaction_request_id` for `transaction_request.get_transaction_consumptions`

