### PR TITLE
Fix errors from asserting a non-deterministic list position

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
@@ -381,7 +381,10 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       wallets = Repo.all(Wallet)
       assert length(wallets) == 4
-      assert Enum.at(wallets, 3).address == response["data"]["address"]
+
+      assert Enum.any?(wallets, fn wallet ->
+               wallet.address == response["data"]["address"]
+             end)
     end
 
     test "inserts a new burn wallet for an account" do
@@ -403,7 +406,10 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       wallets = Repo.all(Wallet)
       assert length(wallets) == 4
-      assert Enum.at(wallets, 3).address == response["data"]["address"]
+
+      assert Enum.any?(wallets, fn wallet ->
+               wallet.address == response["data"]["address"]
+             end)
     end
 
     test "fails to insert a primary wallet for a user" do
@@ -458,8 +464,14 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       wallets = Repo.all(Wallet)
       assert length(wallets) == 5
-      assert Enum.at(wallets, 3).address == response_1["data"]["address"]
-      assert Enum.at(wallets, 4).address == response_2["data"]["address"]
+
+      assert Enum.any?(wallets, fn wallet ->
+               wallet.address == response_1["data"]["address"]
+             end)
+
+      assert Enum.any?(wallets, fn wallet ->
+               wallet.address == response_2["data"]["address"]
+             end)
     end
 
     test "fails to insert a burn wallet for a user" do


### PR DESCRIPTION
Issue/Task Number: -

# Overview

This PR fixes random test failures due to asserting a specific position in a list.

# Changes

- Update `AdminAPI.V1.ProviderAuth.WalletControllerTest` to use `Enum.any?/2` instead of asserting on `Enum.at/2`

# Implementation Details

Since some assertions do not imply any sorting, asserting on `Enum.at/2` is replaced with `Enum.any?/2`.

Example errors:

```
  1) test /wallet.create inserts a new burn wallet for an account (AdminAPI.V1.ProviderAuth.WalletControllerTest)

     test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs:387
     Assertion with == failed
     code:  assert Enum.at(wallets, 3).address() == response["data"]["address"]
     left:  "druk472088053824"
     right: "fazd729024613357"
     stacktrace:
       test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs:406: (test)
```

# Usage

Run `mix test`. All tests should pass.

# Impact

Code changes only. No DB migration or API changes
