### PR TITLE
Properly handle invalid amounts for consumption

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -207,6 +207,10 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
     handle_error(conn, error)
   end
 
+  defp respond({:error, code, description}, conn, _dispatch?) do
+    handle_error(conn, code, description)
+  end
+
   defp respond({:error, changeset}, conn, _dispatch?) do
     handle_error(conn, :invalid_parameter, changeset)
   end

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -132,13 +132,18 @@ defmodule EWallet.TransactionConsumptionValidator do
     end
   end
 
-  def validate_amount(%TransactionRequest{allow_amount_override: true} = _request, amount) do
+  def validate_amount(%TransactionRequest{allow_amount_override: true} = _request, amount)
+      when is_integer(amount) do
     {:ok, amount}
   end
 
   def validate_amount(%TransactionRequest{allow_amount_override: false} = _request, amount)
       when not is_nil(amount) do
     {:error, :unauthorized_amount_override}
+  end
+
+  def validate_amount(_request, amount) do
+    {:error, :invalid_parameter, "'amount' is not an integer: #{amount}."}
   end
 
   @spec get_and_validate_token(%TransactionRequest{}, String.t() | nil) ::


### PR DESCRIPTION
Issue/Task Number: 416
closes #416

# Overview

Amount sent as float or `nil` were not returning errors as expected, and instead were raising `500` errors. This PR fixes that.

# Changes

- Handle `float` amounts when consuming (returns an error)
- Handle `nil` amount when consuming and request amount is also `nil` (returns an error)
