### PR TITLE
Allow cross-token transactions from/to exchange wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Here are some resources if you want to learn more about how the eWallet works.
 -   [eWallet Entites](/docs/design/entities.md)
 -   [eWallet Components](/docs/design/components.md)
 -   [A closer look at wallets](/docs/design/wallets.md)
+-   [Transactions and entries](/docs/design/transactions_and_entries.md)
 
 # Contributing
 

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -424,6 +424,104 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       assert response["data"]["to"]["token_id"] == token_2.id
     end
 
+    test "create a transaction with exchange wallet also being the `from` wallet" do
+      exchange_account = Account.get_master_account()
+      exchange_wallet = Account.get_primary_wallet(exchange_account)
+      {:ok, user} = :user |> params_for() |> User.insert()
+      user_wallet = User.get_primary_wallet(user)
+
+      token_1 = insert(:token)
+      token_2 = insert(:token)
+
+      mint!(token_1)
+      mint!(token_2)
+
+      pair = insert(:exchange_pair, from_token: token_1, to_token: token_2, rate: 2)
+
+      response =
+        admin_user_request("/transaction.create", %{
+          "idempotency_token" => "12344",
+          "from_address" => exchange_wallet.address,
+          "to_address" => user_wallet.address,
+          "from_token_id" => token_1.id,
+          "to_token_id" => token_2.id,
+          "exchange_account_id" => exchange_account.id,
+          "from_amount" => 1_000
+        })
+
+      assert response["success"] == true
+      assert response["data"]["object"] == "transaction"
+
+      assert response["data"]["exchange"]["rate"] == 2
+      assert response["data"]["exchange"]["calculated_at"] != nil
+      assert response["data"]["exchange"]["exchange_pair_id"] == pair.id
+      assert response["data"]["exchange"]["exchange_pair"]["id"] == pair.id
+
+      assert response["data"]["from"]["address"] == exchange_wallet.address
+      assert response["data"]["from"]["amount"] == 1_000
+      assert response["data"]["from"]["account_id"] == exchange_account.id
+      assert response["data"]["from"]["user_id"] == nil
+      assert response["data"]["from"]["token_id"] == token_1.id
+
+      assert response["data"]["to"]["address"] == user_wallet.address
+      assert response["data"]["to"]["amount"] == 2_000
+      assert response["data"]["to"]["account_id"] == nil
+      assert response["data"]["to"]["user_id"] == user.id
+      assert response["data"]["to"]["token_id"] == token_2.id
+    end
+
+    test "create a transaction with exchange wallet also being the `to` wallet" do
+      exchange_account = Account.get_master_account()
+      exchange_wallet = Account.get_primary_wallet(exchange_account)
+      {:ok, user} = :user |> params_for() |> User.insert()
+      user_wallet = User.get_primary_wallet(user)
+
+      token_1 = insert(:token)
+      token_2 = insert(:token)
+
+      mint!(token_1)
+      mint!(token_2)
+
+      pair = insert(:exchange_pair, from_token: token_1, to_token: token_2, rate: 2)
+
+      set_initial_balance(%{
+        address: user_wallet.address,
+        token: token_1,
+        amount: 2_000_000
+      })
+
+      response =
+        admin_user_request("/transaction.create", %{
+          "idempotency_token" => "12344",
+          "from_address" => user_wallet.address,
+          "to_address" => exchange_wallet.address,
+          "from_token_id" => token_1.id,
+          "to_token_id" => token_2.id,
+          "exchange_account_id" => exchange_account.id,
+          "from_amount" => 1_000
+        })
+
+      assert response["success"] == true
+      assert response["data"]["object"] == "transaction"
+
+      assert response["data"]["exchange"]["rate"] == 2
+      assert response["data"]["exchange"]["calculated_at"] != nil
+      assert response["data"]["exchange"]["exchange_pair_id"] == pair.id
+      assert response["data"]["exchange"]["exchange_pair"]["id"] == pair.id
+
+      assert response["data"]["from"]["address"] == user_wallet.address
+      assert response["data"]["from"]["amount"] == 1_000
+      assert response["data"]["from"]["account_id"] == nil
+      assert response["data"]["from"]["user_id"] == user.id
+      assert response["data"]["from"]["token_id"] == token_1.id
+
+      assert response["data"]["to"]["address"] == exchange_wallet.address
+      assert response["data"]["to"]["amount"] == 2_000
+      assert response["data"]["to"]["account_id"] == exchange_account.id
+      assert response["data"]["to"]["user_id"] == nil
+      assert response["data"]["to"]["token_id"] == token_2.id
+    end
+
     test "returns an error when doing exchange with invalid exchange_account_id" do
       {:ok, user_1} = :user |> params_for() |> User.insert()
       {:ok, user_2} = :user |> params_for() |> User.insert()
