### PR TITLE
Add /access_key.update

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
@@ -63,6 +63,26 @@ defmodule AdminAPI.V1.KeyController do
   end
 
   @doc """
+  Update a key.
+  """
+  def update(conn, %{"id" => id} = attrs) do
+    with %Key{} = api_key <- Key.get(id) || {:error, :api_key_not_found},
+         {:ok, key} <- Key.update(api_key, attrs) do
+      render(conn, :key, %{key: key})
+    else
+      {:error, code} when is_atom(code) ->
+        handle_error(conn, code)
+
+      {:error, changeset} ->
+        handle_error(conn, :invalid_parameter, changeset)
+    end
+  end
+
+  def update(conn, _attrs) do
+    handle_error(conn, :invalid_parameter, "`id` is required")
+  end
+
+  @doc """
   Soft-deletes an existing key.
   """
   def delete(conn, %{"access_key" => access_key}) do

--- a/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
@@ -63,7 +63,7 @@ defmodule AdminAPI.V1.KeyController do
   end
 
   @doc """
-  Update a key.
+  Updates a key.
   """
   def update(conn, %{"id" => id} = attrs) do
     with %Key{} = api_key <- Key.get(id) || {:error, :api_key_not_found},

--- a/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
@@ -66,7 +66,7 @@ defmodule AdminAPI.V1.KeyController do
   Updates a key.
   """
   def update(conn, %{"id" => id} = attrs) do
-    with %Key{} = api_key <- Key.get(id) || {:error, :api_key_not_found},
+    with %Key{} = api_key <- Key.get(id) || {:error, :key_not_found},
          {:ok, key} <- Key.update(api_key, attrs) do
       render(conn, :key, %{key: key})
     else

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -112,6 +112,7 @@ defmodule AdminAPI.V1.Router do
     # API Access endpoints
     post("/access_key.all", KeyController, :all)
     post("/access_key.create", KeyController, :create)
+    post("/access_key.update", KeyController, :update)
     post("/access_key.delete", KeyController, :delete)
 
     post("/api_key.all", APIKeyController, :all)

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -1212,6 +1212,22 @@ paths:
           $ref: "#/components/responses/AccessKeyResponse"
         '500':
           $ref: "#/components/responses/InternalServerError"
+  /access_key.update:
+    post:
+      tags:
+        - API Access
+      summary: Update a pair of access and secret keys by its id
+      operationId: access_key_update
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        $ref: '#/components/requestBodies/AccessKeyUpdateBody'
+      responses:
+        '200':
+          $ref: "#/components/responses/AccessKeyResponse"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
   /access_key.delete:
     post:
       tags:
@@ -4862,6 +4878,22 @@ components:
               search_term: ""
               sort_by: "created_at"
               sort_dir: "desc"
+    AccessKeyUpdateBody:
+      description: The parameters to use for updating an access key
+      required: true
+      content:
+        application/vnd.omisego.v1+json:
+          schema:
+            properties:
+              id:
+                type: string
+              expired:
+                type: boolean
+            required:
+              - id
+            example:
+              id: "key_01ce83yphmq6vt4qnmn3ykwcw6"
+              expired: true
     AccessKeyDeleteBody:
       description: The parameters to use for deleting an access key
       required: true
@@ -4930,7 +4962,7 @@ components:
               - id
               - expired
             example:
-              id: "key_01ce83yphmq6vt4qnmn3ykwcw6"
+              id: "api_01ce83yphmq6vt4qnmn3ykwcw6"
               expired: true
     APIKeyDeleteBody:
       description: The parameters to use for deleting an API key
@@ -4944,7 +4976,7 @@ components:
             required:
               - id
             example:
-              id: "key_01ce83yphmq6vt4qnmn3ykwcw6"
+              id: "api_01ce83yphmq6vt4qnmn3ykwcw6"
 
   ######################################
   #           REQUEST HEADERS          #

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
@@ -134,7 +134,7 @@ defmodule AdminAPI.V1.AdminAuth.KeyControllerTest do
 
       assert response["data"]["id"] == key.id
       assert response["data"]["expired"] == true
-      assert response["data"]["access_key"] == "old_key"
+      assert response["data"]["access_key"] == "key"
       assert response["data"]["secret_key"] == nil
 
       # Because secret_key_hash is not returned, fetch to confirm it was not changed

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -23,6 +23,7 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
                        # Secret keys cannot be retrieved after creation
                        "secret_key" => nil,
                        "account_id" => Assoc.get(key_1, [:account, :id]),
+                       "expired" => key_1.expired,
                        "created_at" => Date.to_iso8601(key_1.inserted_at),
                        "updated_at" => Date.to_iso8601(key_1.updated_at),
                        "deleted_at" => Date.to_iso8601(key_1.deleted_at)
@@ -34,6 +35,7 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
                        # Secret keys cannot be retrieved after creation
                        "secret_key" => nil,
                        "account_id" => Assoc.get(key_2, [:account, :id]),
+                       "expired" => key_2.expired,
                        "created_at" => Date.to_iso8601(key_2.inserted_at),
                        "updated_at" => Date.to_iso8601(key_2.updated_at),
                        "deleted_at" => Date.to_iso8601(key_2.deleted_at)
@@ -67,6 +69,7 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
                  "access_key" => _,
                  "secret_key" => _,
                  "account_id" => _,
+                 "expired" => _,
                  "created_at" => _,
                  "updated_at" => _,
                  "deleted_at" => _
@@ -76,6 +79,7 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
       assert response["data"]["id"] == key.id
       assert response["data"]["access_key"] == key.access_key
       assert response["data"]["account_id"] == Account.get_master_account().id
+      assert response["data"]["expired"] == key.expired
       assert response["data"]["created_at"] == Date.to_iso8601(key.inserted_at)
       assert response["data"]["updated_at"] == Date.to_iso8601(key.updated_at)
       assert response["data"]["deleted_at"] == Date.to_iso8601(key.deleted_at)
@@ -83,6 +87,59 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
       # We cannot know the `secret_key` from the controller call,
       # so we can only check that it is a string with some length.
       assert String.length(response["data"]["secret_key"]) > 0
+    end
+  end
+
+  describe "/access_key.update" do
+    test "disables the key" do
+      key = insert(:key)
+      assert key.expired == false
+
+      response =
+        provider_request("/access_key.update", %{
+          id: key.id,
+          expired: true
+        })
+
+      assert response["data"]["id"] == key.id
+      assert response["data"]["expired"] == true
+    end
+
+    test "enables the key" do
+      key = insert(:key, expired: true)
+      assert key.expired == true
+
+      response =
+        provider_request("/access_key.update", %{
+          id: key.id,
+          expired: false
+        })
+
+      assert response["data"]["id"] == key.id
+      assert response["data"]["expired"] == false
+    end
+
+    test "does not update any other fields" do
+      key = insert(:key, access_key: "key", secret_key: "secret", secret_key_hash: "hash")
+      assert key.expired == false
+
+      response =
+        provider_request("/access_key.update", %{
+          id: key.id,
+          expired: true,
+          access_key: "new_key",
+          secret_key: "new_secret_key",
+          secret_key_hash: "new_secret_key_hash"
+        })
+
+      assert response["data"]["id"] == key.id
+      assert response["data"]["expired"] == true
+      assert response["data"]["access_key"] == "old_key"
+      assert response["data"]["secret_key"] == nil
+
+      # Because secret_key_hash is not returned, fetch to confirm it was not changed
+      updated = Key.get(key.id)
+      assert updated.secret_key_hash == key.secret_key_hash
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -134,7 +134,7 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
 
       assert response["data"]["id"] == key.id
       assert response["data"]["expired"] == true
-      assert response["data"]["access_key"] == "old_key"
+      assert response["data"]["access_key"] == "key"
       assert response["data"]["secret_key"] == nil
 
       # Because secret_key_hash is not returned, fetch to confirm it was not changed

--- a/apps/admin_api/test/admin_api/v1/views/key_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/key_view_test.exs
@@ -17,6 +17,7 @@ defmodule AdminAPI.V1.KeyViewTest do
           access_key: key.access_key,
           secret_key: key.secret_key,
           account_id: key.account.id,
+          expired: key.expired,
           created_at: Date.to_iso8601(key.inserted_at),
           updated_at: Date.to_iso8601(key.updated_at),
           deleted_at: Date.to_iso8601(key.deleted_at)
@@ -52,6 +53,7 @@ defmodule AdminAPI.V1.KeyViewTest do
               access_key: key1.access_key,
               secret_key: key1.secret_key,
               account_id: key1.account.id,
+              expired: key1.expired,
               created_at: Date.to_iso8601(key1.inserted_at),
               updated_at: Date.to_iso8601(key1.updated_at),
               deleted_at: Date.to_iso8601(key1.deleted_at)
@@ -62,6 +64,7 @@ defmodule AdminAPI.V1.KeyViewTest do
               access_key: key2.access_key,
               secret_key: key2.secret_key,
               account_id: key2.account.id,
+              expired: key2.expired,
               created_at: Date.to_iso8601(key2.inserted_at),
               updated_at: Date.to_iso8601(key2.updated_at),
               deleted_at: Date.to_iso8601(key2.deleted_at)

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
@@ -20,6 +20,7 @@ defmodule EWallet.Web.V1.KeySerializer do
       access_key: key.access_key,
       secret_key: key.secret_key,
       account_id: key.account.id,
+      expired: key.expired,
       created_at: Date.to_iso8601(key.inserted_at),
       updated_at: Date.to_iso8601(key.updated_at),
       deleted_at: Date.to_iso8601(key.deleted_at)

--- a/apps/ewallet/test/ewallet/web/v1/serializers/key_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/key_serializer_test.exs
@@ -14,6 +14,7 @@ defmodule EWallet.Web.V1.KeySerializerTest do
         access_key: key.access_key,
         secret_key: key.secret_key,
         account_id: key.account.id,
+        expired: key.expired,
         created_at: Date.to_iso8601(key.inserted_at),
         updated_at: Date.to_iso8601(key.updated_at),
         deleted_at: Date.to_iso8601(key.deleted_at)
@@ -49,6 +50,7 @@ defmodule EWallet.Web.V1.KeySerializerTest do
             access_key: key1.access_key,
             secret_key: key1.secret_key,
             account_id: key1.account.id,
+            expired: key1.expired,
             created_at: Date.to_iso8601(key1.inserted_at),
             updated_at: Date.to_iso8601(key1.updated_at),
             deleted_at: Date.to_iso8601(key1.deleted_at)
@@ -59,6 +61,7 @@ defmodule EWallet.Web.V1.KeySerializerTest do
             access_key: key2.access_key,
             secret_key: key2.secret_key,
             account_id: key2.account.id,
+            expired: key2.expired,
             created_at: Date.to_iso8601(key2.inserted_at),
             updated_at: Date.to_iso8601(key2.updated_at),
             deleted_at: Date.to_iso8601(key2.deleted_at)

--- a/apps/ewallet_db/priv/repo/migrations/20180706054113_add_expired_to_key.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20180706054113_add_expired_to_key.exs
@@ -1,0 +1,9 @@
+defmodule EWalletDB.Repo.Migrations.AddExpiredToKey do
+  use Ecto.Migration
+
+  def change do
+    alter table(:key) do
+      add :expired, :boolean, null: false, default: false
+    end
+  end
+end

--- a/apps/ewallet_db/priv/repo/seeds/01_user.exs
+++ b/apps/ewallet_db/priv/repo/seeds/01_user.exs
@@ -15,7 +15,7 @@ defmodule EWalletDB.Repo.Seeds.UserSeed do
         {:title, "What email and password should I set for your first admin user?"},
         {:text, @argsline_desc},
         {:input, {:email, :admin_email, "E-mail", "admin@example.com"}},
-        {:input, {:password, :admin_password, "Password", {Crypto, :generate_key, [16]}}},
+        {:input, {:password, :admin_password, "Password", {Crypto, :generate_base64_key, [16]}}},
       ],
     ]
   end

--- a/apps/ewallet_db/priv/repo/seeds_sample/00_admin_panel_user.exs
+++ b/apps/ewallet_db/priv/repo/seeds_sample/00_admin_panel_user.exs
@@ -1,13 +1,13 @@
 defmodule EWalletDB.Repo.Seeds.AdminPanelUserSampleSeed do
-  import EWalletDB.Helpers.Crypto, only: [generate_key: 1]
+  import EWalletDB.Helpers.Crypto, only: [generate_base64_key: 1]
   alias EWalletDB.User
 
   @seed_data [
-    %{email: "admin_brand1@example.com", password: generate_key(16), metadata: %{}},
-    %{email: "admin_branch1@example.com", password: generate_key(16), metadata: %{}},
-    %{email: "viewer_master@example.com", password: generate_key(16), metadata: %{}},
-    %{email: "viewer_brand1@example.com", password: generate_key(16), metadata: %{}},
-    %{email: "viewer_branch1@example.com", password: generate_key(16), metadata: %{}},
+    %{email: "admin_brand1@example.com", password: generate_base64_key(16), metadata: %{}},
+    %{email: "admin_branch1@example.com", password: generate_base64_key(16), metadata: %{}},
+    %{email: "viewer_master@example.com", password: generate_base64_key(16), metadata: %{}},
+    %{email: "viewer_brand1@example.com", password: generate_base64_key(16), metadata: %{}},
+    %{email: "viewer_branch1@example.com", password: generate_base64_key(16), metadata: %{}},
   ]
 
   def seed do

--- a/apps/ewallet_db/test/ewallet_db/api_key_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/api_key_test.exs
@@ -48,6 +48,20 @@ defmodule EWalletDB.APIKeyTest do
     end
   end
 
+  describe "APIKey.update/2" do
+    test_update_ignores_changing(APIKey, :key)
+    test_update_ignores_changing(APIKey, :owner_app)
+
+    test_update_field_ok(APIKey, :expired, false, true)
+
+    test_update_field_ok(
+      APIKey,
+      :exchange_address,
+      insert(:wallet).address,
+      insert(:wallet).address
+    )
+  end
+
   describe "APIKey.authenticate/2" do
     test "returns the API key" do
       account = insert(:account)

--- a/apps/ewallet_db/test/ewallet_db/key_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/key_test.exs
@@ -90,6 +90,25 @@ defmodule EWalletDB.KeyTest do
     end
   end
 
+  describe "update/2" do
+    test_update_field_ok(Key, :expired, false, true)
+    test_update_ignores_changing(Key, :access_key)
+
+    test "does not update secret_key_hash when given a new secret_key" do
+      original = insert(:key, %{secret_key: "original_secret_key"})
+      {:ok, updated} = Key.update(original, %{secret_key: "new_secret_key"})
+
+      assert updated.secret_key_hash == original.secret_key_hash
+    end
+
+    test "does not update secret_key_hash when given a new secret_key_hash" do
+      original = insert(:key, %{secret_key_hash: "original_secret_key"})
+      {:ok, updated} = Key.update(original, %{secret_key_hash: "changed"})
+
+      assert updated.secret_key_hash == original.secret_key_hash
+    end
+  end
+
   describe "authenticate/2" do
     test "returns an existing key if access and secret key match" do
       account = insert(:account)

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -166,6 +166,7 @@ defmodule EWalletDB.Factory do
       secret_key: Base.url_encode64(secret_key, padding: false),
       secret_key_hash: Crypto.hash_secret(secret_key),
       account: insert(:account),
+      expired: false,
       deleted_at: nil
     }
   end

--- a/apps/ewallet_db/test/support/schema_case.ex
+++ b/apps/ewallet_db/test/support/schema_case.ex
@@ -477,6 +477,31 @@ defmodule EWalletDB.SchemaCase do
   end
 
   @doc """
