### PR TITLE
Switch to SHA2 for secret key hashing

### DIFF
--- a/apps/admin_api/lib/admin_api/invites/inviter.ex
+++ b/apps/admin_api/lib/admin_api/invites/inviter.ex
@@ -38,7 +38,7 @@ defmodule AdminAPI.Inviter do
         {:ok, user} =
           User.insert(%{
             email: email,
-            password: Crypto.generate_key(32)
+            password: Crypto.generate_base64_key(32)
           })
 
         user

--- a/apps/admin_api/test/admin_api/v1/plugs/admin_api_auth_plug_test.exs
+++ b/apps/admin_api/test/admin_api/v1/plugs/admin_api_auth_plug_test.exs
@@ -4,7 +4,7 @@ defmodule AdminAPI.V1.AdminAPIAuthPlugTest do
 
   describe "AdminAPIAuthPlug.call/2 with provider auth" do
     test "authenticates if both access key and secret key are correct" do
-      conn = test_with("OMGProvider", @access_key, @secret_key)
+      conn = test_with("OMGProvider", @access_key, Base.url_encode64(@secret_key))
 
       refute conn.halted
       assert conn.assigns.authenticated == true

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -226,10 +226,11 @@ defmodule AdminAPI.ConnCase do
   def provider_request(path, data \\ %{}, opts \\ [])
       when is_binary(path) and byte_size(path) > 0 do
     {status, _opts} = Keyword.pop(opts, :status, :ok)
+    secret_key = Base.url_encode64(@secret_key)
 
     build_conn()
     |> put_req_header("accept", @header_accept)
-    |> put_auth_header("OMGProvider", @access_key, @secret_key)
+    |> put_auth_header("OMGProvider", @access_key, secret_key)
     |> post(@base_dir <> path, data)
     |> json_response(status)
   end

--- a/apps/ewallet_db/lib/ewallet_db/api_key.ex
+++ b/apps/ewallet_db/lib/ewallet_db/api_key.ex
@@ -78,7 +78,7 @@ defmodule EWalletDB.APIKey do
     attrs =
       attrs
       |> Map.put_new_lazy(:account_uuid, fn -> get_master_account_uuid() end)
-      |> Map.put_new_lazy(:key, fn -> Crypto.generate_key(@key_bytes) end)
+      |> Map.put_new_lazy(:key, fn -> Crypto.generate_base64_key(@key_bytes) end)
 
     %APIKey{}
     |> changeset(attrs)

--- a/apps/ewallet_db/lib/ewallet_db/auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/auth_token.ex
@@ -76,7 +76,7 @@ defmodule EWalletDB.AuthToken do
       owner_app: Atom.to_string(owner_app),
       user_uuid: user.uuid,
       account_uuid: if(account, do: account.uuid, else: nil),
-      token: Crypto.generate_key(@key_length)
+      token: Crypto.generate_base64_key(@key_length)
     }
 
     insert(attrs)

--- a/apps/ewallet_db/lib/ewallet_db/forget_password_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/forget_password_request.ex
@@ -68,7 +68,7 @@ defmodule EWalletDB.ForgetPasswordRequest do
   Generates a forget password request for the given user.
   """
   def generate(user) do
-    token = Crypto.generate_key(@token_length)
+    token = Crypto.generate_base64_key(@token_length)
     {:ok, _} = insert(%{token: token, user_uuid: user.uuid})
     ForgetPasswordRequest.get(user, token)
   end

--- a/apps/ewallet_db/lib/ewallet_db/invite.ex
+++ b/apps/ewallet_db/lib/ewallet_db/invite.ex
@@ -77,7 +77,7 @@ defmodule EWalletDB.Invite do
   """
   def generate(user, opts \\ [preload: []]) do
     # Insert a new invite
-    {:ok, invite} = insert(%{token: Crypto.generate_key(@token_length)})
+    {:ok, invite} = insert(%{token: Crypto.generate_base64_key(@token_length)})
 
     # Assign the invite to the user
     changeset = change(user, invite_uuid: invite.uuid)

--- a/apps/ewallet_db/test/ewallet_db/helpers/crypto_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/helpers/crypto_test.exs
@@ -2,14 +2,14 @@ defmodule EWalletDB.Helpers.CryptoTest do
   use ExUnit.Case
   alias EWalletDB.Helpers.Crypto
 
-  describe "generate_key/1" do
+  describe "generate_base64_key/1" do
     test "returns a key with the specified length" do
-      key = Crypto.generate_key(32)
+      key = Crypto.generate_base64_key(32)
       # ceil(32 * 4 / 3)
       assert String.length(key) == 43
 
       # Test with another length to make sure it's not hardcoded.
-      key = Crypto.generate_key(64)
+      key = Crypto.generate_base64_key(64)
       # ceil(64 * 4 / 3)
       assert String.length(key) == 86
     end

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -122,7 +122,7 @@ defmodule EWalletDB.Factory do
 
   def invite_factory do
     %Invite{
-      token: Crypto.generate_key(32)
+      token: Crypto.generate_base64_key(32)
     }
   end
 
@@ -164,8 +164,8 @@ defmodule EWalletDB.Factory do
 
     %Key{
       access_key: access_key,
-      secret_key: secret_key,
-      secret_key_hash: Crypto.hash_password(secret_key),
+      secret_key: Base.url_encode64(secret_key),
+      secret_key_hash: Crypto.hash_secret(secret_key),
       account: insert(:account),
       deleted_at: nil
     }


### PR DESCRIPTION
Issue/Task Number: T494

# Overview

This PR switches away from Bcrypt to SHA2 for hashing of the secret keys.

# Impact

All current access/secret keys should be deleted since they will not be usable anymore.