### PR TITLE
Remove vagrant setup from readme temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Pick one of the following setup approaches that best suits your needs:
 Setup | Description | Recommended for
 -----------|-------------|----------------
 [Docker](docs/setup/docker.md) | A pre-packaged image for production uses. No build-time dependencies. Packaged with Distillery. | Developers and DevOps looking to integrate or deploy the eWallet without changing its internals.
-[Vagrant](docs/setup/vagrant.md) | _Currently supports MacOS only._ A development environment bootstrapper using Vagrant. Comes with default configurations and full build tools. | Developers looking to contribute to the codebase.
 [Bare&#x2011;metal](docs/setup/bare_metal.md) | Set up directly onto your base operating system. You will need to install Elixir, project's dependencies and Postgres manually if you havn't. | Developers and DevOps preferring to manage all dependencies and configurations themselves for any purposes.
 
 ## Documentation


### PR DESCRIPTION
Closes #386

# Overview

This PR removes Vagrant setup instructions from README as Goban bootstrapper needs to be updated.

# Changes

- Removed Vagrant setup from README.md

# Implementation Details

As Goban requires quite a bit of refresh. The instructions to use Vagrant is removed temporarily so it does not mislead users to try it out.

# Usage

N/A

# Impact

N/A
