### PR TITLE
Send back failure reason for transactions

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWalletDB.{User, Account}
+  alias EWalletDB.{User, Account, Transaction}
 
   # credo:disable-for-next-line
   setup do
@@ -595,6 +595,17 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
                  } - Attempted debit: 12345.67 #{token.id}",
                "messages" => nil,
                "object" => "error"
+             }
+
+      transaction = get_last_inserted(Transaction)
+      assert transaction.error_code == "insufficient_funds"
+      assert transaction.error_description == nil
+
+      assert transaction.error_data == %{
+               "address" => wallet_1.address,
+               "amount_to_debit" => 1_234_567,
+               "current_amount" => 0,
+               "token_id" => token.id
              }
     end
 

--- a/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
@@ -51,6 +51,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
           metadata: %{some: "metadata"},
           encrypted_metadata: %{},
           status: transaction.status,
+          error_code: nil,
+          error_description: nil,
           created_at: Date.to_iso8601(transaction.inserted_at),
           updated_at: Date.to_iso8601(transaction.updated_at)
         }
@@ -119,6 +121,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
               metadata: %{some: "metadata"},
               encrypted_metadata: %{},
               status: transaction1.status,
+              error_code: nil,
+              error_description: nil,
               created_at: Date.to_iso8601(transaction1.inserted_at),
               updated_at: Date.to_iso8601(transaction1.updated_at)
             },
@@ -162,6 +166,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
               metadata: %{some: "metadata"},
               encrypted_metadata: %{},
               status: transaction2.status,
+              error_code: nil,
+              error_description: nil,
               created_at: Date.to_iso8601(transaction2.inserted_at),
               updated_at: Date.to_iso8601(transaction2.updated_at)
             }

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
@@ -51,6 +51,8 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
         metadata: %{some: "metadata"},
         encrypted_metadata: %{},
         status: transaction.status,
+        error_code: nil,
+        error_description: nil,
         created_at: Date.to_iso8601(transaction.inserted_at),
         updated_at: Date.to_iso8601(transaction.updated_at)
       }
@@ -60,6 +62,56 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
 
     test "serializes to nil if the transaction is not loaded" do
       assert TransactionSerializer.serialize(%NotLoaded{}) == nil
+    end
+
+    test "serializes the error description properly if nil" do
+      transaction =
+        insert(
+          :transaction,
+          error_code: "exchange_invalid_rate"
+        )
+
+      serialized = TransactionSerializer.serialize(transaction)
+      assert serialized[:error_code] == "exchange:invalid_rate"
+
+      assert serialized[:error_description] == "The exchange is attempted with an invalid rate"
+    end
+
+    test "serializes the error description properly" do
+      transaction =
+        insert(
+          :transaction,
+          error_code: "insufficient_funds",
+          error_description: "Some description."
+        )
+
+      serialized = TransactionSerializer.serialize(transaction)
+      assert serialized[:error_code] == "transaction:insufficient_funds"
+      assert serialized[:error_description] == "Some description."
+    end
+
+    test "serializes the error data properly" do
+      token = insert(:token)
+
+      transaction =
+        insert(
+          :transaction,
+          error_code: "insufficient_funds",
+          error_data: %{
+            "address" => "123",
+            "amount_to_debit" => 100_000,
+            "current_amount" => 0,
+            "token_id" => token.id
+          }
+        )
+
+      serialized = TransactionSerializer.serialize(transaction)
+      assert serialized[:error_code] == "transaction:insufficient_funds"
+
+      assert serialized[:error_description] ==
+               "The specified wallet (123) does not contain enough funds. Available: 0 #{token.id} - Attempted debit: 1000 #{
+                 token.id
+               }"
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
@@ -50,6 +50,8 @@ defmodule EWalletAPI.V1.TransactionViewTest do
           metadata: %{some: "metadata"},
           encrypted_metadata: %{},
           status: transaction.status,
+          error_code: nil,
+          error_description: nil,
           created_at: Date.to_iso8601(transaction.inserted_at),
           updated_at: Date.to_iso8601(transaction.updated_at)
         }


### PR DESCRIPTION
Issue/Task Number: T489

# Overview

This PR adds the failure reason to transactions returned to clients. Until now, it was only stored in the DB without facing the users past failure. 

# Changes

- Add `error_code` and `error_description` for `TransactionSerializer`
