### PR TITLE
use unauthenticated request

### DIFF
--- a/apps/admin_panel/assets/src/services/adminService.js
+++ b/apps/admin_panel/assets/src/services/adminService.js
@@ -1,4 +1,4 @@
-import { authenticatedRequest, authenticatedMultipartRequest } from './apiService'
+import { authenticatedRequest, authenticatedMultipartRequest, unAuthenticatedRequest } from './apiService'
 
 export function getAllAdmins ({ perPage, sort, query, ...rest }) {
   return authenticatedRequest({
@@ -24,7 +24,7 @@ export function uploadAvatar ({ id, avatar }) {
 }
 
 export function createAdmin ({ resetToken, password, passwordConfirmation, email }) {
-  return authenticatedRequest({
+  return unAuthenticatedRequest({
     path: '/invite.accept',
     data: {
       email,


### PR DESCRIPTION
Issue/Task Number: -

# Overview

When accepting invite, we need to call a request to create an account. This request is not an authenticated request which makes only logged in users will be able to accept invite.

# Changes

- Change endpoint to `unauthenticated`

# Implementation Details

-

# Usage

Invite someone, and accept the link to create a new password and login.

# Impact

Deploy as usual.
