### PR TITLE
Ensure email and redirect_url are not nil when resetting a password

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/reset_password_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/reset_password_controller.ex
@@ -6,7 +6,8 @@ defmodule AdminAPI.V1.ResetPasswordController do
   alias Bamboo.Email
 
   @spec reset(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def reset(conn, %{"email" => email, "redirect_url" => redirect_url}) do
+  def reset(conn, %{"email" => email, "redirect_url" => redirect_url})
+      when not is_nil(email) and not is_nil(redirect_url) do
     with true <- valid_url?(redirect_url) || :invalid_redirect_url,
          %User{} = user <- User.get_by_email(email) || :user_email_not_found,
          {_, _} <- ForgetPasswordRequest.delete_all(user),

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/reset_password_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/reset_password_controller_test.exs
@@ -43,6 +43,17 @@ defmodule AdminAPI.V1.AdminAuth.ResetPasswordControllerTest do
                "The `redirect_url` is not allowed to be used. Got: #{redirect_url}"
     end
 
+    test "returns an error when sending email = nil" do
+      response =
+        unauthenticated_request("/admin.reset_password", %{
+          "email" => nil,
+          "redirect_url" => @redirect_url
+        })
+
+      assert response["success"] == false
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
     test "returns an error if no user is found with the associated email" do
       response =
         unauthenticated_request("/admin.reset_password", %{


### PR DESCRIPTION
Issue/Task Number: #345 
closes #345 

# Overview

E2E tests found out that sending a `nil` email when resetting a password would result in a `500` error. This is now fixed in this PR by checking that the `email` (and `redirect_url`) are not `nil`.

# Changes

- Add test to reproduce the issue
- Add guard clause to protect the controller function