+  Test schema's update/2 ignores changing of the given field
+  """
+  defmacro test_update_ignores_changing(schema, field, old \\ "old", new \\ "new") do
+    quote do
+      test "prevents changing of #{unquote(field)}" do
+        schema = unquote(schema)
+        field = unquote(field)
+        old = unquote(old)
+        new = unquote(new)
+
+        {res, original} =
+          schema
+          |> get_factory
+          |> params_for(%{field => old})
+          |> schema.insert()
+
+        {res, updated} = schema.update(original, %{field => new})
+
+        assert res == :ok
+        assert Map.fetch!(updated, field) == old
+      end
+    end
+  end
+
+  @doc """
   Test schema's metadata and encrypted metadata
   """
   defmacro test_default_metadata_fields(schema, table) do


### PR DESCRIPTION
Issue/Task Number: T463

# Overview

This PR adds `/access_key.update` allowing enable/disable of access keys.

# Changes

- Updated the `Key`'s controller, view, serializer and their tests to support `/access_key.update`
- Updated Open API spec for `/access_key.update`
- Added typespecs to `EWalletDB.Key`
- Added missing `APIKey.update/2` tests

# Implementation Details

A straight-forward addition of `/access_key.update` endpoint.

# Usage

Try `/access_key.update`:

**Request:**
```sh
curl POST \
10.5.10.10:4000/api/admin/access_key.update \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGProvider $(echo -n "access_key:secret_key" | base64 | tr -d '\n')" \
-H "Content-Type: application/json" \
-d '{
"id": "key_01chqcgrggh1hxja6y7hnqwavm",
"expired": true
}' \
-v -w "\n" | jq
```

**Response:**
```json
{
  "version": "1",
  "success": true,
  "data": {
    "updated_at": "2018-07-06T08:56:59.643492Z",
    "secret_key": null,
    "object": "key",
    "id": "key_01chqcgrggh1hxja6y7hnqwavm",
    "expired": true,
    "deleted_at": null,
    "created_at": "2018-07-06T08:49:43.440970Z",
    "account_id": "acc_01chqcgp9v235zbx3d8dg3dpmb",
    "access_key": "eMDPJkj1g0rWWb5PZSdR07yyXERKSj7W73jWhcN2aSk"
  }
}
```

# Impact

- Run `mix ecto.migrate` after deployment
- API changes: Add new `/access_key.update` endpoint