### PR TITLE
Send events when consuming in client API

### DIFF
--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_consumption_controller.ex
@@ -24,7 +24,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionController do
       when idempotency_token != nil do
     conn.assigns.user
     |> TransactionConsumptionConsumerGate.consume(attrs)
-    |> respond(conn, false)
+    |> respond(conn, true)
   end
 
   def consume_for_user(conn, _) do


### PR DESCRIPTION
Issue/Task Number: A

# Overview

This PR fixes events not being sent in the consumption controller in the client API (detected thanks to our E2E tests, yay)
