### PR TITLE
Add amount validation on transactions

### DIFF
--- a/apps/ewallet/lib/ewallet/application.ex
+++ b/apps/ewallet/lib/ewallet/application.ex
@@ -2,9 +2,12 @@ defmodule EWallet.Application do
   @moduledoc false
   use Application
 
+  @precision 38
+
   def start(_type, _args) do
     import Supervisor.Spec
 
+    set_decimal_context()
     # List all child processes to be supervised
     children = [
       worker(EWallet.Scheduler, [])
@@ -14,5 +17,11 @@ defmodule EWallet.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: EWallet.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp set_decimal_context do
+    Decimal.get_context()
+    |> Map.put(:precision, @precision)
+    |> Decimal.set_context()
   end
 end

--- a/apps/ewallet/lib/ewallet/formatters/amount_formatter.ex
+++ b/apps/ewallet/lib/ewallet/formatters/amount_formatter.ex
@@ -3,19 +3,10 @@ defmodule EWallet.AmountFormatter do
   A string formatter for amounts
   """
   def format(amount, subunit_to_unit) do
-    subunit_to_unit
-    |> to_decimals()
-    |> float_to_binary(amount / subunit_to_unit)
-    |> String.replace_trailing(".0", "")
-  end
+    Decimal.set_context(%Decimal.Context{Decimal.get_context() | precision: 38})
 
-  defp float_to_binary(decimals, value) do
-    :erlang.float_to_binary(value, [:compact, {:decimals, decimals}])
-  end
-
-  defp to_decimals(subunit_to_unit) do
-    subunit_to_unit
-    |> :math.log10()
-    |> Kernel.trunc()
+    amount
+    |> Decimal.div(subunit_to_unit)
+    |> Decimal.to_string(:normal)
   end
 end

--- a/apps/ewallet/lib/ewallet/formatters/amount_formatter.ex
+++ b/apps/ewallet/lib/ewallet/formatters/amount_formatter.ex
@@ -3,8 +3,6 @@ defmodule EWallet.AmountFormatter do
   A string formatter for amounts
   """
   def format(amount, subunit_to_unit) do
-    Decimal.set_context(%Decimal.Context{Decimal.get_context() | precision: 38})
-
     amount
     |> Decimal.div(subunit_to_unit)
     |> Decimal.to_string(:normal)

--- a/apps/ewallet_db/lib/ewallet_db/token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/token.ex
@@ -82,7 +82,11 @@ defmodule EWalletDB.Token do
       :metadata,
       :encrypted_metadata
     ])
-    |> validate_number(:subunit_to_unit, greater_than: 0, less_than_or_equal_to: 1.0e18)
+    |> validate_number(
+      :subunit_to_unit,
+      greater_than: 0,
+      less_than_or_equal_to: 1_000_000_000_000_000_000
+    )
     |> validate_immutable(:symbol)
     |> unique_constraint(:symbol)
     |> unique_constraint(:iso_code)

--- a/apps/ewallet_db/lib/ewallet_db/transaction.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction.ex
@@ -124,6 +124,8 @@ defmodule EWalletDB.Transaction do
       :metadata,
       :encrypted_metadata
     ])
+    |> validate_number(:from_amount, less_than: 100_000_000_000_000_000_000_000_000_000_000_000)
+    |> validate_number(:to_amount, less_than: 100_000_000_000_000_000_000_000_000_000_000_000)
     |> validate_from_wallet_identifier()
     |> validate_inclusion(:status, @statuses)
     |> validate_inclusion(:type, @types)

--- a/apps/ewallet_db/test/ewallet_db/token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/token_test.exs
@@ -26,13 +26,13 @@ defmodule EWalletDB.TokenTest do
     end
 
     test "allow subunit to be set between 0 and 1.0e18" do
-      {:ok, token} = :token |> params_for(subunit_to_unit: 1.0e18) |> Token.insert()
+      {:ok, token} = :token |> params_for(subunit_to_unit: 1_000_000_000_000_000_000) |> Token.insert()
 
       assert token.subunit_to_unit == 1_000_000_000_000_000_000
     end
 
     test "fails to insert when subunit is equal to 1.0e19" do
