### PR TITLE
Add fallback for upload_avatar endpoints

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
@@ -153,6 +153,8 @@ defmodule AdminAPI.V1.AccountController do
     end
   end
 
+  def upload_avatar(conn, _), do: handle_error(conn, :invalid_parameter)
+
   defp respond(%Paginator{} = paginator, conn) do
     render(conn, :accounts, %{accounts: paginator})
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/self_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/self_controller.ex
@@ -53,6 +53,8 @@ defmodule AdminAPI.V1.SelfController do
     end
   end
 
+  def upload_avatar(conn, _), do: handle_error(conn, :invalid_parameter)
+
   @doc """
   Retrieves the upper-most account that the given user has membership in.
   """

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_controller_test.exs
@@ -371,6 +371,18 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
                "http://localhost:4000/public/uploads/test/account/avatars/#{account.id}/thumb.png?v="
     end
 
+    test "returns an error when 'avatar' is not sent" do
+      account = insert(:account)
+
+      response =
+        admin_user_request("/account.upload_avatar", %{
+          "id" => account.id
+        })
+
+      assert response["success"] == false
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
     test "removes the avatar from an account" do
       account = insert(:account)
 

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/self_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/self_controller_test.exs
@@ -96,6 +96,13 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
                "http://localhost:4000/public/uploads/test/user/avatars/#{uuid}/thumb.png?v="
     end
 
+    test "returns an error when 'avatar' is not sent" do
+      response = admin_user_request("/me.upload_avatar", %{})
+
+      assert response["success"] == false
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
     test "removes the avatar from a user" do
       account = insert(:account)
       role = insert(:role, %{name: "some_role"})


### PR DESCRIPTION
Issue/Task Number: #346 
closes #346

# Overview

Fallback pattern matching functions were missing for the `upload_avatar` endpoints, resulting in a 500.

# Changes

- Add tests to reproduce the error for accounts and admins
- Add the fallbacks
