### PR TITLE
Prevent the use of disabled keys

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
@@ -83,8 +83,8 @@ defmodule AdminAPI.V1.KeyController do
   """
   @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def update(conn, %{"id" => id} = attrs) do
-    with %Key{} = api_key <- Key.get(id) || {:error, :key_not_found},
-         {:ok, key} <- Key.update(api_key, attrs) do
+    with %Key{} = key <- Key.get(id) || {:error, :key_not_found},
+         {:ok, key} <- Key.update(key, attrs) do
       render(conn, :key, %{key: key})
     else
       {:error, code} when is_atom(code) ->

--- a/apps/ewallet_db/lib/ewallet_db/key.ex
+++ b/apps/ewallet_db/lib/ewallet_db/key.ex
@@ -137,7 +137,7 @@ defmodule EWalletDB.Key do
     query =
       from(
         k in Key,
-        where: k.access_key == ^access,
+        where: k.access_key == ^access and k.expired == false,
         join: a in assoc(k, :account),
         preload: [account: a]
       )

--- a/apps/ewallet_db/test/ewallet_db/key_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/key_test.exs
@@ -139,9 +139,10 @@ defmodule EWalletDB.KeyTest do
         })
         |> Key.insert()
 
-      {:ok, _key} = Key.update(key, %{
-        expired: true
-      })
+      {:ok, _key} =
+        Key.update(key, %{
+          expired: true
+        })
 
       res = Key.authenticate("access123", Base.url_encode64("secret321"))
       assert res == false


### PR DESCRIPTION
Issue/Task Number: 371
closes #371

# Overview

Currently, disabled keys can still be used to authenticate requests. This PR fixes that by only using non-expired keys.

# Changes

- Add test
- Fix key authenticate function
