### PR TITLE
Switch user_id to id for /user.get_transaction_consumptions

### DIFF
--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -1132,7 +1132,7 @@ paths:
         - ProviderAuth: []
         - AdminAuth: []
       requestBody:
-        $ref: '#/components/requestBodies/TransactionConsumptionAllForUserBody'
+        $ref: '#/components/requestBodies/UserIdentifierWithFiltersBody'
       responses:
         '200':
           $ref: "#/components/responses/TransactionConsumptionsResponse"
@@ -4916,7 +4916,7 @@ components:
         application/vnd.omisego.v1+json:
           schema:
             properties:
-              user_id:
+              id:
                 type: string
               page:
                 type: integer
@@ -4932,9 +4932,9 @@ components:
                 type: string
                 enum: ["asc", "desc"]
             required:
-              - user_id
+              - id
             example:
-              user_id: "usr_02cbfg6v9thrc3sd9m1v4gazjv"
+              id: "usr_02cbfg6v9thrc3sd9m1v4gazjv"
               page: 1
               per_page: 10
               search_terms: {}

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -182,7 +182,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
              }
     end
 
-    test "returns :account_id_not_found when user_id is not provided" do
+    test "returns :account_id_not_found when id is not provided" do
       response =
         admin_user_request("/account.get_transaction_consumptions", %{
           "id" => "fake",
@@ -289,7 +289,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       }
     end
 
-    test "returns :invalid_parameter when user_id or provider_user_id is not provided" do
+    test "returns :invalid_parameter when id or provider_user_id is not provided" do
       response =
         admin_user_request("/user.get_transaction_consumptions", %{
           "sort_by" => "created",
@@ -308,10 +308,10 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
              }
     end
 
-    test "returns :user_id_not_found when user_id is not valid" do
+    test "returns :id_not_found when id is not valid" do
       response =
         admin_user_request("/user.get_transaction_consumptions", %{
-          "user_id" => "fake",
+          "id" => "fake",
           "sort_by" => "created",
           "sort_dir" => "asc"
         })
@@ -347,6 +347,24 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                    "There is no user corresponding to the provided provider_user_id"
                }
              }
+    end
+
+    test "returns all the transaction_consumptions for a user when given an id", meta do
+      response =
+        admin_user_request("/user.get_transaction_consumptions", %{
+          "id" => meta.user.id,
+          "sort_by" => "created",
+          "sort_dir" => "asc"
+        })
+
+      assert length(response["data"]["data"]) == 2
+
+      assert Enum.map(response["data"]["data"], fn t ->
+               t["id"]
+             end) == [
+               meta.tc_2.id,
+               meta.tc_3.id
+             ]
     end
 
     test "returns all the transaction_consumptions for a user when given a user_id", meta do

--- a/apps/ewallet/lib/ewallet/fetchers/user_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/user_fetcher.ex
@@ -5,6 +5,14 @@ defmodule EWallet.UserFetcher do
   alias EWalletDB.{User}
 
   @spec fetch(map()) :: {:ok, %User{}} | {:error, atom()}
+  def fetch(%{"id" => id}) do
+    with %User{} = user <- User.get(id) || :user_id_not_found do
+      {:ok, user}
+    else
+      error -> {:error, error}
+    end
+  end
+
   def fetch(%{"user_id" => user_id}) do
     with %User{} = user <- User.get(user_id) || :user_id_not_found do
       {:ok, user}


### PR DESCRIPTION
Issue/Task Number: #402 
closes #402

# Overview

The params for `/user.get_transaction_consumptions` were not consistent with the rest of the API. This PR fixes it.

# Changes

- Add support for `id` 
- Add tests
- Keep support for `user_id` through the `UserFetcher` to not break the API.