### PR TITLE
Move E2E seed's master account value from compile-time to runtime

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
@@ -14,8 +14,14 @@ defmodule AdminAPI.V1.AdminAuth.KeyControllerTest do
       assert Enum.all?(response["data"]["data"], fn key -> key["secret_key"] == nil end)
 
       assert Enum.count(response["data"]["data"]) == 2
-      assert Enum.any?(response["data"]["data"], fn key -> key["access_key"] == key_1.access_key end)
-      assert Enum.any?(response["data"]["data"], fn key -> key["access_key"] == key_2.access_key end)
+
+      assert Enum.any?(response["data"]["data"], fn key ->
+               key["access_key"] == key_1.access_key
+             end)
+
+      assert Enum.any?(response["data"]["data"], fn key ->
+               key["access_key"] == key_2.access_key
+             end)
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -10,12 +10,12 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
 
       response = provider_request("/access_key.all")
 
-      assert Enum.all?(response["data"], fn key -> key["object"] == "key" end)
-      assert Enum.all?(response["data"], fn key -> key["secret_key"] == nil end)
+      assert Enum.all?(response["data"]["data"], fn key -> key["object"] == "key" end)
+      assert Enum.all?(response["data"]["data"], fn key -> key["secret_key"] == nil end)
 
-      assert Enum.count(response["data"]) == 2
-      assert Enum.any?(response["data"], fn key -> key["access_key"] == key_1.access_key end)
-      assert Enum.any?(response["data"], fn key -> key["access_key"] == key_2.access_key end)
+      assert Enum.count(response["data"]["data"]) == 2
+      assert Enum.any?(response["data"]["data"], fn key -> key["access_key"] == key_1.access_key end)
+      assert Enum.any?(response["data"]["data"], fn key -> key["access_key"] == key_2.access_key end)
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -9,46 +9,12 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
       key_1 = Key |> Repo.get_by(access_key: @access_key) |> Repo.preload([:account])
       key_2 = insert(:key, %{secret_key: "the_secret_key"})
 
-      assert provider_request("/access_key.all") ==
-               %{
-                 "version" => "1",
-                 "success" => true,
-                 "data" => %{
-                   "object" => "list",
-                   "data" => [
-                     %{
-                       "object" => "key",
-                       "id" => key_1.id,
-                       "access_key" => key_1.access_key,
-                       # Secret keys cannot be retrieved after creation
-                       "secret_key" => nil,
-                       "account_id" => Assoc.get(key_1, [:account, :id]),
-                       "expired" => key_1.expired,
-                       "created_at" => Date.to_iso8601(key_1.inserted_at),
-                       "updated_at" => Date.to_iso8601(key_1.updated_at),
-                       "deleted_at" => Date.to_iso8601(key_1.deleted_at)
-                     },
-                     %{
-                       "object" => "key",
-                       "id" => key_2.id,
-                       "access_key" => key_2.access_key,
-                       # Secret keys cannot be retrieved after creation
-                       "secret_key" => nil,
-                       "account_id" => Assoc.get(key_2, [:account, :id]),
-                       "expired" => key_2.expired,
-                       "created_at" => Date.to_iso8601(key_2.inserted_at),
-                       "updated_at" => Date.to_iso8601(key_2.updated_at),
-                       "deleted_at" => Date.to_iso8601(key_2.deleted_at)
-                     }
-                   ],
-                   "pagination" => %{
-                     "current_page" => 1,
-                     "per_page" => 10,
-                     "is_first_page" => true,
-                     "is_last_page" => true
-                   }
-                 }
-               }
+      response = provider_request("/access_key.all")
+
+      assert Enum.count(response["data"]) == 2
+      assert Enum.all?(response["data"], fn key -> key.object == "key" end)
+      assert Enum.all?(response["data"], fn key -> key.access_key != nil end)
+      assert Enum.all?(response["data"], fn key -> key.secret_key == nil end)
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -2,7 +2,6 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWallet.Web.Date
   alias EWalletDB.{Repo, Account, Key}
-  alias EWalletDB.Helpers.Assoc
 
   describe "/access_key.all" do
     test "responds with a list of keys without secret keys" do
@@ -11,10 +10,12 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
 
       response = provider_request("/access_key.all")
 
