### PR TITLE
Fix Token ID generation should generate the ULID part in lower case

### DIFF
--- a/apps/ewallet_db/lib/ewallet_db/token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/token.ex
@@ -98,7 +98,7 @@ defmodule EWalletDB.Token do
     case get_field(changeset, :id) do
       nil ->
         symbol = get_field(changeset, :symbol)
-        ulid = ULID.generate()
+        ulid = ULID.generate() |> String.downcase()
         put_change(changeset, :id, build_id(symbol, ulid, opts))
 
       _ ->

--- a/apps/ewallet_db/priv/repo/migrations/20180627115719_update_token_id_to_lowercase.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180627115719_update_token_id_to_lowercase.exs
@@ -1,0 +1,32 @@
+defmodule EWalletDB.Repo.Migrations.UpdateTokenIdToLowercase do
+  use Ecto.Migration
+  import Ecto.Query
+  alias EWalletDB.Repo
+
+  @table "token"
+
+  def up do
+    query = from(t in @table,
+                 select: [t.uuid, t.id],
+                 lock: "FOR UPDATE")
+
+    for [uuid, id] <- Repo.all(query) do
+      [prefix, symbol, ulid] = String.split(id, "_", parts: 3)
+      new_id = prefix <> "_" <> symbol <> "_" <> String.downcase(ulid)
+
+      query = from(t in @table,
+                   where: t.uuid == ^uuid,
+                   update: [set: [id: ^new_id]])
+
+      Repo.update_all(query, [])
+    end
+  end
+
+  def down do
+    # Not converting the uppercase back because:
+    # 1. We don't know which tokens had uppercases (tokens inserted before this migration),
+    #    and which had lowercases (tokens created after this migration).
+    # 2. The lowercased ID should still work.
+    # 3. `up/0` can be called again without breaking.
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/token_test.exs
@@ -20,8 +20,9 @@ defmodule EWalletDB.TokenTest do
       {:ok, token} = :token |> params_for(id: nil, symbol: "OMG") |> Token.insert()
 
       assert "tok_OMG_" <> ulid = token.id
-      # A ULID has 26 characters
+      # A ULID has 26 characters and are lower cases
       assert String.length(ulid) == 26
+      assert ulid == String.downcase(ulid)
     end
 
     test "allow subunit to be set between 0 and 1.0e18" do

--- a/apps/local_ledger_db/priv/repo/migrations/20180627122112_update_id_to_lowercase_in_token.exs
+++ b/apps/local_ledger_db/priv/repo/migrations/20180627122112_update_id_to_lowercase_in_token.exs
@@ -1,0 +1,102 @@
+defmodule LocalLedgerDB.Repo.Migrations.UpdateIdToLowercaseInToken do
+  use Ecto.Migration
+  import Ecto.Query
+  alias LocalLedgerDB.Repo
+
+  def up do
+    ##################
+    # Add new fields #
+    ##################
+    alter table(:token) do
+      add :new_id, :string, null: true
+    end
+
+    create index(:token, :new_id, unique: true)
+
+    alter table(:entry) do
+      add :new_token_id, references(:token, type: :string, column: :new_id),
+                                    null: true
+    end
+
+    flush()
+
+    #######################
+    # Populate new fields #
+    #######################
+    query = from(t in "token",
+                 select: [t.uuid, t.id],
+                 lock: "FOR UPDATE")
+
+    for [uuid, id] <- Repo.all(query) do
+      [prefix, symbol, ulid] = String.split(id, "_", parts: 3)
+      new_id = prefix <> "_" <> symbol <> "_" <> String.downcase(ulid)
+
+      # Update `token` table
+      query = from(t in "token",
+                   where: t.uuid == ^uuid,
+                   update: [set: [new_id: ^new_id]])
+
+      Repo.update_all(query, [])
+
+      # Update `entry` table
+      query = from(t in "entry",
+                   where: t.token_id == ^id,
+                   update: [set: [new_token_id: ^new_id]])
+
+      Repo.update_all(query, [])
+
+      # Update `cached_balance` table
+      query = from(t in "cached_balance",
+                   where: fragment("amounts \\? ?", ^id),
+                   update: [set: [amounts: fragment("amounts - ? || jsonb_build_object(?, amounts->?)",
+                                                    type(^id, :string),
+                                                    type(^new_id, :string),
+                                                    type(^id, :string))]])
+
+      Repo.update_all(query, [])
+    end
+
+    #################################
+    # Swap old fields with new ones #
+    #################################
+
+    alter table(:entry) do
+      modify :new_token_id, :string, null: false
+      remove(:token_id)
+    end
+    rename table(:entry), :new_token_id, to: :token_id
+
+    alter table(:token) do
+      modify :new_id, :string, null: false
+      remove(:id)
+    end
+    rename table(:token), :new_id, to: :id
+
+    flush()
+
+    ##################
+    # Rename indexes #
+    ##################
+
+    # Indexes and constraints don't get renamed when fields are renamed,
+    # so we manually rename them for consistency.
+    execute """
+      ALTER INDEX token_new_id_index
+      RENAME TO token_id_index
+      """
+
+    execute """
+      ALTER TABLE entry
+      RENAME CONSTRAINT entry_new_token_id_fkey
+      TO entry_token_id_fkey
+      """
+  end
+
+  def down do
+    # Not converting the uppercase back because:
+    # 1. We don't know which tokens had uppercases (tokens inserted before this migration),
+    #    and which had lowercases (tokens created after this migration).
+    # 2. The lowercased ID should still work.
+    # 3. `up/0` can be called again without breaking.
+  end
+end


### PR DESCRIPTION
Issue/Task Number: T401

# Overview

This PR fixes the token ID generation so that the ULID part is in lower case.

For example, `tok_ETH_01CH0AP3NQYSAWHHZNGJCC6WZ4` should be `tok_ETH_01ch0ap3nqysawhhzngjcc6wz4`.

# Changes

- Updated `EWalletDB.Token` to lower case the ULID part before saving.
- Added DB migrations to update existing token IDs in `ewallet_db` and `local_ledger_db`

# Implementation Details

Straight forward lower-casing during token insert.

# Usage

Try `/token.create`.

# Impact

`mix ecto.migrate` after deploy.
