### PR TITLE
Whitelist only BASE_URL for invitation emails

### DIFF
--- a/apps/admin_api/config/config.exs
+++ b/apps/admin_api/config/config.exs
@@ -9,6 +9,7 @@ use Mix.Config
 config :admin_api,
   namespace: AdminAPI,
   ecto_repos: [],
+  base_url: System.get_env("BASE_URL") || "http://localhost:4000",
   sender_email: System.get_env("SENDER_EMAIL") || "admin@localhost"
 
 # Configs for the endpoint

--- a/apps/admin_api/config/prod.exs
+++ b/apps/admin_api/config/prod.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+config :admin_panel, base_url: System.get_env("BASE_URL")
+
 # Configs for Bamboo emailing library
 config :admin_api, AdminAPI.Mailer,
   adapter: Bamboo.SMTPAdapter,

--- a/apps/admin_api/lib/admin_api/invites/inviter.ex
+++ b/apps/admin_api/lib/admin_api/invites/inviter.ex
@@ -4,12 +4,13 @@ defmodule AdminAPI.Inviter do
   """
   alias AdminAPI.{InviteEmail, Mailer}
   alias EWallet.EmailValidator
-  alias EWalletDB.{Repo, Invite, Membership, User}
+  alias EWalletDB.{Account, Repo, Invite, Membership, Role, User}
   alias EWalletDB.Helpers.Crypto
 
   @doc """
   Creates the user if not exists, then sends the invite email out.
   """
+  @spec invite(String.t(), %Account{}, %Role{}, String.t()) :: {:ok, %Invite{}} | {:error, atom()}
   def invite(email, account, role, redirect_url) do
     {:ok, invite} =
       email
@@ -19,8 +20,7 @@ defmodule AdminAPI.Inviter do
 
     {:ok, _membership} = Membership.assign(invite.user, account, role)
 
-    _ = send_email(invite, redirect_url)
-    {:ok, invite}
+    send_email(invite, redirect_url)
   catch
     error when is_atom(error) -> {:error, error}
   end
@@ -59,10 +59,24 @@ defmodule AdminAPI.Inviter do
   @doc """
   Sends the invite email.
   """
+  @spec send_email(%Invite{}, String.t()) ::
+          {:ok, %Invite{}} | {:error, :invalid_parameter, String.t()}
   def send_email(invite, redirect_url) do
-    invite
-    |> Repo.preload(:user)
-    |> InviteEmail.create(redirect_url)
-    |> Mailer.deliver_now()
+    if valid_url?(redirect_url) do
+      invite
+      |> Repo.preload(:user)
+      |> InviteEmail.create(redirect_url)
+      |> Mailer.deliver_now()
+
+      {:ok, invite}
+    else
+      {:error, :invalid_parameter,
+       "The `redirect_url` is not allowed to be used. Got: #{redirect_url}"}
+    end
+  end
+
+  defp valid_url?(url) do
+    base_url = Application.get_env(:admin_api, :base_url)
+    String.starts_with?(url, base_url)
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
@@ -39,12 +39,15 @@ defmodule AdminAPI.V1.AccountMembershipController do
       {true, :user_id_not_found} ->
         handle_error(conn, :user_id_not_found)
 
-      {:error, error} when is_atom(error) ->
-        handle_error(conn, error)
+      {:error, code} when is_atom(code) ->
+        handle_error(conn, code)
 
       # Matches a different error format returned by Membership.assign_user/2
       {:error, changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
+
+      {:error, code, description} ->
+        handle_error(conn, code, description)
     end
   end
 
@@ -75,21 +78,15 @@ defmodule AdminAPI.V1.AccountMembershipController do
   end
 
   defp assign_or_invite(email, account, role, redirect_url) when is_binary(email) do
-    case Inviter.invite(email, account, role, redirect_url) do
-      {:ok, invite} -> {:ok, invite.user}
-      {:error, _} = error -> error
-    end
+    Inviter.invite(email, account, role, redirect_url)
   end
 
   defp assign_or_invite(user, account, role, redirect_url) do
     case User.get_status(user) do
       :pending_confirmation ->
-        invite =
-          user
-          |> User.get_invite()
-          |> Inviter.send_email(redirect_url)
-
-        {:ok, invite}
+        user
+        |> User.get_invite()
+        |> Inviter.send_email(redirect_url)
 
       :active ->
         Membership.assign(user, account, role)

--- a/apps/ewallet_db/lib/ewallet_db/forget_password_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/forget_password_request.ex
@@ -60,8 +60,6 @@ defmodule EWalletDB.ForgetPasswordRequest do
     ForgetPasswordRequest
     |> where([f], f.user_uuid == ^user.uuid)
     |> Repo.delete_all()
-
-    user
   end
 
   @doc """


### PR DESCRIPTION
Issue/Task Number: T484

# Overview

This PR whitelists only the configured `BASE_URL` environment variable to be used for `redirect_url` when sending invitation and forget password emails. Thanks to the spotting by @jarindr.

# Changes

- Add `base_url: System.get_env("BASE_URL")` as an :admin_api env
- Update `AdminAPI.Inviter` to whitelist redirect_url
- Update `AdminAPI.V1.ResetPasswordController` to whitelist redirect_url

# Implementation Details

Checking against the `BASE_URL` still allows attacks from the same base url, but given the un-likelihood of such setup, this PR should be sufficient for the time being.

The url checks for user invitation and forget password is not at the same level: `Inviter` vs. `ResetPasswordController`. It could have been refactored but given the amount of code changes needed it's not worth it towards 1.0

# Usage

Try `/api/admin/admin.reset_password` or `/api/admin/account.assign_user`. The request should fail with `client:invalid_parameter` with the description that the given redirect_url is invalid.

# Impact

Code changes only. The `BASE_URL` is reused from the existing required environment variable.
