### PR TITLE
Fix token stats when token not minted yet

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/token_controller_test.exs
@@ -122,6 +122,19 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
                "messages" => nil
              }
     end
+
+    test "returns the stats for a token that hasn't been minted" do
+      token = insert(:token)
+      response = admin_user_request("/token.stats", %{"id" => token.id})
+      assert response["success"]
+
+      assert response["data"] == %{
+               "object" => "token_stats",
+               "token_id" => token.id,
+               "token" => token |> TokenSerializer.serialize() |> stringify_keys(),
+               "total_supply" => 0
+             }
+    end
   end
 
   describe "/token.create" do

--- a/apps/ewallet_db/lib/ewallet_db/types/integer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/types/integer.ex
@@ -17,9 +17,9 @@ defmodule EWalletDB.Types.Integer do
     {:ok, Decimal.to_integer(value)}
   end
 
-  def load!(value) do
-    Decimal.to_integer(value)
-  end
+  def load!(nil), do: 0
+
+  def load!(value), do: Decimal.to_integer(value)
 
   def dump(value) do
     {:ok, value}


### PR DESCRIPTION
# Overview

This PR fixes an issue where the load!/1 function was crashing when provided with nil.