-      {:error, error} = :token |> params_for(subunit_to_unit: 1.0e19) |> Token.insert()
+      {:error, error} = :token |> params_for(subunit_to_unit: 10_000_000_000_000_000_000) |> Token.insert()
 
       assert error.errors == [
                subunit_to_unit:
@@ -51,7 +51,7 @@ defmodule EWalletDB.TokenTest do
     end
 
     test "fails to insert when subunit is superior to 1.0e18" do
-      {:error, error} = :token |> params_for(subunit_to_unit: 1.0e82) |> Token.insert()
+      {:error, error} = :token |> params_for(subunit_to_unit: 100_000_000_000_000_000_000_000) |> Token.insert()
 
       assert error.errors == [
                subunit_to_unit:

--- a/apps/ewallet_db/test/ewallet_db/token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/token_test.exs
@@ -26,13 +26,15 @@ defmodule EWalletDB.TokenTest do
     end
 
     test "allow subunit to be set between 0 and 1.0e18" do
-      {:ok, token} = :token |> params_for(subunit_to_unit: 1_000_000_000_000_000_000) |> Token.insert()
+      {:ok, token} =
+        :token |> params_for(subunit_to_unit: 1_000_000_000_000_000_000) |> Token.insert()
 
       assert token.subunit_to_unit == 1_000_000_000_000_000_000
     end
 
     test "fails to insert when subunit is equal to 1.0e19" do
-      {:error, error} = :token |> params_for(subunit_to_unit: 10_000_000_000_000_000_000) |> Token.insert()
+      {:error, error} =
+        :token |> params_for(subunit_to_unit: 10_000_000_000_000_000_000) |> Token.insert()
 
       assert error.errors == [
                subunit_to_unit:
@@ -51,7 +53,8 @@ defmodule EWalletDB.TokenTest do
     end
 
     test "fails to insert when subunit is superior to 1.0e18" do
-      {:error, error} = :token |> params_for(subunit_to_unit: 100_000_000_000_000_000_000_000) |> Token.insert()
+      {:error, error} =
+        :token |> params_for(subunit_to_unit: 100_000_000_000_000_000_000_000) |> Token.insert()
 
       assert error.errors == [
                subunit_to_unit:

--- a/apps/ewallet_db/test/ewallet_db/transaction_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_test.exs
@@ -162,10 +162,12 @@ defmodule EWalletDB.TransactionTest do
         |> Transaction.insert()
 
       assert res == :error
+
       assert error.errors == [
-        from_amount: {"must be less than %{number}",
-         [validation: :number, number: 100_000_000_000_000_000_000_000_000_000_000_000]}
-      ]
+               from_amount:
+                 {"must be less than %{number}",
+                  [validation: :number, number: 100_000_000_000_000_000_000_000_000_000_000_000]}
+             ]
     end
 
     test "fails when to_amount is >= 100_000_000_000_000_000_000_000_000_000_000_000 (max 35 digits)" do
@@ -175,10 +177,12 @@ defmodule EWalletDB.TransactionTest do
         |> Transaction.insert()
 
       assert res == :error
+
       assert error.errors == [
-        to_amount: {"must be less than %{number}",
-         [validation: :number, number: 100_000_000_000_000_000_000_000_000_000_000_000]}
-      ]
+               to_amount:
+                 {"must be less than %{number}",
+                  [validation: :number, number: 100_000_000_000_000_000_000_000_000_000_000_000]}
+             ]
     end
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/transaction_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_test.exs
@@ -87,6 +87,26 @@ defmodule EWalletDB.TransactionTest do
                from: {"can't be blank", [validation: :required]}
              ]
     end
+
+    test "succeed with from_amount < 100_000_000_000_000_000_000_000_000_000_000_000" do
+      {res, transaction} =
+        :transaction
+        |> params_for(from_amount: 99_999_999_999_999_999_999_999_999_999_999_999)
+        |> Transaction.insert()
+
+      assert res == :ok
+      assert transaction.from_amount == 99_999_999_999_999_999_999_999_999_999_999_999
+    end
+
+    test "succeed with to_amount < 100_000_000_000_000_000_000_000_000_000_000_000" do
+      {res, transaction} =
+        :transaction
+        |> params_for(to_amount: 99_999_999_999_999_999_999_999_999_999_999_999)
+        |> Transaction.insert()
+
+      assert res == :ok
+      assert transaction.to_amount == 99_999_999_999_999_999_999_999_999_999_999_999
+    end
   end
 
   describe "confirm/2" do
@@ -133,6 +153,32 @@ defmodule EWalletDB.TransactionTest do
       assert transaction.error_code == "error"
       assert transaction.error_description == nil
       assert transaction.error_data == %{}
+    end
+
+    test "fails when from_amount is >= 100_000_000_000_000_000_000_000_000_000_000_000 (max 35 digits)" do
+      {res, error} =
+        :transaction
+        |> params_for(from_amount: 100_000_000_000_000_000_000_000_000_000_000_000)
+        |> Transaction.insert()
+
+      assert res == :error
+      assert error.errors == [
+        from_amount: {"must be less than %{number}",
+         [validation: :number, number: 100_000_000_000_000_000_000_000_000_000_000_000]}
+      ]
+    end
+
+    test "fails when to_amount is >= 100_000_000_000_000_000_000_000_000_000_000_000 (max 35 digits)" do
+      {res, error} =
+        :transaction
+        |> params_for(to_amount: 100_000_000_000_000_000_000_000_000_000_000_000)
+        |> Transaction.insert()
+
+      assert res == :error
+      assert error.errors == [
+        to_amount: {"must be less than %{number}",
+         [validation: :number, number: 100_000_000_000_000_000_000_000_000_000_000_000]}
+      ]
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,8 @@ defmodule EWallet.Umbrella.Mixfile do
       {:credo, "~> 0.9.2", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:excoveralls, "~> 0.8", only: :test, runtime: false},
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
+      {:decimal, "~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
Issue/Task Number: 420

# Overview

This PR limits the maximum amount (from and to) that can be passed to a transaction.
Also fixes an issue with the current implementation of the `AmountFormatter` that was losing precision with big numbers

# Changes

- Limit `from_amount` and `to_amount` to be less than `100_000_000_000_000_000_000_000_000_000_000_000`

# Implementation Details

This constraint comes from a limitation of `swift` where we can't easily decode numbers with more than 38 digits.