### PR TITLE
Add back async: false at the channel case level to fix random failures

### DIFF
--- a/apps/admin_api/test/support/channel_case.ex
+++ b/apps/admin_api/test/support/channel_case.ex
@@ -13,7 +13,7 @@ defmodule AdminAPI.ChannelCase do
   of the test unless the test case is marked as async.
   """
 
-  use ExUnit.CaseTemplate
+  use ExUnit.CaseTemplate, async: false
   alias Ecto.Adapters.SQL.Sandbox
 
   using do

--- a/apps/ewallet_api/test/support/channel_case.ex
+++ b/apps/ewallet_api/test/support/channel_case.ex
@@ -13,7 +13,7 @@ defmodule EWalletAPI.ChannelCase do
   of the test unless the test case is marked as async.
   """
 
-  use ExUnit.CaseTemplate
+  use ExUnit.CaseTemplate, async: false
   alias Ecto.Adapters.SQL.Sandbox
 
   using do


### PR DESCRIPTION
Issue/Task Number: A

# Overview

Just an attempt to see if that fixes some stuff (even tho it shouldn't) since I didn't experience failures with that setting for 10builds + when trying it out last time.