### PR TITLE
Fix error description not converting field names from _uuid to _id

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
@@ -188,6 +188,20 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["description"] ==
                "Invalid parameter provided `to_token_id` can't be blank."
     end
+
+    test "returns client:invalid_parameter error if from_token_id and to_token_id are the same" do
+      omg = insert(:token)
+
+      request_data = insert_params(%{from_token_id: omg.id, to_token_id: omg.id})
+      response = admin_user_request("/exchange_pair.create", request_data)
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided `to_token_id` can't have the same value as `from_token_id`."
+    end
   end
 
   describe "/exchange_pair.update" do

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -371,8 +371,10 @@ defmodule EWallet.Web.V1.ErrorHandler do
   end
 
   defp build_template(data, template) do
-    Enum.reduce(data, template, fn {k, v}, desc ->
-      String.replace(desc, "%{#{k}}", "#{v}")
+    Enum.reduce(data, template, fn {k, v}, description ->
+      description
+      |> String.replace("%{#{k}}", "#{v}")
+      |> replace_uuids()
     end)
   end
 


### PR DESCRIPTION
Closes #378.

# Overview

This PR fixes the error description when the description contains `*_uuid` field names, it should convert them to `_id` field names.

# Changes

- Added a call to `replace_uuids/1` while building the error description
- Added an ExchangePairController test to cover this case

# Implementation Details

Since we never expose `*_uuid` fields to the API, this is an umbrella fix on the ErrorHandler so it always convert to `_id` field names.

# Usage

Try `/api/admin/exchange_pair.create` with the same `from_token_id` and `to_token_id` or use the values as reported in #378. The error message should be about `from_token_id` and `to_token_id` and no longer the `*_uuid` fields.

# Impact

No DB changes. API: Only impacts the error description text.