### PR TITLE
All your base are belong to us

### DIFF
--- a/apps/ewallet_db/lib/ewallet_db/helpers/crypto.ex
+++ b/apps/ewallet_db/lib/ewallet_db/helpers/crypto.ex
@@ -25,7 +25,7 @@ defmodule EWalletDB.Helpers.Crypto do
 
   @spec verify_secret(String.t(), String.t()) :: boolean
   def verify_secret(secret, hash) do
-    case Base.url_decode64(secret) do
+    case Base.url_decode64(secret, padding: false) do
       {:ok, decoded} ->
         decoded
         |> hash_secret()

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -163,7 +163,7 @@ defmodule EWalletDB.Factory do
 
     %Key{
       access_key: access_key,
-      secret_key: Base.url_encode64(secret_key),
+      secret_key: Base.url_encode64(secret_key, padding: false),
       secret_key_hash: Crypto.hash_secret(secret_key),
       account: insert(:account),
       deleted_at: nil


### PR DESCRIPTION
# Overview

Fix auth failure due to base64 padding in new secret key scheme.

# Changes

* Use `padding: false`