+      assert Enum.all?(response["data"], fn key -> key["object"] == "key" end)
+      assert Enum.all?(response["data"], fn key -> key["secret_key"] == nil end)
+
       assert Enum.count(response["data"]) == 2
-      assert Enum.all?(response["data"], fn key -> key.object == "key" end)
-      assert Enum.all?(response["data"], fn key -> key.access_key != nil end)
-      assert Enum.all?(response["data"], fn key -> key.secret_key == nil end)
+      assert Enum.any?(response["data"], fn key -> key["access_key"] == key_1.access_key end)
+      assert Enum.any?(response["data"], fn key -> key["access_key"] == key_2.access_key end)
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -14,8 +14,14 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
       assert Enum.all?(response["data"]["data"], fn key -> key["secret_key"] == nil end)
 
       assert Enum.count(response["data"]["data"]) == 2
-      assert Enum.any?(response["data"]["data"], fn key -> key["access_key"] == key_1.access_key end)
-      assert Enum.any?(response["data"]["data"], fn key -> key["access_key"] == key_2.access_key end)
+
+      assert Enum.any?(response["data"]["data"], fn key ->
+               key["access_key"] == key_1.access_key
+             end)
+
+      assert Enum.any?(response["data"]["data"], fn key ->
+               key["access_key"] == key_2.access_key
+             end)
     end
   end
 

--- a/apps/ewallet_db/priv/repo/seeds_test/01_user.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/01_user.exs
@@ -6,13 +6,13 @@ defmodule EWalletDB.Repo.Seeds.UserSeed do
       email: System.get_env("E2E_TEST_ADMIN_EMAIL") || "test_admin@example.com",
       password: System.get_env("E2E_TEST_ADMIN_PASSWORD") || "password",
       metadata: %{},
-      account_uuid: Account.get_master_account().uuid
+      account_name: "master_account"
     },
     %{
       email: System.get_env("E2E_TEST_ADMIN_1_EMAIL") || "test_admin_1@example.com",
       password: System.get_env("E2E_TEST_ADMIN_1_PASSWORD") || "password",
       metadata: %{},
-      account_uuid: Account.get_master_account().uuid
+      account_name: "master_account"
     },
   ]
 
@@ -34,7 +34,8 @@ defmodule EWalletDB.Repo.Seeds.UserSeed do
       nil ->
         case User.insert(data) do
           {:ok, user} ->
-            {:ok, _} = AccountUser.link(data.account_uuid, user.uuid)
+            account = Account.get_by(name: data.account_name)
+            {:ok, _} = AccountUser.link(account.uuid, user.uuid)
 
             writer.success("""
               ID       : #{user.id}


### PR DESCRIPTION
Issue/Task Number: -

# Overview

This PR updates the seed so that it relies on master account uuid from runtime instead of compile-time.

# Changes

- Updated `apps/ewallet_db/priv/repo/seeds_test/01_user.exs`

# Implementation Details

Because during compile time, master account may not exist yet, we cannot rely on `account_uuid` then. This PR updates it so that a static value (`account_name: "master_account"`) is used instead to find the master account.

Original error:

```ex
$ E2E_ENABLED=true mix seed --test --yes
** (UndefinedFunctionError) function nil.uuid/0 is undefined or private
    nil.uuid()
    _build/dev/lib/ewallet_db/priv/repo/seeds_test/01_user.exs:9: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (elixir) lib/code.ex:629: Code.load_file/2
    lib/ewallet/seeders/seeder.ex:45: EWallet.Seeder.mod_from/1
    (elixir) lib/enum.ex:2924: Enum.flat_map_list/2
    (elixir) lib/enum.ex:2925: Enum.flat_map_list/2
    lib/ewallet/seeders/seeder.ex:18: anonymous fn/1 in EWallet.Seeder.gather_seeds/1
    (elixir) lib/enum.ex:2924: Enum.flat_map_list/2
    lib/ewallet/seeders/cli_seeder.ex:38: EWallet.Seeder.CLI.run/2
    (mix) lib/mix/task.ex:314: Mix.Task.run_task/3
    (mix) lib/mix/task.ex:348: Mix.Task.run_alias/3
    (mix) lib/mix/task.ex:277: Mix.Task.run/2
```

# Usage

Run `E2E_ENABLED=true mix seed --test --yes` should no longer fail.

# Impact

No DB or API changes.