### PR TITLE
Remove token_id_not_found error

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/mint_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/mint_controller.ex
@@ -21,7 +21,7 @@ defmodule AdminAPI.V1.MintController do
   @spec all_for_token(Conn.t(), map() | nil) :: Conn.t()
   def all_for_token(conn, %{"id" => id} = attrs) do
     with :ok <- permit(:all, conn.assigns, nil),
-         %Token{} = token <- Token.get(id) || :token_id_not_found do
+         %Token{} = token <- Token.get(id) || :token_not_found do
       token
       |> Mint.query_by_token()
       |> Preloader.to_query(@preload_fields)
@@ -48,7 +48,7 @@ defmodule AdminAPI.V1.MintController do
         } = attrs
       ) do
     with :ok <- permit(:create, conn.assigns, token_id),
-         %Token{} = token <- Token.get(token_id) || :token_id_not_found do
+         %Token{} = token <- Token.get(token_id) || :token_not_found do
       token
       |> MintGate.mint_token(attrs)
       |> respond_single(conn)

--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -179,7 +179,7 @@ defmodule AdminAPI.V1.TokenController do
   end
 
   defp respond_single(nil, conn) do
-    handle_error(conn, :token_id_not_found)
+    handle_error(conn, :token_not_found)
   end
 
   @spec permit(:all | :create | :get | :update, map(), String.t()) ::

--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -36,10 +36,6 @@ defmodule AdminAPI.V1.ErrorHandler do
       code: "account:id_not_found",
       description: "There is no account corresponding to the provided id"
     },
-    token_id_not_found: %{
-      code: "token:id_not_found",
-      description: "There is no token corresponding to the provided id"
-    },
     transaction_id_not_found: %{
       code: "transaction:id_not_found",
       description: "There is no transaction corresponding to the provided id"

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/token_controller_test.exs
@@ -117,8 +117,8 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
 
       assert response["data"] == %{
                "object" => "error",
-               "code" => "token:token_not_found",
-               "description" => "There is no token matching the provided token_id.",
+               "code" => "token:id_not_found",
+               "description" => "There is no token corresponding to the provided id",
                "messages" => nil
              }
     end
@@ -290,8 +290,8 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
 
       assert response["data"] == %{
                "object" => "error",
-               "code" => "token:token_not_found",
-               "description" => "There is no token matching the provided token_id.",
+               "code" => "token:id_not_found",
+               "description" => "There is no token corresponding to the provided id",
                "messages" => nil
              }
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -650,7 +650,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
              }
     end
 
-    test "returns token:token_not_found when token_id does not exist" do
+    test "returns token:id_not_found when token_id does not exist" do
       wallet_1 = insert(:wallet)
       wallet_2 = insert(:wallet)
 
@@ -666,8 +666,8 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       assert response["success"] == false
 
       assert response["data"] == %{
-               "code" => "token:token_not_found",
-               "description" => "There is no token matching the provided token_id.",
+               "code" => "token:id_not_found",
+               "description" => "There is no token corresponding to the provided id",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/token_controller_test.exs
@@ -118,8 +118,8 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
 
       assert response["data"] == %{
                "object" => "error",
-               "code" => "token:token_not_found",
-               "description" => "There is no token matching the provided token_id.",
+               "code" => "token:id_not_found",
+               "description" => "There is no token corresponding to the provided id",
                "messages" => nil
              }
     end
@@ -280,8 +280,8 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
 
       assert response["data"] == %{
                "object" => "error",
-               "code" => "token:token_not_found",
-               "description" => "There is no token matching the provided token_id.",
+               "code" => "token:id_not_found",
+               "description" => "There is no token corresponding to the provided id",
                "messages" => nil
              }
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -649,7 +649,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
              }
     end
 
-    test "returns token:token_not_found when token_id does not exist" do
+    test "returns token:id_not_found when token_id does not exist" do
       wallet_1 = insert(:wallet)
       wallet_2 = insert(:wallet)
 
@@ -665,8 +665,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
       assert response["success"] == false
 
       assert response["data"] == %{
-               "code" => "token:token_not_found",
-               "description" => "There is no token matching the provided token_id.",
+               "code" => "token:id_not_found",
+               "description" => "There is no token corresponding to the provided id",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
@@ -312,8 +312,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
                "success" => false,
                "version" => "1",
                "data" => %{
-                 "code" => "token:token_not_found",
-                 "description" => "There is no token matching the provided token_id.",
+                 "code" => "token:id_not_found",
+                 "description" => "There is no token corresponding to the provided id",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -157,8 +157,8 @@ defmodule EWallet.Web.V1.ErrorHandler do
       description: "The websocket payload could not be decoded."
     },
     token_not_found: %{
-      code: "token:token_not_found",
-      description: "There is no token matching the provided token_id."
+      code: "token:id_not_found",
+      description: "There is no token corresponding to the provided id"
     },
     from_token_not_found: %{
       code: "token:from_token_not_found",

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
@@ -472,8 +472,8 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
                "success" => false,
                "version" => "1",
                "data" => %{
-                 "code" => "token:token_not_found",
-                 "description" => "There is no token matching the provided token_id.",
+                 "code" => "token:id_not_found",
+                 "description" => "There is no token corresponding to the provided id",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -256,8 +256,8 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                "success" => false,
                "version" => "1",
                "data" => %{
-                 "code" => "token:token_not_found",
-                 "description" => "There is no token matching the provided token_id.",
+                 "code" => "token:id_not_found",
+                 "description" => "There is no token corresponding to the provided id",
                  "messages" => nil,
                  "object" => "error"
                }


### PR DESCRIPTION
Issue/Task Number: #347 
closes #347

# Overview

We currently have `token_id_not_found` and `token_not_found`. This PR removes the former and replaces all instances with the latter.
