### PR TITLE
Fix unknown --no-watch option error

### DIFF
--- a/apps/url_dispatcher/lib/mix/tasks/omg.server.ex
+++ b/apps/url_dispatcher/lib/mix/tasks/omg.server.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Omg.Server do
   @doc false
   def run(args) do
     configure_env(args)
-    Run.run(run_args() ++ args)
+    Run.run(run_args())
   end
 
   defp configure_env(["--no-watch" | rest]) do


### PR DESCRIPTION
Issue/Task Number: 
Closes: #381 

# Overview

This PR fixes the issue with `mix omg.server --no-watch` failing to run with the following error:

```ex
$ mix omg.server --no-watch
** (Mix) Could not invoke task "omg.server": 1 error found!
--no-watch : Unknown option
```

# Changes

- Removed adding `args` back during `Mix.Tasks.Omg.Server` starting up.

# Implementation Details

The mix task expects the argument to be removed once it's handled so this PR removes `++ args` that's causing the issue.

# Usage

Run `mix omg.server --no-watch` should start the server up successfully.

# Impact

No changes to API or database schema.