### PR TITLE
Fix mix seed instructions

### DIFF
--- a/docs/setup/bare_metal.md
+++ b/docs/setup/bare_metal.md
@@ -80,10 +80,10 @@ Some initial data is required to start the server. Either run the seed or the sa
 
 ```bash
 # Option 2a: Run this command to set up the initial data
-$ mix do ecto.seed
+$ mix seed
 
 # Option 2b: Run this command to set up the initial data and populate the database with more sample data
-$ mix do ecto.seed --sample
+$ mix seed --sample
 ```
 
 ### Step 3: Start the server

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -102,10 +102,10 @@ Some initial data is required to start the server. Either run the seed or the sa
 
 ```bash
 # Option 2a: Run this command to set up the initial data
-$ docker exec -it <container-id> mix do ecto.seed
+$ docker exec -it <container-id> mix seed
 
 # Option 2b: Run this command to set up the initial data and populate the database with more sample data
-$ docker exec -it <container-id> mix do ecto.seed --sample
+$ docker exec -it <container-id> mix seed --sample
 ```
 
 ## Step 3: Start the server

--- a/docs/setup/vagrant.md
+++ b/docs/setup/vagrant.md
@@ -34,10 +34,10 @@ Some initial data is required to start the server. Either run the seed or the sa
 
 ```bash
 # Option 2a: Run this command to set up the initial data
-$ mix do ecto.seed
+$ mix seed
 
 # Option 2b: Run this command to set up the initial data and populate the database with more sample data
-$ mix do ecto.seed --sample
+$ mix seed --sample
 ```
 
 ### Step 3: Start the server


### PR DESCRIPTION
Closes #406 

# Overview

This PR fixes the `mix seed` instruction in all setup options.

# Changes

- Fixed incorrect commands to `mix seed` in bare-metal, docker and vagrant setup instructions.

# Implementation Details

N/A

# Usage

Setup by following the instructions

# Impact

Documentation changes only