@@ -549,6 +647,40 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       assert response["data"] == %{
                "code" => "wallet:to_address_not_found",
                "description" => "No wallet found for the provided to_address.",
+               "messages" => nil,
+               "object" => "error"
+             }
+    end
+
+    test "returns user:same_address when `from` and `to` and exchange wallet are the same address" do
+      exchange_account = Account.get_master_account()
+      wallet = Account.get_primary_wallet(exchange_account)
+
+      token_1 = insert(:token)
+      token_2 = insert(:token)
+
+      mint!(token_1)
+      mint!(token_2)
+
+      _pair = insert(:exchange_pair, from_token: token_1, to_token: token_2, rate: 2)
+
+      response =
+        admin_user_request("/transaction.create", %{
+          "idempotency_token" => "123",
+          "from_address" => wallet.address,
+          "from_amount" => 1_000_000,
+          "from_token_id" => token_1.id,
+          "to_address" => wallet.address,
+          "to_amount" => 2_000_000,
+          "to_token_id" => token_2.id,
+          "exchange_account_id" => exchange_account.id,
+        })
+
+      assert response["success"] == false
+
+      assert response["data"] == %{
+               "code" => "transaction:same_address",
+               "description" => "Found identical addresses in senders and receivers: #{wallet.address}.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -673,14 +673,15 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
           "to_address" => wallet.address,
           "to_amount" => 2_000_000,
           "to_token_id" => token_2.id,
-          "exchange_account_id" => exchange_account.id,
+          "exchange_account_id" => exchange_account.id
         })
 
       assert response["success"] == false
 
       assert response["data"] == %{
                "code" => "transaction:same_address",
-               "description" => "Found identical addresses in senders and receivers: #{wallet.address}.",
+               "description" =>
+                 "Found identical addresses in senders and receivers: #{wallet.address}.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -672,14 +672,15 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
           "to_address" => wallet.address,
           "to_amount" => 2_000_000,
           "to_token_id" => token_2.id,
-          "exchange_account_id" => exchange_account.id,
+          "exchange_account_id" => exchange_account.id
         })
 
       assert response["success"] == false
 
       assert response["data"] == %{
                "code" => "transaction:same_address",
-               "description" => "Found identical addresses in senders and receivers: #{wallet.address}.",
+               "description" =>
+                 "Found identical addresses in senders and receivers: #{wallet.address}.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/ewallet/test/ewallet/formatters/transaction_formatter_test.exs
+++ b/apps/ewallet/test/ewallet/formatters/transaction_formatter_test.exs
@@ -102,4 +102,58 @@ defmodule EWallet.TransactionFormatterTest do
       assert Enum.count(formatted["entries"]) == 4
     end
   end
+
+  describe "format/1 for cross-token transfers when `from` is also the exchange wallet" do
+    test "returns the expected debit and credit entries" do
+      {:ok, exchange_account} = :account |> params_for() |> Account.insert()
+      exchange_wallet = Account.get_primary_wallet(exchange_account)
+      to_wallet = insert(:wallet)
+      omg = insert(:token)
+      eth = insert(:token)
+
+      transaction =
+        insert(:transaction, %{
+          from_wallet: exchange_wallet,
+          from_amount: 100,
+          from_token: omg,
+          to_wallet: to_wallet,
+          to_amount: 100,
+          to_token: eth,
+          exchange_wallet: exchange_wallet
+        })
+
+      formatted = TransactionFormatter.format(transaction)
+
+      assert has_entry?(formatted, :debit, exchange_wallet.address, 100, eth)
+      assert has_entry?(formatted, :credit, to_wallet.address, 100, eth)
+      assert Enum.count(formatted["entries"]) == 2
+    end
+  end
+
+  describe "format/1 for cross-token transfers when `to` is also the exchange wallet" do
+    test "returns the expected debit and credit entries" do
+      {:ok, exchange_account} = :account |> params_for() |> Account.insert()
+      exchange_wallet = Account.get_primary_wallet(exchange_account)
+      from_wallet = insert(:wallet)
+      omg = insert(:token)
+      eth = insert(:token)
+
+      transaction =
+        insert(:transaction, %{
+          from_wallet: from_wallet,
+          from_amount: 100,
+          from_token: omg,
+          to_wallet: exchange_wallet,
+          to_amount: 100,
+          to_token: eth,
+          exchange_wallet: exchange_wallet
+        })
+
+      formatted = TransactionFormatter.format(transaction)
+
+      assert has_entry?(formatted, :debit, from_wallet.address, 100, omg)
+      assert has_entry?(formatted, :credit, exchange_wallet.address, 100, omg)
+      assert Enum.count(formatted["entries"]) == 2
+    end
+  end
 end

--- a/docs/design/transactions_and_entries.md
+++ b/docs/design/transactions_and_entries.md
@@ -1,0 +1,139 @@
+# Transactions & entries
+
+This document describes how transactions and entries are recorded in the eWallet and Local Ledger
+databases using the double bookkeeping system.
+
+## Double entry bookkeeping
+
+Double entry bookkeeping is a systematic way to record the flow of funds between
+different entities, in this case being wallets.
+
+Each transaction comprises of at least two entries affecting different accounts, one debit
+and one credit. The sum of the debit amounts and the sum of credit amounts in each transaction
+are always equal. If the sums are different, the transaction and entries must be considered
+invalid and not accepted into the Local Ledger database in the first place.
+
+This system allows for a consistent audit trail where every single unit of funds are always
+accounted for, and balances for any point in time can be computed with accuracy using these
+transactions and debit/credit entries.
+
+## eWallet transactions
+
+An eWallet transaction is the record of the original intent and stores any extra data associated
+with the intent. It is not aware of how the accounting or transfer is done behind the scene but
+contains useful user-facing information such as the source and destination of funds for the
+transaction, the extra metadata provided by the provider, etc.
+
+The existent of this transaction does not imply that the transaction occured successfully.
+Instead, the success or failure of the transaction can be determined by looking at
+the transaction's `status` attribute, along with any `error_code`, `error_description`
+and `error_data` associated with the record.
+
+## Local Ledger transactions
+
+A Local Ledger transaction is a logical group of debit/credit entries that satisfies
+an eWallet transaction.
+
+Each Local Ledger transaction is associated with an eWallet transaction. On the other hand,
+an eWallet transaction may or may not associate with a Local Ledger transaction.
+In this latter case, it must be associated with a transaction that occurs somewhere else,
+such as a transaction on the blockchain.
+
+The sum of debit amounts and the sum of credit amounts must be equal within each Local Ledger
+transaction.
+
+## Local Ledger entries
+
+A Local Ledger entry can be either a `debit` or `credit` type. Each entry represents a change
+in value in a wallet.
+
+While the double entry bookkeeping system has a proper definition for debit and credit,
+**it's safe to say within this eWallet context that a debit entry removes funds from a wallet,
+while a credit entry adds funds to a wallet.**
+
+In some cases, looking at the entries alone may be counter-intuitive. The examples below
+highlight some intuitive and counter-intuitive records that may arise in your Local Ledger
+database.
+
+## Examples
+
+Note: Fields are shortened or removed, and values are shortened for readability.
+
+### Same-token transfers
+
+eWallet transaction:
+
+|    id    |      from | from_amount | from_token |        to | to_amount | to_token | exchange_wallet |  status | ledger_uuid |
+|    ----: |     ----: |       ----: |      ----: |     ----: |     ----: |    ----: |           ----: |   ----: |       ----: |
+| txn_1234 | wllt_1111 |        1000 |    tok_ETH | wllt_2222 |      1000 |  tok_ETH |          *NULL* | success |    5bc8a6f5 |
+
+Local Ledger transaction:
+
+|     uuid |
+|    ----: |
+| 5bc8a6f5 |
+
+Local Ledger entries:
+
+| transaction_uuid |     uuid |   type |   address | amount | token_id |
+|            ----: |     ---: |   ---: |      ---: |   ---: |     ---: |
+|         5bc8a6f5 | 7457e16a |  debit | wllt_1111 |   1000 |  tok_ETH |
+|         5bc8a6f5 | 28de919c | credit | wllt_2222 |   1000 |  tok_ETH |
+
+### Cross-token transfers
+
+eWallet transaction:
+
+|    id    |      from | from_amount | from_token |        to | to_amount | to_token | exchange_wallet |  status | ledger_uuid |
+|    ----: |     ----: |       ----: |      ----: |     ----: |     ----: |    ----: |           ----: |   ----: |       ----: |
+| txn_1234 | wllt_1111 |        1000 |    tok_ETH | wllt_2222 |      5000 |  tok_OMG |       exhg_9999 | success |    b83abefd |
+
+Local Ledger transaction:
+
+|     uuid |
+|    ----: |
+| b83abefd |
+
+Local Ledger entries:
+
+| transaction_uuid |     uuid |   type |   address | amount | token_id |
+|            ----: |     ---: |   ---: |      ---: |   ---: |     ---: |
+|         b83abefd | 891dd719 |  debit | wllt_1111 |   1000 |  tok_ETH |
+|         b83abefd | 0c01836f | credit | exhg_9999 |   1000 |  tok_ETH |
+|         b83abefd | aa216b0e |  debit | exhg_9999 |   5000 |  tok_OMG |
+|         b83abefd | de13a367 | credit | wllt_2222 |   5000 |  tok_OMG |
+
+Notice that 4 entries are needed. Two for moving ETH funds from the source to the exchange wallet.
+Another two for moving OMG funds from the exchange to the destination wallet.
+
+### Cross-token transfers from/to an exchange account
+
+eWallet transaction:
+
+|    id    |      from | from_amount | from_token |        to | to_amount | to_token | exchange_wallet |  status | ledger_uuid |
+|    ----: |     ----: |       ----: |      ----: |     ----: |     ----: |    ----: |           ----: |   ----: |       ----: |
+| txn_1234 | wllt_1111 |        1000 |    tok_ETH | exhg_9999 |      5000 |  tok_OMG |       exhg_9999 | success |    b83abefd |
+
+Local Ledger transaction:
+
+|     uuid |
+|    ----: |
+| b83abefd |
+
+Local Ledger entries:
+
+| transaction_uuid |     uuid |   type |   address | amount | token_id |
+|            ----: |     ---: |   ---: |      ---: |   ---: |     ---: |
+|         b83abefd | 777a2690 |  debit | wllt_1111 |   1000 |  tok_ETH |
+|         b83abefd | afb18c43 | credit | exhg_9999 |   1000 |  tok_ETH |
+
+Notice that only 2 Local Ledger entries are made. These two entries are for moving ETH funds from
+the source to the exchange wallet. Since the destination wallet is also the same exchange wallet,
+no entries are made.
+
+Also note that at the same time, the eWallet transaction still shows different `to_token` and
+`from_token` values even though the local ledger performs the transaction in only one token.
+
+This is because the eWallet transaction should still represent the original intent: to have funds
+deducted in one token and arrive as another token with the help of the specified exchange agent,
+while the Local Ledger entries represent the actual movement of funds.

--- a/mix.exs
+++ b/mix.exs
@@ -62,9 +62,12 @@ defmodule EWallet.Umbrella.Mixfile do
       extra_section: "Guides",
       extras: [
         {"README.md", [filename: "introduction", title: "Introduction"]},
-        "docs/design/wallets.md",
         "docs/design/components.md",
+        "docs/design/databases.md",
         "docs/design/entities.md",
+        "docs/design/transactions_and_entries.md",
+        "docs/design/wallets.md",
+        "docs/guides/transaction_request_flow.md",
         "docs/setup/clustering.md",
         "docs/setup/env.md",
         "docs/setup/integration.md"
@@ -73,15 +76,20 @@ defmodule EWallet.Umbrella.Mixfile do
         "Getting Started": [
           "README.md"
         ],
-        "Technical Design": [
-          "docs/design/wallets.md",
-          "docs/design/components.md",
-          "docs/design/entities.md"
-        ],
         "Setting Up": [
           "docs/setup/clustering.md",
           "docs/setup/env.md",
           "docs/setup/integration.md"
+        ],
+        Guides: [
+          "docs/guides/transaction_request_flow.md"
+        ],
+        "Technical Design": [
+          "docs/design/entities.md",
+          "docs/design/components.md",
+          "docs/design/databases.md",
+          "docs/design/wallets.md",
+          "docs/design/transactions_and_entries.md"
         ]
       ],
       groups_for_modules: [


### PR DESCRIPTION
Issue/Task Number: T467

# Overview

This PR fixes the entries generation for cross-token transfers that involve `from` or `to` address being the exchange wallet itself.

# Changes

- Add support for cross-token transfers from/to an exchange wallet into `EWallet.TransactionFormatter`
- Add tests to validate the change in `TransactionFormatterTest` as well as transaction controller tests.
- Fill in some missing test cases between admin user and provider requests.

# Implementation Details

Because usual cross-token transfers require 4 debit/credit entries (2 for moving `from_token` into the exchange account, 2 for moving `to_token` out of the exchange account), so the existing `TransactionFormatter` generates a pair of debit/credit that goes to the same wallet address when an exchange wallet is also used as `from` or `to` address.

This is fixed by having the `TransactionFormatter` detects that if the `from`/`to` is the same address as the exchange wallet, it should generate only 1 pair of entries that moves the funds from the other wallet into the exchange wallet or vice versa.

# Usage

Try `/transaction.create` with `from` or `to` address being the same as the exchange wallet, or `/me.create_transaction` with `to` address being the same as the exchange wallet. The operations should be successful.

# Impact

Code changes only. No DB migrations or API request/response format changes.