### PR TITLE
Prevents category deletion if accounts are still associated

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
@@ -111,7 +111,7 @@ defmodule AdminAPI.V1.CategoryController do
   """
   def delete(conn, %{"id" => id}) do
     with %Category{} = category <- Category.get(id) || {:error, :category_id_not_found},
-         {:ok, deleted} = Category.delete(category),
+         {:ok, deleted} <- Category.delete(category),
          {:ok, deleted} <- Preloader.preload_one(deleted, @preload_fields) do
       render(conn, :category, %{category: deleted})
     else

--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -83,6 +83,10 @@ defmodule AdminAPI.V1.ErrorHandler do
     category_id_not_found: %{
       code: "category:id_not_found",
       description: "There is no category corresponding to the provided id"
+    },
+    category_not_empty: %{
+      code: "category:not_empty",
+      description: "The category has one or more accounts associated"
     }
   }
 

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/category_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
   use AdminAPI.ConnCase, async: true
+  alias EWalletDB.Category
   alias EWalletDB.Helpers.Preloader
 
   describe "/category.all" do
@@ -169,6 +170,29 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
       assert response["success"] == true
       assert response["data"]["object"] == "category"
       assert response["data"]["id"] == category.id
+    end
+
+    test "responds with an error if the category has one or more associated accounts" do
+      account = insert(:account)
+
+      {:ok, category} =
+        :category
+        |> insert()
+        |> Category.update(%{account_ids: [account.id]})
+
+      response = admin_user_request("/category.delete", %{id: category.id})
+
+      assert response ==
+               %{
+                 "version" => "1",
+                 "success" => false,
+                 "data" => %{
+                   "code" => "category:not_empty",
+                   "description" => "The category has one or more accounts associated",
+                   "messages" => nil,
+                   "object" => "error"
+                 }
+               }
     end
 
     test "responds with an error if the provided id is not found" do

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/category_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
   use AdminAPI.ConnCase, async: true
+  alias EWalletDB.Category
   alias EWalletDB.Helpers.Preloader
 
   describe "/category.all" do
@@ -169,6 +170,29 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
       assert response["success"] == true
       assert response["data"]["object"] == "category"
       assert response["data"]["id"] == category.id
+    end
+
+    test "responds with an error if the category has one or more associated accounts" do
+      account = insert(:account)
+
+      {:ok, category} =
+        :category
+        |> insert()
+        |> Category.update(%{account_ids: [account.id]})
+
+      response = admin_user_request("/category.delete", %{id: category.id})
+
+      assert response ==
+               %{
+                 "version" => "1",
+                 "success" => false,
+                 "data" => %{
+                   "code" => "category:not_empty",
+                   "description" => "The category has one or more accounts associated",
+                   "messages" => nil,
+                   "object" => "error"
+                 }
+               }
     end
 
     test "responds with an error if the provided id is not found" do


### PR DESCRIPTION
Issue/Task Number: T394

# Overview

This PR prevents category from being deleted if there are accounts still associated with the category. Thanks to @mederic-p for spotting this.

# Changes

- Update `EWalletDB.Category.delete/1` to check for account emptiness before deleting the category
- Update `AdminAPI.V1.CategoryController` to handle `{:error, :category_not_empty}`
- Add `:category_not_empty` error to AdminAPI's ErrorHandler

# Implementation Details

Simple logic addition to `EWalletDB.Category.delete/1` to check for associated accounts before soft deleting the category.

# Usage

Try `/category.delete` on a category that still has one or more accounts associated.

# Impact

Code changes only. No changes to the DB or API request/response formats.
