### PR TITLE
Prevents an exchange rate of 0 or below

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
@@ -98,6 +98,24 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["rate"] == 2.00
     end
 
+    test "returns an error if given an exchange rate of 0" do
+      request_data = params_for(:exchange_pair, rate: 0)
+      response = admin_user_request("/exchange_pair.create", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
+    test "returns an error if given a negative exchange rate" do
+      request_data = params_for(:exchange_pair, rate: -1)
+      response = admin_user_request("/exchange_pair.create", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
     test "returns an error if a required parameter is not provided" do
       request_data = params_for(:exchange_pair, rate: nil)
       response = admin_user_request("/exchange_pair.create", request_data)
@@ -151,6 +169,24 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
 
       assert response["data"]["description"] ==
                "There is no exchange pair corresponding to the provided id"
+    end
+
+    test "returns an error if given an exchange rate of 0" do
+      request_data = params_for(:exchange_pair, rate: 0)
+      response = admin_user_request("/exchange_pair.update", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
+    test "returns an error if given a negative exchange rate" do
+      request_data = params_for(:exchange_pair, rate: -1)
+      response = admin_user_request("/exchange_pair.update", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/exchange_pair_controller_test.exs
@@ -98,6 +98,24 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["rate"] == 2.00
     end
 
+    test "returns an error if given an exchange rate of 0" do
+      request_data = params_for(:exchange_pair, rate: 0)
+      response = provider_request("/exchange_pair.create", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
+    test "returns an error if given a negative exchange rate" do
+      request_data = params_for(:exchange_pair, rate: -1)
+      response = provider_request("/exchange_pair.create", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
     test "returns an error if a required parameter is not provided" do
       request_data = params_for(:exchange_pair, rate: nil)
       response = provider_request("/exchange_pair.create", request_data)
@@ -151,6 +169,24 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
 
       assert response["data"]["description"] ==
                "There is no exchange pair corresponding to the provided id"
+    end
+
+    test "returns an error if given an exchange rate of 0" do
+      request_data = params_for(:exchange_pair, rate: 0)
+      response = provider_request("/exchange_pair.update", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
+    test "returns an error if given a negative exchange rate" do
+      request_data = params_for(:exchange_pair, rate: -1)
+      response = provider_request("/exchange_pair.update", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
     end
   end
 

--- a/apps/ewallet/lib/ewallet/application.ex
+++ b/apps/ewallet/lib/ewallet/application.ex
@@ -2,7 +2,8 @@ defmodule EWallet.Application do
   @moduledoc false
   use Application
 
-  @precision 38
+  @decimal_precision 38
+  @decimal_rounding :half_even
 
   def start(_type, _args) do
     import Supervisor.Spec
@@ -21,7 +22,8 @@ defmodule EWallet.Application do
 
   defp set_decimal_context do
     Decimal.get_context()
-    |> Map.put(:precision, @precision)
+    |> Map.put(:precision, @decimal_precision)
+    |> Map.put(:rounding, @decimal_rounding)
     |> Decimal.set_context()
   end
 end

--- a/apps/ewallet/lib/ewallet/exchange/exchange.ex
+++ b/apps/ewallet/lib/ewallet/exchange/exchange.ex
@@ -113,8 +113,8 @@ defmodule EWallet.Exchange do
   def calculate(nil, from_token, to_amount, to_token) do
     case get_rate(from_token, to_token) do
       {:ok, rate, pair} ->
-        from_amount = to_amount / rate
-        {:ok, build_result(from_amount, from_token, from_amount * rate, to_token, rate, pair)}
+        from_amount = Decimal.div(to_amount, rate)
+        {:ok, build_result(from_amount, from_token, to_amount, to_token, rate, pair)}
 
       {:error, _} = error ->
         error
@@ -125,7 +125,7 @@ defmodule EWallet.Exchange do
   def calculate(from_amount, from_token, nil, to_token) do
     case get_rate(from_token, to_token) do
       {:ok, rate, pair} ->
-        to_amount = from_amount * rate
+        to_amount = Decimal.mult(from_amount, rate)
         {:ok, build_result(from_amount, from_token, to_amount, to_token, rate, pair)}
 
       {:error, _} = error ->

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -117,7 +117,7 @@ defmodule EWallet.TransactionConsumptionValidator do
   def get_and_validate_token(request, token_id) do
     with %Token{} = token <- Token.get(token_id) || {:error, :token_not_found},
          request_token <- Repo.preload(request, :token).token,
-         {:ok, _pair, _} <- fetch_pair(request.type, request_token.uuid, token.uuid) do
+         {:ok, _pair} <- fetch_pair(request.type, request_token.uuid, token.uuid) do
       {:ok, token}
     else
       error -> error
@@ -141,7 +141,7 @@ defmodule EWallet.TransactionConsumptionValidator do
 
   defp fetch_pair(_type, request_token_uuid, consumption_token_uuid)
        when request_token_uuid == consumption_token_uuid do
-    {:ok, nil, nil}
+    {:ok, nil}
   end
 
   defp fetch_pair(type, request_token_uuid, consumption_token_uuid) do

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -214,19 +214,19 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     exchange_address_not_account: %{
       code: "exchange:exchange_wallet_not_owned_by_account",
-      description: "The specified exchange_wallet is not owned by an account."
+      description: "The specified exchange_wallet is not owned by an account"
     },
     exchange_account_id_not_found: %{
       code: "exchange:account_id_not_found",
-      description: "No account was found with the given exchange_account_id param."
+      description: "No account was found with the given exchange_account_id param"
+    },
+      exchange_client_not_allowed: %{
+      code: "exchange:not_allowed",
+      description: "Exchange consumptions cannot be made through the client API"
     },
     exchange_account_wallet_not_found: %{
       code: "exchange:account_wallet_not_found",
-      description: "No wallet was found with the given exchange_wallet_address param."
-    },
-    exchange_client_not_allowed: %{
-      code: "exchange:not_allowed",
-      description: "Exchange consumptions cannot be made through the client API."
+      description: "No wallet was found with the given exchange_wallet_address param"
     }
   }
 

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -220,7 +220,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
       code: "exchange:account_id_not_found",
       description: "No account was found with the given exchange_account_id param"
     },
-      exchange_client_not_allowed: %{
+    exchange_client_not_allowed: %{
       code: "exchange:not_allowed",
       description: "Exchange consumptions cannot be made through the client API"
     },

--- a/apps/ewallet/mix.exs
+++ b/apps/ewallet/mix.exs
@@ -45,6 +45,7 @@ defmodule EWallet.Mixfile do
       {:quantum, "~> 2.2.6"},
       {:timex, "~> 3.0"},
       {:bodyguard, "~> 2.2"},
+      {:decimal, "~> 1.0"},
       {:ewallet_db, in_umbrella: true},
       {:local_ledger, in_umbrella: true},
       {:local_ledger_db, in_umbrella: true}

--- a/apps/ewallet/test/ewallet/fetchers/amount_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/amount_fetcher_test.exs
@@ -27,26 +27,26 @@ defmodule EWallet.AmountFetcherTest do
       res =
         AmountFetcher.fetch(
           %{
-            "amount" => 1
+            "amount" => 100
           },
           %{},
           %{}
         )
 
-      assert res == {:ok, %{from_amount: 1}, %{to_amount: 1}, %{}}
+      assert res == {:ok, %{from_amount: 100}, %{to_amount: 100}, %{}}
     end
 
     test "returns an error if amount is not an integer (float)" do
       res =
         AmountFetcher.fetch(
           %{
-            "amount" => 1.2
+            "amount" => 100.2
           },
           %{},
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "'amount' is not a number: 1.2"}
+      assert res == {:error, :invalid_parameter, "'amount' is not a number: 100.2"}
     end
 
     test "returns an error if amount is not an integer (string)" do
@@ -68,14 +68,14 @@ defmodule EWallet.AmountFetcherTest do
       res =
         AmountFetcher.fetch(
           %{
-            "from_amount" => 1,
-            "to_amount" => 1
+            "from_amount" => 100,
+            "to_amount" => 100
           },
           %{},
           %{}
         )
 
-      assert res == {:ok, %{from_amount: 1}, %{to_amount: 1}, %{}}
+      assert res == {:ok, %{from_amount: 100}, %{to_amount: 100}, %{}}
     end
 
     test "sets from_amount only when sending nil to_amount with exchange pair" do
@@ -86,7 +86,7 @@ defmodule EWallet.AmountFetcherTest do
       {res, from, to, exchange} =
         AmountFetcher.fetch(
           %{
-            "from_amount" => 1,
+            "from_amount" => 100,
             "to_amount" => nil
           },
           %{from_token: token_1},
@@ -94,8 +94,8 @@ defmodule EWallet.AmountFetcherTest do
         )
 
       assert res == :ok
-      assert from[:from_amount] == 1
-      assert to[:to_amount] == 2
+      assert from[:from_amount] == 100
+      assert to[:to_amount] == 200
       assert exchange[:actual_rate] == 2
       assert exchange[:calculated_at] != nil
       assert exchange[:pair_uuid] == pair.uuid
@@ -108,7 +108,7 @@ defmodule EWallet.AmountFetcherTest do
       res =
         AmountFetcher.fetch(
           %{
-            "from_amount" => 1,
+            "from_amount" => 100,
             "to_amount" => nil
           },
           %{from_token: token_1},
@@ -126,15 +126,15 @@ defmodule EWallet.AmountFetcherTest do
       {res, from, to, exchange} =
         AmountFetcher.fetch(
           %{
-            "from_amount" => 1
+            "from_amount" => 100
           },
           %{from_token: token_1},
           %{to_token: token_2}
         )
 
       assert res == :ok
-      assert from[:from_amount] == 1
-      assert to[:to_amount] == 2
+      assert from[:from_amount] == 100
+      assert to[:to_amount] == 200
       assert exchange[:actual_rate] == 2
       assert exchange[:calculated_at] != nil
       assert exchange[:pair_uuid] == pair.uuid
@@ -147,7 +147,7 @@ defmodule EWallet.AmountFetcherTest do
       res =
         AmountFetcher.fetch(
           %{
-            "from_amount" => 1
+            "from_amount" => 100
           },
           %{from_token: token_1},
           %{to_token: token_2}
@@ -165,15 +165,15 @@ defmodule EWallet.AmountFetcherTest do
         AmountFetcher.fetch(
           %{
             "from_amount" => nil,
-            "to_amount" => 2
+            "to_amount" => 200
           },
           %{from_token: token_1},
           %{to_token: token_2}
         )
 
       assert res == :ok
-      assert from[:from_amount] == 1
-      assert to[:to_amount] == 2
+      assert from[:from_amount] == 100
+      assert to[:to_amount] == 200
       assert exchange[:actual_rate] == 2
       assert exchange[:calculated_at] != nil
       assert exchange[:pair_uuid] == pair.uuid
@@ -187,7 +187,7 @@ defmodule EWallet.AmountFetcherTest do
         AmountFetcher.fetch(
           %{
             "from_amount" => nil,
-            "to_amount" => 2
+            "to_amount" => 200
           },
           %{from_token: token_1},
           %{to_token: token_2}
@@ -204,15 +204,15 @@ defmodule EWallet.AmountFetcherTest do
       {res, from, to, exchange} =
         AmountFetcher.fetch(
           %{
-            "to_amount" => 2
+            "to_amount" => 200
           },
           %{from_token: token_1},
           %{to_token: token_2}
         )
 
       assert res == :ok
-      assert from[:from_amount] == 1
-      assert to[:to_amount] == 2
+      assert from[:from_amount] == 100
+      assert to[:to_amount] == 200
       assert exchange[:actual_rate] == 2
       assert exchange[:calculated_at] != nil
       assert exchange[:pair_uuid] == pair.uuid
@@ -225,7 +225,7 @@ defmodule EWallet.AmountFetcherTest do
       res =
         AmountFetcher.fetch(
           %{
-            "to_amount" => 2
+            "to_amount" => 200
           },
           %{from_token: token_1},
           %{to_token: token_2}

--- a/apps/ewallet_db/lib/ewallet_db/exchange_pair.ex
+++ b/apps/ewallet_db/lib/ewallet_db/exchange_pair.ex
@@ -156,15 +156,15 @@ defmodule EWalletDB.ExchangePair do
   @doc """
   Retrieves an exchange pair using `from_token` and `to_token`.
 
-  If an exchange pair is found, `{:ok, pair, true}` is returned.
+  If an exchange pair is found, `{:ok, pair}` is returned.
   If an exchange pair could not be found, `{:error, :exchange_pair_not_found}` is returned.
   """
   @spec fetch_exchangable_pair(%Token{}, %Token{}, keyword()) ::
-          {:ok, %__MODULE__{}, :direct} | {:error, :exchange_pair_not_found}
+          {:ok, %__MODULE__{}} | {:error, :exchange_pair_not_found}
   def fetch_exchangable_pair(%{uuid: from}, %{uuid: to}, opts \\ []) do
     case get_by([from_token_uuid: from, to_token_uuid: to], opts) do
       %__MODULE__{} = pair ->
-        {:ok, pair, :direct}
+        {:ok, pair}
 
       nil ->
         {:error, :exchange_pair_not_found}

--- a/apps/ewallet_db/lib/ewallet_db/exchange_pair.ex
+++ b/apps/ewallet_db/lib/ewallet_db/exchange_pair.ex
@@ -60,6 +60,7 @@ defmodule EWalletDB.ExchangePair do
     exchange_pair
     |> cast(attrs, [:name, :from_token_uuid, :to_token_uuid, :rate])
     |> validate_required([:name, :rate])
+    |> validate_number(:rate, greater_than: 0)
     |> assoc_constraint(:from_token)
     |> assoc_constraint(:to_token)
     |> unique_constraint(:name)

--- a/apps/ewallet_db/test/ewallet_db/exchange_pair_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/exchange_pair_test.exs
@@ -47,16 +47,15 @@ defmodule EWalletDB.ExchangePairTest do
   end
 
   describe "fetch_exchangable_pair/3" do
-    test "returns {:ok, pair, :direct} if the tokens match a direct pair" do
+    test "returns {:ok, pair} if the tokens match a pair" do
       omg = insert(:token)
       eth = insert(:token)
       inserted_pair = insert(:exchange_pair, from_token: omg, to_token: eth)
 
-      {res, pair, direction} = ExchangePair.fetch_exchangable_pair(omg, eth)
+      {res, pair} = ExchangePair.fetch_exchangable_pair(omg, eth)
 
       assert res == :ok
       assert pair.uuid == inserted_pair.uuid
-      assert direction == :direct
     end
 
     test "returns {:error, :exchange_pair_not_found} if a pair could not be found" do

--- a/apps/ewallet_db/test/ewallet_db/exchange_pair_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/exchange_pair_test.exs
@@ -12,6 +12,24 @@ defmodule EWalletDB.ExchangePairTest do
     test_insert_prevent_blank(ExchangePair, :name)
     test_insert_prevent_blank(ExchangePair, :rate)
     test_insert_generate_timestamps(ExchangePair)
+
+    test "prevents setting exchange rate to 0" do
+      params = params_for(:exchange_pair, rate: 0)
+      {res, changeset} = ExchangePair.insert(params)
+
+      assert res == :error
+      assert changeset.errors ==
+        [rate: {"must be greater than %{number}", [validation: :number, number: 0]}]
+    end
+
+    test "prevents setting exchange rate to a negative number" do
+      params = params_for(:exchange_pair, rate: -1)
+      {res, changeset} = ExchangePair.insert(params)
+
+      assert res == :error
+      assert changeset.errors ==
+        [rate: {"must be greater than %{number}", [validation: :number, number: 0]}]
+    end
   end
 
   describe "deleted?/1" do

--- a/apps/ewallet_db/test/ewallet_db/exchange_pair_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/exchange_pair_test.exs
@@ -18,8 +18,9 @@ defmodule EWalletDB.ExchangePairTest do
       {res, changeset} = ExchangePair.insert(params)
 
       assert res == :error
+
       assert changeset.errors ==
-        [rate: {"must be greater than %{number}", [validation: :number, number: 0]}]
+               [rate: {"must be greater than %{number}", [validation: :number, number: 0]}]
     end
 
     test "prevents setting exchange rate to a negative number" do
@@ -27,8 +28,9 @@ defmodule EWalletDB.ExchangePairTest do
       {res, changeset} = ExchangePair.insert(params)
 
       assert res == :error
+
       assert changeset.errors ==
-        [rate: {"must be greater than %{number}", [validation: :number, number: 0]}]
+               [rate: {"must be greater than %{number}", [validation: :number, number: 0]}]
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,8 +32,7 @@ defmodule EWallet.Umbrella.Mixfile do
       {:credo, "~> 0.9.2", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:excoveralls, "~> 0.8", only: :test, runtime: false},
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
-      {:decimal, "~> 1.0"}
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end
 


### PR DESCRIPTION
Issue/Task Number: T454

# Overview

This PR prevents creating or updating an exchange pair with a rate of zero or below.

# Changes

- Update `ExchangePair`'s changeset to validate for a rate greater than 0
- Added tests for the controllers

# Implementation Details

Straightforward use of [`Ecto.Changeset.validate_number/3`](https://hexdocs.pm/ecto/Ecto.Changeset.html#validate_number/3)

# Usage

Try `/exchange_pair.create` or `/exchange_pair.update` with `rate` of 0 or below. They should return `invalid_parameter` error with the description explaining the validation error.

# Impact

Code changes only. No changes to the DB schema or API request/response format.
