### PR TITLE
Add test to ensure subunit_to_unit > 18 does not return 500

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/token_controller_test.exs
@@ -159,6 +159,18 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
       assert mint == nil
     end
 
+    test "returns an error with decimals > 18 (19 decimals)" do
+      response =
+        admin_user_request("/token.create", %{
+          symbol: "BTC",
+          name: "Bitcoin",
+          subunit_to_unit: 10_000_000_000_000_000_000_000
+        })
+
+      assert response["success"] == false
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
     test "inserts a new token with no minting if amount is nil" do
       response =
         admin_user_request("/token.create", %{


### PR DESCRIPTION
Issue/Task Number: 377
Closes #377

# Overview

It seems the issue has been fixed in #329, but this PR adds a test to ensure it doesn't come back in the future.

# Changes

- Add a test with 22 decimals for the `subunit_to_unit` when creating a token
