### PR TITLE
Add test database setup to bare-metal readme & explanation on bash parentheses

### DIFF
--- a/docs/setup/bare_metal.md
+++ b/docs/setup/bare_metal.md
@@ -58,6 +58,12 @@ Run the following command to setup the databases:
 $ mix do ecto.create, ecto.migrate
 ```
 
+Also, you will need to setup the test database so tests can be run:
+
+```bash
+$ MIX_ENV=test mix do ecto.create, ecto.migrate
+```
+
 ### 1.5 Run the tests
 
 Run the tests to make sure that your setup is healthy:

--- a/docs/setup/bare_metal.md
+++ b/docs/setup/bare_metal.md
@@ -37,6 +37,8 @@ Then, install the front-end dependencies:
 $ (cd apps/admin_panel/assets/ && yarn install)
 ```
 
+_The parentheses above forces the commands to be executed in a subshell, and returns to the current working directory after the execution._
+
 ### 1.3 Configure environment variables
 
 Many configurations have default values pre-defined. If your environment requires different values, run `export ENV=value` to set environment variables in the current session (or add them to whatever profile file you are using).


### PR DESCRIPTION
Closes #384

# Overview

This PR adds the missing test database setup step to the bare-metal setup and explanation on the use of bash parentheses.

# Changes

- Add explanation about parentheses before yarn install
- Add test database setup step

# Implementation Details

N/A

# Usage

Readme changes only.

# Impact

Textual changes only. No API and DB changes.