### PR TITLE
Add full stops to error descriptions and fix typos

### DIFF
--- a/apps/admin_api/lib/admin_api/invites/inviter.ex
+++ b/apps/admin_api/lib/admin_api/invites/inviter.ex
@@ -72,7 +72,7 @@ defmodule AdminAPI.Inviter do
       {:ok, invite}
     else
       {:error, :invalid_parameter,
-       "The `redirect_url` is not allowed to be used. Got: #{redirect_url}"}
+       "The `redirect_url` is not allowed to be used. Got: '#{redirect_url}'."}
     end
   end
 

--- a/apps/admin_api/lib/admin_api/v1/controllers/invite_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/invite_controller.ex
@@ -33,7 +33,7 @@ defmodule AdminAPI.V1.InviteController do
     handle_error(
       conn,
       :invalid_parameter,
-      "'email', 'token', 'password', 'password_confirmation' are required"
+      "Invalid parameter provided. `email`, `token`, `password`, `password_confirmation` are required."
     )
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/controllers/reset_password_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/reset_password_controller.ex
@@ -20,7 +20,7 @@ defmodule AdminAPI.V1.ResetPasswordController do
         handle_error(
           conn,
           :invalid_parameter,
-          "The `redirect_url` is not allowed to be used. Got: #{redirect_url}"
+          "The `redirect_url` is not allowed to be used. Got: '#{redirect_url}'."
         )
 
       error_code ->

--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -126,7 +126,7 @@ defmodule AdminAPI.V1.TokenController do
         |> respond_single(conn)
 
       amount ->
-        handle_error(conn, :invalid_parameter, "Invalid amount provided: '#{amount}'")
+        handle_error(conn, :invalid_parameter, "Invalid amount provided: '#{amount}'.")
     end
   end
 
@@ -146,7 +146,7 @@ defmodule AdminAPI.V1.TokenController do
   end
 
   def update(conn, _),
-    do: handle_error(conn, :invalid_parameter, "Invalid parameter provided: 'id' is required")
+    do: handle_error(conn, :invalid_parameter, "Invalid parameter provided. `id` is required.")
 
   # Respond with a list of tokens
   defp respond_multiple(%Paginator{} = paged_tokens, conn) do

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -70,7 +70,7 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   end
 
   def all_for_account(conn, _) do
-    handle_error(conn, :invalid_parameter, "Parameter 'id' is required.")
+    handle_error(conn, :invalid_parameter, "Invalid parameter provided. `id` is required.")
   end
 
   def all_for_user(conn, attrs) do
@@ -84,7 +84,7 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
         handle_error(
           conn,
           :invalid_parameter,
-          "Parameter 'user_id' or 'provider_user_id' is required."
+          "Invalid parameter provided. `user_id` or `provider_user_id` is required."
         )
 
       error ->
@@ -111,7 +111,7 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
     handle_error(
       conn,
       :invalid_parameter,
-      "Parameter 'formatted_transaction_request_id' is required."
+      "Invalid parameter provided. `formatted_transaction_request_id` is required."
     )
   end
 
@@ -127,7 +127,7 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   end
 
   def all_for_wallet(conn, _) do
-    handle_error(conn, :invalid_parameter, "Parameter 'address' is required.")
+    handle_error(conn, :invalid_parameter, "Invalid parameter provided. `address` is required.")
   end
 
   def all(conn, attrs) do

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
@@ -60,7 +60,7 @@ defmodule AdminAPI.V1.TransactionRequestController do
   end
 
   def all_for_account(conn, _) do
-    handle_error(conn, :invalid_parameter, "Parameter 'id' is required.")
+    handle_error(conn, :invalid_parameter, "Invalid parameter provided. `id` is required.")
   end
 
   @spec do_all(Ecto.Queryable.t(), map(), Plug.Conn.t()) :: Plug.Conn.t()

--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -10,63 +10,63 @@ defmodule AdminAPI.V1.ErrorHandler do
   @errors %{
     invalid_login_credentials: %{
       code: "user:invalid_login_credentials",
-      description: "There is no user corresponding to the provided login credentials"
+      description: "There is no user corresponding to the provided login credentials."
     },
     user_account_not_found: %{
       code: "user:account_not_found",
-      description: "There is no account assigned to the provided user"
+      description: "There is no account assigned to the provided user."
     },
     access_key_unauthorized: %{
       code: "access_key:unauthorized",
-      description: "The current access key is not allowed to perform the requested operation"
+      description: "The current access key is not allowed to perform the requested operation."
     },
     invalid_reset_token: %{
       code: "forget_password:token_not_found",
-      description: "There are no password reset requests corresponding to the provided token"
+      description: "There are no password reset requests corresponding to the provided token."
     },
     auth_token_not_found: %{
       code: "auth_token:not_found",
-      description: "There is no auth token corresponding to the provided token"
+      description: "There is no auth token corresponding to the provided token."
     },
     user_email_not_found: %{
       code: "user:email_not_found",
-      description: "There is no user corresponding to the provided email"
+      description: "There is no user corresponding to the provided email."
     },
     account_id_not_found: %{
       code: "account:id_not_found",
-      description: "There is no account corresponding to the provided id"
+      description: "There is no account corresponding to the provided id."
     },
     transaction_id_not_found: %{
       code: "transaction:id_not_found",
-      description: "There is no transaction corresponding to the provided id"
+      description: "There is no transaction corresponding to the provided id."
     },
     role_name_not_found: %{
       code: "role:name_not_found",
-      description: "There is no role corresponding to the provided name"
+      description: "There is no role corresponding to the provided name."
     },
     membership_not_found: %{
       code: "membership:not_found",
-      description: "The user is not assigned to the provided account"
+      description: "The user is not assigned to the provided account."
     },
     invalid_email: %{
       code: "user:invalid_email",
-      description: "The format of the provided email is invalid"
+      description: "The format of the provided email is invalid."
     },
     invite_not_found: %{
       code: "user:invite_not_found",
-      description: "There is no invite corresponding to the provided email and token"
+      description: "There is no invite corresponding to the provided email and token."
     },
     passwords_mismatch: %{
       code: "user:passwords_mismatch",
-      description: "The provided passwords do not match"
+      description: "The provided passwords do not match."
     },
     key_not_found: %{
       code: "key:not_found",
-      description: "The key could not be found"
+      description: "The key could not be found."
     },
     api_key_not_found: %{
       code: "api_key:not_found",
-      description: "The API key could not be found"
+      description: "The API key could not be found."
     },
     invalid_account_id: %{
       code: "client:invalid_account_id",
@@ -74,19 +74,19 @@ defmodule AdminAPI.V1.ErrorHandler do
     },
     category_id_not_found: %{
       code: "category:id_not_found",
-      description: "There is no category corresponding to the provided id"
+      description: "There is no category corresponding to the provided id."
     },
     category_not_empty: %{
       code: "category:not_empty",
-      description: "The category has one or more accounts associated"
+      description: "The category has one or more accounts associated."
     },
     exchange_pair_already_exists: %{
       code: "exchange:pair_already_exists",
-      description: "The exchange pair for the given tokens already exist"
+      description: "The exchange pair for the given tokens already exists."
     },
     exchange_opposite_pair_not_found: %{
       code: "exchange:opposite_pair_not_found",
-      description: "The opposite exchange pair for the given tokens could not be found"
+      description: "The opposite exchange pair for the given tokens could not be found."
     }
   }
 

--- a/apps/admin_api/test/admin_api/invites/inviter_test.exs
+++ b/apps/admin_api/test/admin_api/invites/inviter_test.exs
@@ -83,7 +83,9 @@ defmodule AdminAPI.InviterTest do
 
       assert res == :error
       assert code == :invalid_parameter
-      assert description == "The `redirect_url` is not allowed to be used. Got: #{redirect_url}"
+
+      assert description ==
+               "The `redirect_url` is not allowed to be used. Got: '#{redirect_url}'."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_controller_test.exs
@@ -213,7 +213,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
       assert response["data"]["code"] == "unauthorized"
 
       assert response["data"]["description"] ==
-               "You are not allowed to perform the requested operation"
+               "You are not allowed to perform the requested operation."
     end
 
     test "returns 'client:invalid_parameter' if the given ID is not in the correct format" do
@@ -224,7 +224,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
       assert response["data"]["code"] == "unauthorized"
 
       assert response["data"]["description"] ==
-               "You are not allowed to perform the requested operation"
+               "You are not allowed to perform the requested operation."
     end
   end
 
@@ -326,7 +326,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns a 'unauthorized' error if id is invalid" do
@@ -338,7 +338,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
       assert response["data"]["code"] == "unauthorized"
 
       assert response["data"]["description"] ==
-               "You are not allowed to perform the requested operation"
+               "You are not allowed to perform the requested operation."
     end
   end
 
@@ -492,7 +492,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
       assert response["data"]["code"] == "unauthorized"
 
       assert response["data"]["description"] ==
-               "You are not allowed to perform the requested operation"
+               "You are not allowed to perform the requested operation."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_membership_controller_test.exs
@@ -164,7 +164,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                  "data" => %{
                    "object" => "error",
                    "code" => "unauthorized",
-                   "description" => "You are not allowed to perform the requested operation",
+                   "description" => "You are not allowed to perform the requested operation.",
                    "messages" => nil
                  }
                }
@@ -178,7 +178,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                  "data" => %{
                    "object" => "error",
                    "code" => "client:invalid_parameter",
-                   "description" => "Invalid parameter provided",
+                   "description" => "Invalid parameter provided.",
                    "messages" => nil
                  }
                }
@@ -224,7 +224,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:invalid_email"
-      assert response["data"]["description"] == "The format of the provided email is invalid"
+      assert response["data"]["description"] == "The format of the provided email is invalid."
     end
 
     test "returns an error if the email is nil" do
@@ -239,7 +239,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:invalid_email"
-      assert response["data"]["description"] == "The format of the provided email is invalid"
+      assert response["data"]["description"] == "The format of the provided email is invalid."
     end
 
     test "returns client:invalid_parameter error if the redirect_url is not allowed" do
@@ -257,7 +257,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "The `redirect_url` is not allowed to be used. Got: #{redirect_url}"
+               "The `redirect_url` is not allowed to be used. Got: '#{redirect_url}'."
     end
 
     test "returns an error if the given user id does not exist" do
@@ -274,7 +274,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "user:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no user corresponding to the provided id"
+               "There is no user corresponding to the provided id."
     end
 
     test "returns an error if the given account id does not exist" do
@@ -305,7 +305,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "role:name_not_found"
 
       assert response["data"]["description"] ==
-               "There is no role corresponding to the provided name"
+               "There is no role corresponding to the provided name."
     end
   end
 
@@ -338,7 +338,9 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "membership:not_found"
-      assert response["data"]["description"] == "The user is not assigned to the provided account"
+
+      assert response["data"]["description"] ==
+               "The user is not assigned to the provided account."
     end
 
     test "returns an error if the given user id does not exist" do
@@ -353,7 +355,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "user:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no user corresponding to the provided id"
+               "There is no user corresponding to the provided id."
     end
 
     test "returns an error if the given account id does not exist" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/admin_auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/admin_auth_controller_test.exs
@@ -101,7 +101,7 @@ defmodule AdminAPI.V1.AdminAuth.AdminAuthControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "user:invalid_login_credentials",
-          "description" => "There is no user corresponding to the provided login credentials",
+          "description" => "There is no user corresponding to the provided login credentials.",
           "messages" => nil
         }
       }
@@ -119,7 +119,7 @@ defmodule AdminAPI.V1.AdminAuth.AdminAuthControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "user:invalid_login_credentials",
-          "description" => "There is no user corresponding to the provided login credentials",
+          "description" => "There is no user corresponding to the provided login credentials.",
           "messages" => nil
         }
       }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/admin_user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/admin_user_controller_test.exs
@@ -88,7 +88,7 @@ defmodule AdminAPI.V1.AdminAuth.AdminUserControllerTest do
       assert response["data"]["code"] == "unauthorized"
 
       assert response["data"]["description"] ==
-               "You are not allowed to perform the requested operation"
+               "You are not allowed to perform the requested operation."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
@@ -195,7 +195,7 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
                "success" => false,
                "data" => %{
                  "code" => "api_key:not_found",
-                 "description" => "The API key could not be found",
+                 "description" => "The API key could not be found.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/category_controller_test.exs
@@ -65,7 +65,7 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
       assert response["data"]["code"] == "category:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no category corresponding to the provided id"
+               "There is no category corresponding to the provided id."
     end
 
     test "returns 'category:id_not_found' if the given ID format is invalid" do
@@ -76,7 +76,7 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
       assert response["data"]["code"] == "category:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no category corresponding to the provided id"
+               "There is no category corresponding to the provided id."
     end
   end
 
@@ -146,7 +146,7 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns an 'unauthorized' error if id is invalid" do
@@ -158,7 +158,7 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
       assert response["data"]["code"] == "category:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no category corresponding to the provided id"
+               "There is no category corresponding to the provided id."
     end
   end
 
@@ -188,7 +188,7 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
                  "success" => false,
                  "data" => %{
                    "code" => "category:not_empty",
-                   "description" => "The category has one or more accounts associated",
+                   "description" => "The category has one or more accounts associated.",
                    "messages" => nil,
                    "object" => "error"
                  }
@@ -204,7 +204,7 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
                  "success" => false,
                  "data" => %{
                    "code" => "category:id_not_found",
-                   "description" => "There is no category corresponding to the provided id",
+                   "description" => "There is no category corresponding to the provided id.",
                    "messages" => nil,
                    "object" => "error"
                  }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
@@ -65,7 +65,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:pair_id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no exchange pair corresponding to the provided id"
+               "There is no exchange pair corresponding to the provided id."
     end
 
     test "returns 'exchange:id_not_found' if the given ID format is invalid" do
@@ -76,7 +76,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:pair_id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no exchange pair corresponding to the provided id"
+               "There is no exchange pair corresponding to the provided id."
     end
   end
 
@@ -138,7 +138,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` must be greater than 0."
+               "Invalid parameter provided. `rate` must be greater than 0."
     end
 
     test "returns client:invalid_parameter error if given a negative exchange rate" do
@@ -150,7 +150,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` must be greater than 0."
+               "Invalid parameter provided. `rate` must be greater than 0."
     end
 
     test "returns client:invalid_parameter error if rate is not provided" do
@@ -162,7 +162,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` can't be blank."
+               "Invalid parameter provided. `rate` can't be blank."
     end
 
     test "returns client:invalid_parameter error if from_token_id is not provided" do
@@ -174,7 +174,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `from_token_id` can't be blank."
+               "Invalid parameter provided. `from_token_id` can't be blank."
     end
 
     test "returns client:invalid_parameter error if to_token_id is not provided" do
@@ -186,7 +186,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `to_token_id` can't be blank."
+               "Invalid parameter provided. `to_token_id` can't be blank."
     end
 
     test "returns client:invalid_parameter error if from_token_id and to_token_id are the same" do
@@ -200,7 +200,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `to_token_id` can't have the same value as `from_token_id`."
+               "Invalid parameter provided. `to_token_id` can't have the same value as `from_token_id`."
     end
   end
 
@@ -290,7 +290,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:opposite_pair_not_found"
 
       assert response["data"]["description"] ==
-               "The opposite exchange pair for the given tokens could not be found"
+               "The opposite exchange pair for the given tokens could not be found."
     end
 
     test "returns a 'client:invalid_parameter' error if id is not provided" do
@@ -299,7 +299,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns a 'user:unauthorized' error if id is invalid" do
@@ -310,7 +310,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:pair_id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no exchange pair corresponding to the provided id"
+               "There is no exchange pair corresponding to the provided id."
     end
 
     test "returns an error if given an exchange rate of 0" do
@@ -322,7 +322,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` must be greater than 0."
+               "Invalid parameter provided. `rate` must be greater than 0."
     end
 
     test "returns an error if given a negative exchange rate" do
@@ -334,7 +334,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` must be greater than 0."
+               "Invalid parameter provided. `rate` must be greater than 0."
     end
   end
 
@@ -398,7 +398,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:opposite_pair_not_found"
 
       assert response["data"]["description"] ==
-               "The opposite exchange pair for the given tokens could not be found"
+               "The opposite exchange pair for the given tokens could not be found."
 
       assert ExchangePair.get(pair.id) != nil
     end
@@ -411,7 +411,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:pair_id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no exchange pair corresponding to the provided id"
+               "There is no exchange pair corresponding to the provided id."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/fallback_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/fallback_controller_test.exs
@@ -9,7 +9,7 @@ defmodule AdminAPI.V1.AdminAuth.FallbackControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:endpoint_not_found",
-          "description" => "Endpoint not found",
+          "description" => "Endpoint not found.",
           "messages" => nil
         }
       }
@@ -24,7 +24,7 @@ defmodule AdminAPI.V1.AdminAuth.FallbackControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:endpoint_not_found",
-          "description" => "Endpoint not found",
+          "description" => "Endpoint not found.",
           "messages" => nil
         }
       }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/invite_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/invite_controller_test.exs
@@ -48,7 +48,7 @@ defmodule AdminAPI.V1.AdminAuth.InviteControllerTest do
       assert response["data"]["code"] == "user:invite_not_found"
 
       assert response["data"]["description"] ==
-               "There is no invite corresponding to the provided email and token"
+               "There is no invite corresponding to the provided email and token."
     end
 
     test "returns :invite_not_found error if the token is incorrect" do
@@ -61,7 +61,7 @@ defmodule AdminAPI.V1.AdminAuth.InviteControllerTest do
       assert response["data"]["code"] == "user:invite_not_found"
 
       assert response["data"]["description"] ==
-               "There is no invite corresponding to the provided email and token"
+               "There is no invite corresponding to the provided email and token."
     end
 
     test "returns :passwords_mismatch error if the passwords do not match" do
@@ -72,7 +72,7 @@ defmodule AdminAPI.V1.AdminAuth.InviteControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:passwords_mismatch"
-      assert response["data"]["description"] == "The provided passwords do not match"
+      assert response["data"]["description"] == "The provided passwords do not match."
     end
 
     test "returns client:invalid_parameter error if the password has less than 8 characters" do
@@ -85,7 +85,7 @@ defmodule AdminAPI.V1.AdminAuth.InviteControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `password` must be 8 characters or more."
+               "Invalid parameter provided. `password` must be 8 characters or more."
     end
 
     test "returns :invalid_parameter error if a required parameter is missing" do
@@ -104,7 +104,7 @@ defmodule AdminAPI.V1.AdminAuth.InviteControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "'email', 'token', 'password', 'password_confirmation' are required"
+               "Invalid parameter provided. `email`, `token`, `password`, `password_confirmation` are required."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
@@ -139,7 +139,7 @@ defmodule AdminAPI.V1.AdminAuth.KeyControllerTest do
                "success" => false,
                "data" => %{
                  "code" => "key:not_found",
-                 "description" => "The key could not be found",
+                 "description" => "The key could not be found.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/mint_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/mint_controller_test.exs
@@ -161,7 +161,7 @@ defmodule AdminAPI.V1.AdminAuth.MintControllerTest do
 
       refute response["success"]
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "fails to mint a non existing token" do
@@ -205,7 +205,7 @@ defmodule AdminAPI.V1.AdminAuth.MintControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `amount` must be greater than 0."
+               "Invalid parameter provided. `amount` must be greater than 0."
 
       assert response["data"]["messages"] == %{"amount" => ["number"]}
     end
@@ -224,7 +224,7 @@ defmodule AdminAPI.V1.AdminAuth.MintControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `amount` must be greater than 0."
+               "Invalid parameter provided. `amount` must be greater than 0."
 
       assert response["data"]["messages"] == %{"amount" => ["number"]}
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/mint_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/mint_controller_test.exs
@@ -188,7 +188,7 @@ defmodule AdminAPI.V1.AdminAuth.MintControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "String number is not a valid number: 'abc'."
+      assert response["data"]["description"] == "Invalid parameter provided. String number is not a valid number: 'abc'."
     end
 
     test "fails to mint with mint amount == 0" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/mint_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/mint_controller_test.exs
@@ -188,7 +188,9 @@ defmodule AdminAPI.V1.AdminAuth.MintControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided. String number is not a valid number: 'abc'."
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. String number is not a valid number: 'abc'."
     end
 
     test "fails to mint with mint amount == 0" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/reset_password_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/reset_password_controller_test.exs
@@ -40,7 +40,7 @@ defmodule AdminAPI.V1.AdminAuth.ResetPasswordControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "The `redirect_url` is not allowed to be used. Got: #{redirect_url}"
+               "The `redirect_url` is not allowed to be used. Got: '#{redirect_url}'."
     end
 
     test "returns an error when sending email = nil" do
@@ -177,7 +177,7 @@ defmodule AdminAPI.V1.AdminAuth.ResetPasswordControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `password` must be 8 characters or more."
+               "Invalid parameter provided. `password` must be 8 characters or more."
 
       assert ForgetPasswordRequest |> Repo.all() |> length() == 1
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/self_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/self_controller_test.exs
@@ -57,7 +57,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
       assert response["success"] == false
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `email` has already been taken."
+               "Invalid parameter provided. `email` has already been taken."
 
       assert response["data"]["code"] == "client:invalid_parameter"
     end
@@ -246,7 +246,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
                  "data" => %{
                    "object" => "error",
                    "code" => "user:account_not_found",
-                   "description" => "There is no account assigned to the provided user",
+                   "description" => "There is no account assigned to the provided user.",
                    "messages" => nil
                  }
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/token_controller_test.exs
@@ -80,7 +80,7 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
       assert response["data"]["code"] == "token:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no token corresponding to the provided id"
+               "There is no token corresponding to the provided id."
     end
 
     test "returns 'client:invalid_parameter' if id was not provided" do
@@ -89,7 +89,7 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
   end
 
@@ -118,7 +118,7 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
       assert response["data"] == %{
                "object" => "error",
                "code" => "token:id_not_found",
-               "description" => "There is no token corresponding to the provided id",
+               "description" => "There is no token corresponding to the provided id.",
                "messages" => nil
              }
     end
@@ -255,7 +255,7 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `symbol` can't be blank."
+               "Invalid parameter provided. `symbol` can't be blank."
 
       inserted = Token |> Repo.all() |> Enum.at(0)
       assert inserted == nil
@@ -295,7 +295,7 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `name` can't be blank."
+               "Invalid parameter provided. `name` can't be blank."
     end
 
     test "Raises invalid_parameter error if id is missing" do
@@ -306,7 +306,7 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
       assert response["data"] == %{
                "object" => "error",
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided: 'id' is required",
+               "description" => "Invalid parameter provided. `id` is required.",
                "messages" => nil
              }
     end
@@ -319,7 +319,7 @@ defmodule AdminAPI.V1.AdminAuth.TokenControllerTest do
       assert response["data"] == %{
                "object" => "error",
                "code" => "token:id_not_found",
-               "description" => "There is no token corresponding to the provided id",
+               "description" => "There is no token corresponding to the provided id.",
                "messages" => nil
              }
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -173,7 +173,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'id' is required.",
+                 "description" => "Invalid parameter provided. `id` is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -197,7 +197,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                  "messages" => nil,
                  "object" => "error",
                  "code" => "unauthorized",
-                 "description" => "You are not allowed to perform the requested operation"
+                 "description" => "You are not allowed to perform the requested operation."
                }
              }
     end
@@ -299,7 +299,8 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'user_id' or 'provider_user_id' is required.",
+                 "description" =>
+                   "Invalid parameter provided. `user_id` or `provider_user_id` is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -323,7 +324,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                  "messages" => nil,
                  "object" => "error",
                  "code" => "user:id_not_found",
-                 "description" => "There is no user corresponding to the provided id"
+                 "description" => "There is no user corresponding to the provided id."
                }
              }
     end
@@ -344,7 +345,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                  "object" => "error",
                  "code" => "user:provider_user_id_not_found",
                  "description" =>
-                   "There is no user corresponding to the provided provider_user_id"
+                   "There is no user corresponding to the provided provider_user_id."
                }
              }
     end
@@ -487,7 +488,8 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'formatted_transaction_request_id' is required.",
+                 "description" =>
+                   "Invalid parameter provided. `formatted_transaction_request_id` is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -511,7 +513,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                  "code" => "unauthorized",
                  "messages" => nil,
                  "object" => "error",
-                 "description" => "You are not allowed to perform the requested operation"
+                 "description" => "You are not allowed to perform the requested operation."
                }
              }
     end
@@ -618,7 +620,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'address' is required.",
+                 "description" => "Invalid parameter provided. `address` is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -642,7 +644,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                  "code" => "unauthorized",
                  "messages" => nil,
                  "object" => "error",
-                 "description" => "You are not allowed to perform the requested operation"
+                 "description" => "You are not allowed to perform the requested operation."
                }
              }
     end
@@ -857,13 +859,13 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `from` can't be the address of a burn wallet."
+               "Invalid parameter provided. `from` can't be the address of a burn wallet."
 
       inserted_consumption = TransactionConsumption |> Repo.all() |> Enum.at(0)
       assert inserted_consumption.error_code == "client:invalid_parameter"
 
       assert inserted_consumption.error_description ==
-               "Invalid parameter provided `from` can't be the address of a burn wallet."
+               "Invalid parameter provided. `from` can't be the address of a burn wallet."
     end
 
     test "consumes the request and transfers the appropriate amount of tokens with string",
@@ -1474,7 +1476,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided",
+                 "description" => "Invalid parameter provided.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -1367,7 +1367,9 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
 
       assert response["success"] == false
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided. `amount` is not an integer: 1.2365."
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. `amount` is not an integer: 1.2365."
     end
 
     test "fails to consume and return an insufficient funds error", meta do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -1339,7 +1339,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "'amount' is required for transaction consumption."
+               "Invalid parameter provided. `amount` is required for transaction consumption."
     end
 
     test "fails to consume and return an error when amount is a decimal number", meta do
@@ -1367,7 +1367,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
 
       assert response["success"] == false
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "'amount' is not an integer: 1.2365."
+      assert response["data"]["description"] == "Invalid parameter provided. `amount` is not an integer: 1.2365."
     end
 
     test "fails to consume and return an insufficient funds error", meta do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -433,7 +433,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       assert response["data"]["code"] == "transaction:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no transaction corresponding to the provided id"
+               "There is no transaction corresponding to the provided id."
     end
 
     test "returns 'transaction:id_not_found' if the given ID format is invalid" do
@@ -444,7 +444,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       assert response["data"]["code"] == "transaction:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no transaction corresponding to the provided id"
+               "There is no transaction corresponding to the provided id."
     end
   end
 
@@ -552,7 +552,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
                "description" =>
-                 "Invalid parameter provided `from` can't be the address of a burn wallet.",
+                 "Invalid parameter provided. `from` can't be the address of a burn wallet.",
                "messages" => %{"from" => ["burn_wallet_as_sender_not_allowed"]},
                "object" => "error"
              }
@@ -615,7 +615,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
                "messages" => nil,
                "object" => "error",
                "code" => "client:invalid_parameter",
-               "description" => "'idempotency_token' is required."
+               "description" => "Invalid parameter provided. `idempotency_token` is required."
              }
     end
 
@@ -667,7 +667,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
 
       assert response["data"] == %{
                "code" => "token:id_not_found",
-               "description" => "There is no token corresponding to the provided id",
+               "description" => "There is no token corresponding to the provided id.",
                "messages" => nil,
                "object" => "error"
              }
@@ -714,7 +714,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
 
       assert response["data"] == %{
                "code" => "unauthorized",
-               "description" => "You are not allowed to perform the requested operation",
+               "description" => "You are not allowed to perform the requested operation.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -691,7 +691,8 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided. String number is not a valid number: 'fake'.",
+               "description" =>
+                 "Invalid parameter provided. String number is not a valid number: 'fake'.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -691,7 +691,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "String number is not a valid number: 'fake'.",
+               "description" => "Invalid parameter provided. String number is not a valid number: 'fake'.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
@@ -372,7 +372,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided `type` is invalid.",
+                 "description" => "Invalid parameter provided. `type` is invalid.",
                  "messages" => %{"type" => ["inclusion"]},
                  "object" => "error"
                }
@@ -415,7 +415,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "account:account_wallet_mismatch",
-                 "description" => "The provided wallet does not belong to the given account",
+                 "description" => "The provided wallet does not belong to the given account.",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -463,7 +463,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "unauthorized",
-                 "description" => "You are not allowed to perform the requested operation",
+                 "description" => "You are not allowed to perform the requested operation.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_auth_controller_test.exs
@@ -46,7 +46,7 @@ defmodule AdminAPI.V1.AdminAuth.UserAuthControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "user:provider_user_id_not_found",
-          "description" => "There is no user corresponding to the provided provider_user_id",
+          "description" => "There is no user corresponding to the provided provider_user_id.",
           "messages" => nil
         }
       }
@@ -63,7 +63,7 @@ defmodule AdminAPI.V1.AdminAuth.UserAuthControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }
@@ -80,7 +80,7 @@ defmodule AdminAPI.V1.AdminAuth.UserAuthControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_controller_test.exs
@@ -247,7 +247,7 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "unauthorized",
-          "description" => "You are not allowed to perform the requested operation",
+          "description" => "You are not allowed to perform the requested operation.",
           "messages" => nil
         }
       }
@@ -265,7 +265,7 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }
@@ -282,7 +282,7 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }
@@ -331,7 +331,7 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided " <> "`provider_user_id` can't be blank."
+               "Invalid parameter provided. " <> "`provider_user_id` can't be blank."
 
       assert response["data"]["messages"] == %{"provider_user_id" => ["required"]}
     end
@@ -346,7 +346,7 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided " <> "`username` can't be blank."
+               "Invalid parameter provided. " <> "`username` can't be blank."
 
       assert response["data"]["messages"] == %{"username" => ["required"]}
     end
@@ -485,7 +485,7 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns an error if user for provider_user_id is not found" do
@@ -514,7 +514,7 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/wallet_controller_test.exs
@@ -316,7 +316,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
                "data" => %{
                  "object" => "error",
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided",
+                 "description" => "Invalid parameter provided.",
                  "messages" => nil
                }
              }
@@ -332,7 +332,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
                "data" => %{
                  "object" => "error",
                  "code" => "unauthorized",
-                 "description" => "You are not allowed to perform the requested operation",
+                 "description" => "You are not allowed to perform the requested operation.",
                  "messages" => nil
                }
              }
@@ -348,7 +348,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
                "data" => %{
                  "object" => "error",
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided",
+                 "description" => "Invalid parameter provided.",
                  "messages" => nil
                }
              }
@@ -385,7 +385,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
   end
 
@@ -404,7 +404,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided `identifier` has invalid format.",
+               "description" => "Invalid parameter provided. `identifier` has invalid format.",
                "messages" => %{"identifier" => ["format"]},
                "object" => "error"
              }
@@ -468,7 +468,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided `identifier` has invalid format.",
+               "description" => "Invalid parameter provided. `identifier` has invalid format.",
                "messages" => %{"identifier" => ["format"]},
                "object" => "error"
              }
@@ -522,7 +522,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided `account_id` can't be blank.",
+               "description" => "Invalid parameter provided. `account_id` can't be blank.",
                "messages" => %{"account_id" => ["required"]},
                "object" => "error"
              }
@@ -545,7 +545,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
                "description" =>
-                 "Invalid parameter provided `account_id`, `user_id` only one must be present.",
+                 "Invalid parameter provided. `account_id`, `user_id` only one must be present.",
                "messages" => %{"account_id, user_id" => ["only_one_required"]},
                "object" => "error"
              }
@@ -563,7 +563,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
       assert response["data"] == %{
                "code" => "unauthorized",
                "object" => "error",
-               "description" => "You are not allowed to perform the requested operation",
+               "description" => "You are not allowed to perform the requested operation.",
                "messages" => nil
              }
     end
@@ -581,7 +581,7 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided `identifier` can't be blank.",
+               "description" => "Invalid parameter provided. `identifier` can't be blank.",
                "messages" => %{"identifier" => ["required"]},
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_controller_test.exs
@@ -172,7 +172,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns a 'unauthorized' error if id is invalid" do

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_membership_controller_test.exs
@@ -162,7 +162,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
                  "data" => %{
                    "object" => "error",
                    "code" => "unauthorized",
-                   "description" => "You are not allowed to perform the requested operation",
+                   "description" => "You are not allowed to perform the requested operation.",
                    "messages" => nil
                  }
                }
@@ -176,7 +176,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
                  "data" => %{
                    "object" => "error",
                    "code" => "client:invalid_parameter",
-                   "description" => "Invalid parameter provided",
+                   "description" => "Invalid parameter provided.",
                    "messages" => nil
                  }
                }
@@ -222,7 +222,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "user:invalid_email"
-      assert response["data"]["description"] == "The format of the provided email is invalid"
+      assert response["data"]["description"] == "The format of the provided email is invalid."
     end
 
     test "returns an error if the given user id does not exist" do
@@ -239,7 +239,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "user:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no user corresponding to the provided id"
+               "There is no user corresponding to the provided id."
     end
 
     test "returns an error if the given account id does not exist" do
@@ -256,7 +256,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "unauthorized"
 
       assert response["data"]["description"] ==
-               "You are not allowed to perform the requested operation"
+               "You are not allowed to perform the requested operation."
     end
 
     test "returns an error if the given role does not exist" do
@@ -273,7 +273,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "role:name_not_found"
 
       assert response["data"]["description"] ==
-               "There is no role corresponding to the provided name"
+               "There is no role corresponding to the provided name."
     end
   end
 
@@ -306,7 +306,9 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "membership:not_found"
-      assert response["data"]["description"] == "The user is not assigned to the provided account"
+
+      assert response["data"]["description"] ==
+               "The user is not assigned to the provided account."
     end
 
     test "returns an error if the given user id does not exist" do
@@ -321,7 +323,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "user:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no user corresponding to the provided id"
+               "There is no user corresponding to the provided id."
     end
 
     test "returns an error if the given account id does not exist" do
@@ -336,7 +338,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
       assert response["data"]["code"] == "unauthorized"
 
       assert response["data"]["description"] ==
-               "You are not allowed to perform the requested operation"
+               "You are not allowed to perform the requested operation."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
@@ -195,7 +195,7 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
                "success" => false,
                "data" => %{
                  "code" => "api_key:not_found",
-                 "description" => "The API key could not be found",
+                 "description" => "The API key could not be found.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/category_controller_test.exs
@@ -65,7 +65,7 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
       assert response["data"]["code"] == "category:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no category corresponding to the provided id"
+               "There is no category corresponding to the provided id."
     end
 
     test "returns 'category:id_not_found' if the given ID format is invalid" do
@@ -76,7 +76,7 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
       assert response["data"]["code"] == "category:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no category corresponding to the provided id"
+               "There is no category corresponding to the provided id."
     end
   end
 
@@ -146,7 +146,7 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns an 'unauthorized' error if id is invalid" do
@@ -158,7 +158,7 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
       assert response["data"]["code"] == "category:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no category corresponding to the provided id"
+               "There is no category corresponding to the provided id."
     end
   end
 
@@ -188,7 +188,7 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
                  "success" => false,
                  "data" => %{
                    "code" => "category:not_empty",
-                   "description" => "The category has one or more accounts associated",
+                   "description" => "The category has one or more accounts associated.",
                    "messages" => nil,
                    "object" => "error"
                  }
@@ -204,7 +204,7 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
                  "success" => false,
                  "data" => %{
                    "code" => "category:id_not_found",
-                   "description" => "There is no category corresponding to the provided id",
+                   "description" => "There is no category corresponding to the provided id.",
                    "messages" => nil,
                    "object" => "error"
                  }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/exchange_pair_controller_test.exs
@@ -65,7 +65,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:pair_id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no exchange pair corresponding to the provided id"
+               "There is no exchange pair corresponding to the provided id."
     end
 
     test "returns 'exchange:id_not_found' if the given ID format is invalid" do
@@ -76,7 +76,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:pair_id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no exchange pair corresponding to the provided id"
+               "There is no exchange pair corresponding to the provided id."
     end
   end
 
@@ -138,7 +138,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` must be greater than 0."
+               "Invalid parameter provided. `rate` must be greater than 0."
     end
 
     test "returns client:invalid_parameter error if given a negative exchange rate" do
@@ -150,7 +150,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` must be greater than 0."
+               "Invalid parameter provided. `rate` must be greater than 0."
     end
 
     test "returns client:invalid_parameter error if a required parameter is not provided" do
@@ -162,7 +162,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` can't be blank."
+               "Invalid parameter provided. `rate` can't be blank."
     end
 
     test "returns client:invalid_parameter error if from_token_id is not provided" do
@@ -174,7 +174,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `from_token_id` can't be blank."
+               "Invalid parameter provided. `from_token_id` can't be blank."
     end
 
     test "returns client:invalid_parameter error if to_token_id is not provided" do
@@ -186,7 +186,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `to_token_id` can't be blank."
+               "Invalid parameter provided. `to_token_id` can't be blank."
     end
   end
 
@@ -276,7 +276,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:opposite_pair_not_found"
 
       assert response["data"]["description"] ==
-               "The opposite exchange pair for the given tokens could not be found"
+               "The opposite exchange pair for the given tokens could not be found."
     end
 
     test "returns a 'client:invalid_parameter' error if id is not provided" do
@@ -285,7 +285,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns a 'user:unauthorized' error if id is invalid" do
@@ -296,7 +296,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:pair_id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no exchange pair corresponding to the provided id"
+               "There is no exchange pair corresponding to the provided id."
     end
 
     test "returns an error if given an exchange rate of 0" do
@@ -308,7 +308,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` must be greater than 0."
+               "Invalid parameter provided. `rate` must be greater than 0."
     end
 
     test "returns an error if given a negative exchange rate" do
@@ -320,7 +320,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `rate` must be greater than 0."
+               "Invalid parameter provided. `rate` must be greater than 0."
     end
   end
 
@@ -384,7 +384,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:opposite_pair_not_found"
 
       assert response["data"]["description"] ==
-               "The opposite exchange pair for the given tokens could not be found"
+               "The opposite exchange pair for the given tokens could not be found."
 
       assert ExchangePair.get(pair.id) != nil
     end
@@ -397,7 +397,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["code"] == "exchange:pair_id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no exchange pair corresponding to the provided id"
+               "There is no exchange pair corresponding to the provided id."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/fallback_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/fallback_controller_test.exs
@@ -9,7 +9,7 @@ defmodule AdminAPI.V1.ProviderAuth.FallbackControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:endpoint_not_found",
-          "description" => "Endpoint not found",
+          "description" => "Endpoint not found.",
           "messages" => nil
         }
       }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -139,7 +139,7 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
                "success" => false,
                "data" => %{
                  "code" => "key:not_found",
-                 "description" => "The key could not be found",
+                 "description" => "The key could not be found.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/mint_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/mint_controller_test.exs
@@ -136,7 +136,7 @@ defmodule AdminAPI.V1.ProviderAuth.MintControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "String number is not a valid number: 'abc'."
+      assert response["data"]["description"] == "Invalid parameter provided. String number is not a valid number: 'abc'."
     end
 
     test "fails to mint with mint amount == 0" do

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/mint_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/mint_controller_test.exs
@@ -136,7 +136,9 @@ defmodule AdminAPI.V1.ProviderAuth.MintControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided. String number is not a valid number: 'abc'."
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. String number is not a valid number: 'abc'."
     end
 
     test "fails to mint with mint amount == 0" do

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/mint_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/mint_controller_test.exs
@@ -153,7 +153,7 @@ defmodule AdminAPI.V1.ProviderAuth.MintControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `amount` must be greater than 0."
+               "Invalid parameter provided. `amount` must be greater than 0."
 
       assert response["data"]["messages"] == %{"amount" => ["number"]}
     end
@@ -172,7 +172,7 @@ defmodule AdminAPI.V1.ProviderAuth.MintControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `amount` must be greater than 0."
+               "Invalid parameter provided. `amount` must be greater than 0."
 
       assert response["data"]["messages"] == %{"amount" => ["number"]}
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/token_controller_test.exs
@@ -80,7 +80,7 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
       assert response["data"]["code"] == "token:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no token corresponding to the provided id"
+               "There is no token corresponding to the provided id."
     end
 
     test "returns 'client:invalid_parameter' if id was not provided" do
@@ -89,7 +89,7 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
   end
 
@@ -119,7 +119,7 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
       assert response["data"] == %{
                "object" => "error",
                "code" => "token:id_not_found",
-               "description" => "There is no token corresponding to the provided id",
+               "description" => "There is no token corresponding to the provided id.",
                "messages" => nil
              }
     end
@@ -198,7 +198,7 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
       assert mint == nil
       assert response["success"] == false
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid amount provided: '0'"
+      assert response["data"]["description"] == "Invalid amount provided: '0'."
     end
 
     test "mints the given amount of tokens" do
@@ -233,7 +233,7 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `symbol` can't be blank."
+               "Invalid parameter provided. `symbol` can't be blank."
 
       inserted = Token |> Repo.all() |> Enum.at(0)
       assert inserted == nil
@@ -268,7 +268,7 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
       assert response["data"] == %{
                "object" => "error",
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided: 'id' is required",
+               "description" => "Invalid parameter provided. `id` is required.",
                "messages" => nil
              }
     end
@@ -281,7 +281,7 @@ defmodule AdminAPI.V1.ProviderAuth.TokenControllerTest do
       assert response["data"] == %{
                "object" => "error",
                "code" => "token:id_not_found",
-               "description" => "There is no token corresponding to the provided id",
+               "description" => "There is no token corresponding to the provided id.",
                "messages" => nil
              }
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
@@ -173,7 +173,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'id' is required.",
+                 "description" => "Invalid parameter provided. `id` is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -197,7 +197,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                  "messages" => nil,
                  "object" => "error",
                  "code" => "unauthorized",
-                 "description" => "You are not allowed to perform the requested operation"
+                 "description" => "You are not allowed to perform the requested operation."
                }
              }
     end
@@ -299,7 +299,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'user_id' or 'provider_user_id' is required.",
+                 "description" =>
+                   "Invalid parameter provided. `user_id` or `provider_user_id` is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -323,7 +324,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                  "messages" => nil,
                  "object" => "error",
                  "code" => "user:id_not_found",
-                 "description" => "There is no user corresponding to the provided id"
+                 "description" => "There is no user corresponding to the provided id."
                }
              }
     end
@@ -344,7 +345,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                  "object" => "error",
                  "code" => "user:provider_user_id_not_found",
                  "description" =>
-                   "There is no user corresponding to the provided provider_user_id"
+                   "There is no user corresponding to the provided provider_user_id."
                }
              }
     end
@@ -469,7 +470,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'formatted_transaction_request_id' is required.",
+                 "description" =>
+                   "Invalid parameter provided. `formatted_transaction_request_id` is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -493,7 +495,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                  "code" => "unauthorized",
                  "messages" => nil,
                  "object" => "error",
-                 "description" => "You are not allowed to perform the requested operation"
+                 "description" => "You are not allowed to perform the requested operation."
                }
              }
     end
@@ -600,7 +602,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
       assert response == %{
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Parameter 'address' is required.",
+                 "description" => "Invalid parameter provided. `address` is required.",
                  "messages" => nil,
                  "object" => "error"
                },
@@ -624,7 +626,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                  "code" => "unauthorized",
                  "messages" => nil,
                  "object" => "error",
-                 "description" => "You are not allowed to perform the requested operation"
+                 "description" => "You are not allowed to perform the requested operation."
                }
              }
     end
@@ -839,13 +841,13 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided `from` can't be the address of a burn wallet."
+               "Invalid parameter provided. `from` can't be the address of a burn wallet."
 
       inserted_consumption = TransactionConsumption |> Repo.all() |> Enum.at(0)
       assert inserted_consumption.error_code == "client:invalid_parameter"
 
       assert inserted_consumption.error_description ==
-               "Invalid parameter provided `from` can't be the address of a burn wallet."
+               "Invalid parameter provided. `from` can't be the address of a burn wallet."
     end
 
     test "consumes the request and transfers the appropriate amount of tokens with string",
@@ -1456,7 +1458,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided",
+                 "description" => "Invalid parameter provided.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -432,7 +432,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
       assert response["data"]["code"] == "transaction:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no transaction corresponding to the provided id"
+               "There is no transaction corresponding to the provided id."
     end
 
     test "returns 'transaction:id_not_found' if the given ID format is invalid" do
@@ -443,7 +443,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
       assert response["data"]["code"] == "transaction:id_not_found"
 
       assert response["data"]["description"] ==
-               "There is no transaction corresponding to the provided id"
+               "There is no transaction corresponding to the provided id."
     end
   end
 
@@ -551,7 +551,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
                "description" =>
-                 "Invalid parameter provided `from` can't be the address of a burn wallet.",
+                 "Invalid parameter provided. `from` can't be the address of a burn wallet.",
                "messages" => %{"from" => ["burn_wallet_as_sender_not_allowed"]},
                "object" => "error"
              }
@@ -614,7 +614,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
                "messages" => nil,
                "object" => "error",
                "code" => "client:invalid_parameter",
-               "description" => "'idempotency_token' is required."
+               "description" => "Invalid parameter provided. `idempotency_token` is required."
              }
     end
 
@@ -666,7 +666,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
 
       assert response["data"] == %{
                "code" => "token:id_not_found",
-               "description" => "There is no token corresponding to the provided id",
+               "description" => "There is no token corresponding to the provided id.",
                "messages" => nil,
                "object" => "error"
              }
@@ -713,7 +713,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
 
       assert response["data"] == %{
                "code" => "unauthorized",
-               "description" => "You are not allowed to perform the requested operation",
+               "description" => "You are not allowed to perform the requested operation.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -690,7 +690,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided. String number is not a valid number: 'fake'.",
+               "description" =>
+                 "Invalid parameter provided. String number is not a valid number: 'fake'.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -690,7 +690,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "String number is not a valid number: 'fake'.",
+               "description" => "Invalid parameter provided. String number is not a valid number: 'fake'.",
                "messages" => nil,
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
@@ -243,7 +243,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided `type` is invalid.",
+                 "description" => "Invalid parameter provided. `type` is invalid.",
                  "messages" => %{"type" => ["inclusion"]},
                  "object" => "error"
                }
@@ -286,7 +286,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "account:account_wallet_mismatch",
-                 "description" => "The provided wallet does not belong to the given account",
+                 "description" => "The provided wallet does not belong to the given account.",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -313,7 +313,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "token:id_not_found",
-                 "description" => "There is no token corresponding to the provided id",
+                 "description" => "There is no token corresponding to the provided id.",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -345,7 +345,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "unauthorized",
-                 "description" => "You are not allowed to perform the requested operation",
+                 "description" => "You are not allowed to perform the requested operation.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_auth_controller_test.exs
@@ -46,7 +46,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserAuthControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "user:provider_user_id_not_found",
-          "description" => "There is no user corresponding to the provided provider_user_id",
+          "description" => "There is no user corresponding to the provided provider_user_id.",
           "messages" => nil
         }
       }
@@ -63,7 +63,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserAuthControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }
@@ -80,7 +80,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserAuthControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_controller_test.exs
@@ -130,7 +130,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "unauthorized",
-          "description" => "You are not allowed to perform the requested operation",
+          "description" => "You are not allowed to perform the requested operation.",
           "messages" => nil
         }
       }
@@ -148,7 +148,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }
@@ -165,7 +165,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }
@@ -214,7 +214,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided " <> "`provider_user_id` can't be blank."
+               "Invalid parameter provided. " <> "`provider_user_id` can't be blank."
 
       assert response["data"]["messages"] == %{"provider_user_id" => ["required"]}
     end
@@ -229,7 +229,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "Invalid parameter provided " <> "`username` can't be blank."
+               "Invalid parameter provided. " <> "`username` can't be blank."
 
       assert response["data"]["messages"] == %{"username" => ["required"]}
     end
@@ -368,7 +368,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns an error if user for provider_user_id is not found" do
@@ -397,7 +397,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
       assert response["success"] == false
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
@@ -268,7 +268,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
                "data" => %{
                  "object" => "error",
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided",
+                 "description" => "Invalid parameter provided.",
                  "messages" => nil
                }
              }
@@ -284,7 +284,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
                "data" => %{
                  "object" => "error",
                  "code" => "unauthorized",
-                 "description" => "You are not allowed to perform the requested operation",
+                 "description" => "You are not allowed to perform the requested operation.",
                  "messages" => nil
                }
              }
@@ -300,7 +300,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
                "data" => %{
                  "object" => "error",
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided",
+                 "description" => "Invalid parameter provided.",
                  "messages" => nil
                }
              }
@@ -337,7 +337,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
   end
 
@@ -356,7 +356,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided `identifier` has invalid format.",
+               "description" => "Invalid parameter provided. `identifier` has invalid format.",
                "messages" => %{"identifier" => ["format"]},
                "object" => "error"
              }
@@ -426,7 +426,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided `identifier` has invalid format.",
+               "description" => "Invalid parameter provided. `identifier` has invalid format.",
                "messages" => %{"identifier" => ["format"]},
                "object" => "error"
              }
@@ -488,7 +488,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
 
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided `account_id` can't be blank.",
+               "description" => "Invalid parameter provided. `account_id` can't be blank.",
                "messages" => %{"account_id" => ["required"]},
                "object" => "error"
              }
@@ -511,7 +511,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
                "description" =>
-                 "Invalid parameter provided `account_id`, `user_id` only one must be present.",
+                 "Invalid parameter provided. `account_id`, `user_id` only one must be present.",
                "messages" => %{"account_id, user_id" => ["only_one_required"]},
                "object" => "error"
              }
@@ -529,7 +529,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
       assert response["data"] == %{
                "code" => "unauthorized",
                "object" => "error",
-               "description" => "You are not allowed to perform the requested operation",
+               "description" => "You are not allowed to perform the requested operation.",
                "messages" => nil
              }
     end
@@ -548,7 +548,7 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
       assert response["data"] == %{
                "code" => "client:invalid_parameter",
                "object" => "error",
-               "description" => "Invalid parameter provided `identifier` can't be blank.",
+               "description" => "Invalid parameter provided. `identifier` can't be blank.",
                "messages" => %{"identifier" => ["required"]}
              }
 

--- a/apps/admin_api/test/admin_api/v1/error_handler_test.exs
+++ b/apps/admin_api/test/admin_api/v1/error_handler_test.exs
@@ -22,7 +22,7 @@ defmodule AdminAPI.V1.ErrorHandlerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }
@@ -48,7 +48,7 @@ defmodule AdminAPI.V1.ErrorHandlerTest do
           "object" => "error",
           "code" => "client:invalid_parameter",
           "description" =>
-            "Invalid parameter provided" <>
+            "Invalid parameter provided." <>
               " `field2` can't be blank." <> " `field3` can't be blank.",
           "messages" => %{
             "field2" => ["required"],
@@ -72,7 +72,7 @@ defmodule AdminAPI.V1.ErrorHandlerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_version",
-          "description" => "Invalid API version Given: 'invalid_header'.",
+          "description" => "Invalid API version. Given: 'invalid_header'.",
           "messages" => nil
         }
       }

--- a/apps/admin_api/test/admin_api/versioned_router_test.exs
+++ b/apps/admin_api/test/admin_api/versioned_router_test.exs
@@ -23,7 +23,7 @@ defmodule AdminAPI.VersionedRouterTest do
           "object" => "error",
           "code" => "client:invalid_version",
           "description" =>
-            "Invalid API version Given: 'application/vnd.omisego.invalid_ver+json'.",
+            "Invalid API version. Given: 'application/vnd.omisego.invalid_ver+json'.",
           "messages" => nil
         }
       }

--- a/apps/ewallet/lib/ewallet/fetchers/account_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/account_fetcher.ex
@@ -73,7 +73,7 @@ defmodule EWallet.AccountFetcher do
 
   def fetch_exchange_account(_attrs, _from) do
     {:error, :invalid_parameter,
-     "'exchange_account_id' or 'exchange_wallet_address' is required.'"}
+     "Invalid parameter provided. `exchange_account_id` or `exchange_wallet_address` is required.'"}
   end
 
   defp return_from(exchange, account, wallet) do

--- a/apps/ewallet/lib/ewallet/fetchers/amount_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/amount_fetcher.ex
@@ -72,7 +72,8 @@ defmodule EWallet.AmountFetcher do
 
   # Returns error if neither `amount`, `from_amount` or `to_amount` is provided
   def fetch(_, _, _) do
-    {:error, :invalid_parameter, "'amount', 'from_amount' or 'to_amount' is required."}
+    {:error, :invalid_parameter,
+     "Invalid parameter provided. `amount`, `from_amount` or `to_amount` is required."}
   end
 
   # Uses `Exchange.validate/4` if both `from_amount` and `to_amount` are provided.
@@ -112,7 +113,8 @@ defmodule EWallet.AmountFetcher do
   end
 
   defp do_fetch(_, _, _, _) do
-    {:error, :invalid_parameter, "'amount', 'from_amount' or 'to_amount' is required"}
+    {:error, :invalid_parameter,
+     "Invalid parameter provided. `amount`, `from_amount` or `to_amount` is required."}
   end
 
   defp handle_string_amount({amount_1, amount_2}, fun) do

--- a/apps/ewallet/lib/ewallet/fetchers/amount_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/amount_fetcher.ex
@@ -16,7 +16,7 @@ defmodule EWallet.AmountFetcher do
       )
       when not is_nil(amount) and not is_nil(from_token_id) and not is_nil(to_token_id) do
     {:error, :invalid_parameter,
-     "'amount' not allowed when exchanging values. Use from_amount and/or to_amount."}
+     "Invalid parameter provided. `amount` not allowed when exchanging values. Use `from_amount` and/or `to_amount`."}
   end
 
   def fetch(%{"amount" => amount}, from, to) when is_binary(amount) do
@@ -30,7 +30,7 @@ defmodule EWallet.AmountFetcher do
   end
 
   def fetch(%{"amount" => amount}, _from, _to) do
-    {:error, :invalid_parameter, "'amount' is not an integer: #{amount}"}
+    {:error, :invalid_parameter, "Invalid parameter provided. `amount` is not an integer: #{amount}"}
   end
 
   #

--- a/apps/ewallet/lib/ewallet/fetchers/amount_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/amount_fetcher.ex
@@ -30,7 +30,8 @@ defmodule EWallet.AmountFetcher do
   end
 
   def fetch(%{"amount" => amount}, _from, _to) do
-    {:error, :invalid_parameter, "Invalid parameter provided. `amount` is not an integer: #{amount}"}
+    {:error, :invalid_parameter,
+     "Invalid parameter provided. `amount` is not an integer: #{amount}"}
   end
 
   #

--- a/apps/ewallet/lib/ewallet/fetchers/token_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/token_fetcher.ex
@@ -23,6 +23,6 @@ defmodule EWallet.TokenFetcher do
 
   def fetch(_, _from, _to) do
     {:error, :invalid_parameter,
-     "'token_id' or a pair 'from_token_id'/'to_token_id' is required."}
+     "Invalid parameter provided. `token_id` or a pair of `from_token_id` and `to_token_id` is required."}
   end
 end

--- a/apps/ewallet/lib/ewallet/gates/transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transaction_gate.ex
@@ -79,7 +79,7 @@ defmodule EWallet.TransactionGate do
   end
 
   def get_or_insert(_, _, _, _) do
-    {:error, :invalid_parameter, "'idempotency_token' is required."}
+    {:error, :invalid_parameter, "Invalid parameter provided. `idempotency_token` is required."}
   end
 
   def update_transaction(

--- a/apps/ewallet/lib/ewallet/helper.ex
+++ b/apps/ewallet/lib/ewallet/helper.ex
@@ -27,7 +27,7 @@ defmodule EWallet.Helper do
         {:ok, amount}
 
       _ ->
-        {:error, :invalid_parameter, "String number is not a valid number: '#{string}'."}
+        {:error, :invalid_parameter, "Invalid parameter provided. String number is not a valid number: '#{string}'."}
     end
   end
 
@@ -48,7 +48,7 @@ defmodule EWallet.Helper do
         formatted_strings = Enum.join(strings, ", ")
 
         {:error, :invalid_parameter,
-         "String numbers are not valid numbers: '#{formatted_strings}'."}
+         "Invalid parameter provided. String numbers are not valid numbers: '#{formatted_strings}'."}
 
       false ->
         amounts

--- a/apps/ewallet/lib/ewallet/helper.ex
+++ b/apps/ewallet/lib/ewallet/helper.ex
@@ -27,7 +27,8 @@ defmodule EWallet.Helper do
         {:ok, amount}
 
       _ ->
-        {:error, :invalid_parameter, "Invalid parameter provided. String number is not a valid number: '#{string}'."}
+        {:error, :invalid_parameter,
+         "Invalid parameter provided. String number is not a valid number: '#{string}'."}
     end
   end
 

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -144,7 +144,8 @@ defmodule EWallet.TransactionConsumptionValidator do
   end
 
   def validate_amount(_request, amount) do
-    {:error, :invalid_parameter, "Invalid parameter provided. `amount` is not an integer: #{amount}."}
+    {:error, :invalid_parameter,
+     "Invalid parameter provided. `amount` is not an integer: #{amount}."}
   end
 
   @spec get_and_validate_token(%TransactionRequest{}, String.t() | nil) ::

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -144,7 +144,7 @@ defmodule EWallet.TransactionConsumptionValidator do
   end
 
   def validate_amount(_request, amount) do
-    {:error, :invalid_parameter, "'amount' is not an integer: #{amount}."}
+    {:error, :invalid_parameter, "Invalid parameter provided. `amount` is not an integer: #{amount}."}
   end
 
   @spec get_and_validate_token(%TransactionRequest{}, String.t() | nil) ::

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -114,7 +114,8 @@ defmodule EWallet.TransactionConsumptionValidator do
           | {:error, :unauthorized_amount_override}
           | {:error, :invalid_parameter, String.t()}
   def validate_amount(%TransactionRequest{amount: nil} = _request, nil) do
-    {:error, :invalid_parameter, "'amount' is required for transaction consumption."}
+    {:error, :invalid_parameter,
+     "Invalid parameter provided. `amount` is required for transaction consumption."}
   end
 
   def validate_amount(%TransactionRequest{amount: _amount} = _request, nil) do
@@ -147,7 +148,7 @@ defmodule EWallet.TransactionConsumptionValidator do
           | {:error, atom(), String.t()}
   def get_and_validate_token(%TransactionRequest{token_uuid: nil} = _request, nil) do
     {:error, :invalid_parameter,
-     "'token_id' is required since the transaction request does not specify any."}
+     "Invalid parameter provided. `token_id` is required since the transaction request does not specify any."}
   end
 
   def get_and_validate_token(%TransactionRequest{token_uuid: _token_uuid} = request, nil) do

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -11,48 +11,48 @@ defmodule EWallet.Web.V1.ErrorHandler do
   @errors %{
     invalid_auth_scheme: %{
       code: "client:invalid_auth_scheme",
-      description: "The provided authentication scheme is not supported"
+      description: "The provided authentication scheme is not supported."
     },
     invalid_version: %{
       code: "client:invalid_version",
       description: "Invalid API version",
-      template: "Invalid API version Given: '%{accept}'."
+      template: "Invalid API version. Given: '%{accept}'."
     },
     unauthorized: %{
       code: "unauthorized",
-      description: "You are not allowed to perform the requested operation"
+      description: "You are not allowed to perform the requested operation."
     },
     invalid_parameter: %{
       code: "client:invalid_parameter",
-      description: "Invalid parameter provided"
+      description: "Invalid parameter provided."
     },
     invalid_api_key: %{
       code: "client:invalid_api_key",
-      description: "The provided API key can't be found or is invalid"
+      description: "The provided API key can't be found or is invalid."
     },
     endpoint_not_found: %{
       code: "client:endpoint_not_found",
-      description: "Endpoint not found"
+      description: "Endpoint not found."
     },
     internal_server_error: %{
       code: "server:internal_server_error",
-      description: "Something went wrong on the server"
+      description: "Something went wrong on the server."
     },
     unknown_error: %{
       code: "server:unknown_error",
-      description: "An unknown error occured on the server"
+      description: "An unknown error occured on the server."
     },
     account_not_found: %{
       code: "account:not_found",
-      description: "There is no user corresponding to the provided account id"
+      description: "There is no user corresponding to the provided account id."
     },
     auth_token_not_found: %{
       code: "user:auth_token_not_found",
-      description: "There is no account or user corresponding to the provided auth_token"
+      description: "There is no account or user corresponding to the provided auth_token."
     },
     auth_token_expired: %{
       code: "user:auth_token_expired",
-      description: "The provided token is expired or has been invalidated"
+      description: "The provided token is expired or has been invalidated."
     },
     insufficient_funds: %{
       code: "transaction:insufficient_funds",
@@ -64,7 +64,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
     inserted_transaction_could_not_be_loaded: %{
       code: "db:inserted_transaction_could_not_be_loaded",
       description:
-        "We could not load the transaction after insertion. Please try submitting the same transaction again (with identical idempontecy token!)."
+        "We could not load the transaction after insertion. Please try submitting the same transaction again (with identical idempontecy token)."
     },
     transaction_request_not_found: %{
       code: "transaction_request:transaction_request_not_found",
@@ -158,7 +158,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     token_not_found: %{
       code: "token:id_not_found",
-      description: "There is no token corresponding to the provided id"
+      description: "There is no token corresponding to the provided id."
     },
     from_token_not_found: %{
       code: "token:from_token_not_found",
@@ -170,71 +170,71 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     user_wallet_mismatch: %{
       code: "user:user_wallet_mismatch",
-      description: "The provided wallet does not belong to the current user"
+      description: "The provided wallet does not belong to the current user."
     },
     account_wallet_mismatch: %{
       code: "account:account_wallet_mismatch",
-      description: "The provided wallet does not belong to the given account"
+      description: "The provided wallet does not belong to the given account."
     },
     invalid_access_secret_key: %{
       code: "client:invalid_access_secret_key",
-      description: "Invalid access and/or secret key"
+      description: "Invalid access and/or secret key."
     },
     user_id_not_found: %{
       code: "user:id_not_found",
-      description: "There is no user corresponding to the provided id"
+      description: "There is no user corresponding to the provided id."
     },
     provider_user_id_not_found: %{
       code: "user:provider_user_id_not_found",
-      description: "There is no user corresponding to the provided provider_user_id"
+      description: "There is no user corresponding to the provided provider_user_id."
     },
     wallet_not_found: %{
       code: "wallet:wallet_not_found",
-      description: "There is no wallet corresponding to the provided address"
+      description: "There is no wallet corresponding to the provided address."
     },
     user_wallet_not_found: %{
       code: "user:wallet_not_found",
-      description: "There is no user wallet corresponding to the provided address"
+      description: "There is no user wallet corresponding to the provided address."
     },
     account_wallet_not_found: %{
       code: "account:wallet_not_found",
-      description: "There is no account wallet corresponding to the provided address"
+      description: "There is no account wallet corresponding to the provided address."
     },
     account_id_not_found: %{
       code: "user:account_id_not_found",
-      description: "There is no account corresponding to the provided account_id"
+      description: "There is no account corresponding to the provided account_id."
     },
     exchange_pair_id_not_found: %{
       code: "exchange:pair_id_not_found",
-      description: "There is no exchange pair corresponding to the provided id"
+      description: "There is no exchange pair corresponding to the provided id."
     },
     exchange_pair_not_found: %{
       code: "exchange:pair_not_found",
-      description: "There is no exchange pair corresponding to the provided tokens"
+      description: "There is no exchange pair corresponding to the provided tokens."
     },
     exchange_invalid_rate: %{
       code: "exchange:invalid_rate",
-      description: "The exchange is attempted with an invalid rate"
+      description: "The exchange is attempted with an invalid rate."
     },
     exchange_address_not_account: %{
       code: "exchange:exchange_wallet_not_owned_by_account",
-      description: "The specified exchange_wallet is not owned by an account"
+      description: "The specified exchange_wallet is not owned by an account."
     },
     exchange_account_id_not_found: %{
       code: "exchange:account_id_not_found",
-      description: "No account was found with the given exchange_account_id param"
+      description: "No account was found with the given exchange_account_id param."
     },
     exchange_client_not_allowed: %{
       code: "exchange:not_allowed",
-      description: "Exchange consumptions cannot be made through the client API"
+      description: "Exchange consumptions cannot be made through the client API."
     },
     exchange_account_wallet_not_found: %{
       code: "exchange:account_wallet_not_found",
-      description: "No wallet was found with the given exchange_wallet_address param"
+      description: "No wallet was found with the given exchange_wallet_address param."
     },
     exchange_account_wallet_mismatch: %{
       code: "exchange:account_wallet_mismatch",
-      description: "The given exchange wallet does not belong to the specified exchange account"
+      description: "The given exchange wallet does not belong to the specified exchange account."
     },
     request_already_contains_exchange: %{
       code: "consumption:request_already_contains_exchange_wallet",

--- a/apps/ewallet/test/ewallet/fetchers/account_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/account_fetcher_test.exs
@@ -168,7 +168,7 @@ defmodule EWallet.AccountFetcherTest do
 
       assert res ==
                {:error, :invalid_parameter,
-                "'exchange_account_id' or 'exchange_wallet_address' is required.'"}
+                "Invalid parameter provided. `exchange_account_id` or `exchange_wallet_address` is required.'"}
     end
 
     test "returns an error if from_token is not found" do
@@ -185,7 +185,7 @@ defmodule EWallet.AccountFetcherTest do
 
       assert res ==
                {:error, :invalid_parameter,
-                "'exchange_account_id' or 'exchange_wallet_address' is required.'"}
+                "Invalid parameter provided. `exchange_account_id` or `exchange_wallet_address` is required.'"}
     end
 
     test "returns an error if to_token is not found" do
@@ -202,7 +202,7 @@ defmodule EWallet.AccountFetcherTest do
 
       assert res ==
                {:error, :invalid_parameter,
-                "'exchange_account_id' or 'exchange_wallet_address' is required.'"}
+                "Invalid parameter provided. `exchange_account_id` or `exchange_wallet_address` is required.'"}
     end
   end
 
@@ -220,7 +220,7 @@ defmodule EWallet.AccountFetcherTest do
 
       assert res ==
                {:error, :invalid_parameter,
-                "'exchange_account_id' or 'exchange_wallet_address' is required.'"}
+                "Invalid parameter provided. `exchange_account_id` or `exchange_wallet_address` is required.'"}
     end
 
     test "returns an error when given only to_token_id" do
@@ -236,7 +236,7 @@ defmodule EWallet.AccountFetcherTest do
 
       assert res ==
                {:error, :invalid_parameter,
-                "'exchange_account_id' or 'exchange_wallet_address' is required.'"}
+                "Invalid parameter provided. `exchange_account_id` or `exchange_wallet_address` is required.'"}
     end
 
     test "returns an error with invalid params" do
@@ -244,7 +244,7 @@ defmodule EWallet.AccountFetcherTest do
 
       assert res ==
                {:error, :invalid_parameter,
-                "'exchange_account_id' or 'exchange_wallet_address' is required.'"}
+                "Invalid parameter provided. `exchange_account_id` or `exchange_wallet_address` is required.'"}
     end
   end
 end

--- a/apps/ewallet/test/ewallet/fetchers/amount_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/amount_fetcher_test.exs
@@ -20,7 +20,7 @@ defmodule EWallet.AmountFetcherTest do
 
       assert res ==
                {:error, :invalid_parameter,
-                "'amount' not allowed when exchanging values. Use from_amount and/or to_amount."}
+                "Invalid parameter provided. `amount` not allowed when exchanging values. Use `from_amount` and/or `to_amount`."}
     end
 
     test "sets the amount in from_amount and to_amount" do
@@ -65,7 +65,7 @@ defmodule EWallet.AmountFetcherTest do
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "'amount' is not an integer: 100.2"}
+      assert res == {:error, :invalid_parameter, "Invalid parameter provided. `amount` is not an integer: 100.2"}
     end
 
     test "returns an error if amount is not an integer (string)" do
@@ -78,7 +78,7 @@ defmodule EWallet.AmountFetcherTest do
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "String number is not a valid number: 'fake'."}
+      assert res == {:error, :invalid_parameter, "Invalid parameter provided. String number is not a valid number: 'fake'."}
     end
   end
 
@@ -297,7 +297,7 @@ defmodule EWallet.AmountFetcherTest do
         )
 
       assert res ==
-               {:error, :invalid_parameter, "String numbers are not valid numbers: 'fake, fake'."}
+               {:error, :invalid_parameter, "Invalid parameter provided. String numbers are not valid numbers: 'fake, fake'."}
     end
 
     test "returns an error when sending invalid from_amount" do
@@ -310,7 +310,7 @@ defmodule EWallet.AmountFetcherTest do
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "String number is not a valid number: 'fake'."}
+      assert res == {:error, :invalid_parameter, "Invalid parameter provided. String number is not a valid number: 'fake'."}
     end
 
     test "returns an error when sending invalid to_amount" do
@@ -323,7 +323,7 @@ defmodule EWallet.AmountFetcherTest do
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "String number is not a valid number: 'fake'."}
+      assert res == {:error, :invalid_parameter, "Invalid parameter provided. String number is not a valid number: 'fake'."}
     end
 
     test "returns an error when sending nil to_amount" do

--- a/apps/ewallet/test/ewallet/fetchers/amount_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/amount_fetcher_test.exs
@@ -65,7 +65,9 @@ defmodule EWallet.AmountFetcherTest do
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "Invalid parameter provided. `amount` is not an integer: 100.2"}
+      assert res ==
+               {:error, :invalid_parameter,
+                "Invalid parameter provided. `amount` is not an integer: 100.2"}
     end
 
     test "returns an error if amount is not an integer (string)" do
@@ -78,7 +80,9 @@ defmodule EWallet.AmountFetcherTest do
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "Invalid parameter provided. String number is not a valid number: 'fake'."}
+      assert res ==
+               {:error, :invalid_parameter,
+                "Invalid parameter provided. String number is not a valid number: 'fake'."}
     end
   end
 
@@ -297,7 +301,8 @@ defmodule EWallet.AmountFetcherTest do
         )
 
       assert res ==
-               {:error, :invalid_parameter, "Invalid parameter provided. String numbers are not valid numbers: 'fake, fake'."}
+               {:error, :invalid_parameter,
+                "Invalid parameter provided. String numbers are not valid numbers: 'fake, fake'."}
     end
 
     test "returns an error when sending invalid from_amount" do
@@ -310,7 +315,9 @@ defmodule EWallet.AmountFetcherTest do
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "Invalid parameter provided. String number is not a valid number: 'fake'."}
+      assert res ==
+               {:error, :invalid_parameter,
+                "Invalid parameter provided. String number is not a valid number: 'fake'."}
     end
 
     test "returns an error when sending invalid to_amount" do
@@ -323,7 +330,9 @@ defmodule EWallet.AmountFetcherTest do
           %{}
         )
 
-      assert res == {:error, :invalid_parameter, "Invalid parameter provided. String number is not a valid number: 'fake'."}
+      assert res ==
+               {:error, :invalid_parameter,
+                "Invalid parameter provided. String number is not a valid number: 'fake'."}
     end
 
     test "returns an error when sending nil to_amount" do

--- a/apps/ewallet/test/ewallet/fetchers/amount_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/amount_fetcher_test.exs
@@ -340,7 +340,8 @@ defmodule EWallet.AmountFetcherTest do
         )
 
       assert res ==
-               {:error, :invalid_parameter, "'amount', 'from_amount' or 'to_amount' is required."}
+               {:error, :invalid_parameter,
+                "Invalid parameter provided. `amount`, `from_amount` or `to_amount` is required."}
     end
   end
 
@@ -349,7 +350,8 @@ defmodule EWallet.AmountFetcherTest do
       res = AmountFetcher.fetch(%{}, %{}, %{})
 
       assert res ==
-               {:error, :invalid_parameter, "'amount', 'from_amount' or 'to_amount' is required."}
+               {:error, :invalid_parameter,
+                "Invalid parameter provided. `amount`, `from_amount` or `to_amount` is required."}
     end
   end
 end

--- a/apps/ewallet/test/ewallet/fetchers/token_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/token_fetcher_test.exs
@@ -114,7 +114,9 @@ defmodule EWallet.TokenFetcherTest do
 
       assert res == :error
       assert code == :invalid_parameter
-      assert desc == "'token_id' or a pair 'from_token_id'/'to_token_id' is required."
+
+      assert desc ==
+               "Invalid parameter provided. `token_id` or a pair of `from_token_id` and `to_token_id` is required."
     end
   end
 end

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_consumer_gate_test.exs
@@ -1324,7 +1324,9 @@ defmodule EWallet.TransactionConsumptionConsumerGateTest do
 
       assert res == :error
       assert code == :invalid_parameter
-      assert desc == "'amount' is required for transaction consumption."
+
+      assert desc ==
+               "Invalid parameter provided. `amount` is required for transaction consumption."
     end
 
     test "returns 'user_wallet_not_found' when address is invalid", meta do

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
@@ -75,8 +75,7 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
 
       serialized = TransactionSerializer.serialize(transaction)
       assert serialized[:error_code] == "exchange:invalid_rate"
-
-      assert serialized[:error_description] == "The exchange is attempted with an invalid rate"
+      assert serialized[:error_description] == "The exchange is attempted with an invalid rate."
     end
 
     test "serializes the error description properly" do

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/fallback_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/fallback_controller_test.exs
@@ -9,7 +9,7 @@ defmodule EWalletAPI.V1.FallbackControllerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:endpoint_not_found",
-          "description" => "Endpoint not found",
+          "description" => "Endpoint not found.",
           "messages" => nil
         }
       }

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
@@ -551,7 +551,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided",
+                 "description" => "Invalid parameter provided.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_controller_test.exs
@@ -226,7 +226,7 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "'idempotency_token' is required.",
+                 "description" => "Invalid parameter provided. `idempotency_token` is required.",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -473,7 +473,7 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "token:id_not_found",
-                 "description" => "There is no token corresponding to the provided id",
+                 "description" => "There is no token corresponding to the provided id.",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -515,7 +515,7 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided",
+                 "description" => "Invalid parameter provided.",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -596,7 +596,7 @@ defmodule EWalletAPI.V1.TransactionControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "'token_id' or a pair 'from_token_id'/'to_token_id' is required."
+               "Invalid parameter provided. `token_id` or a pair of `from_token_id` and `to_token_id` is required."
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -186,7 +186,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "client:invalid_parameter",
-                 "description" => "Invalid parameter provided `type` is invalid.",
+                 "description" => "Invalid parameter provided. `type` is invalid.",
                  "messages" => %{"type" => ["inclusion"]},
                  "object" => "error"
                }
@@ -210,7 +210,8 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "user:wallet_not_found",
-                 "description" => "There is no user wallet corresponding to the provided address",
+                 "description" =>
+                   "There is no user wallet corresponding to the provided address.",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -235,7 +236,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "user:user_wallet_mismatch",
-                 "description" => "The provided wallet does not belong to the current user",
+                 "description" => "The provided wallet does not belong to the current user.",
                  "messages" => nil,
                  "object" => "error"
                }
@@ -257,7 +258,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                "version" => "1",
                "data" => %{
                  "code" => "token:id_not_found",
-                 "description" => "There is no token corresponding to the provided id",
+                 "description" => "There is no token corresponding to the provided id.",
                  "messages" => nil,
                  "object" => "error"
                }

--- a/apps/ewallet_api/test/ewallet_api/v1/error_handler_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/error_handler_test.exs
@@ -23,7 +23,7 @@ defmodule EWalletAPI.V1.ErrorHandlerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_parameter",
-          "description" => "Invalid parameter provided",
+          "description" => "Invalid parameter provided.",
           "messages" => nil
         }
       }
@@ -49,7 +49,7 @@ defmodule EWalletAPI.V1.ErrorHandlerTest do
           "object" => "error",
           "code" => "client:invalid_parameter",
           "description" =>
-            "Invalid parameter provided" <>
+            "Invalid parameter provided." <>
               " `field2` can't be blank." <> " `field3` can't be blank.",
           "messages" => %{
             "field2" => ["required"],
@@ -73,7 +73,7 @@ defmodule EWalletAPI.V1.ErrorHandlerTest do
         "data" => %{
           "object" => "error",
           "code" => "client:invalid_version",
-          "description" => "Invalid API version Given: 'invalid_header'.",
+          "description" => "Invalid API version. Given: 'invalid_header'.",
           "messages" => nil
         }
       }

--- a/apps/ewallet_api/test/ewallet_api/versioned_router_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/versioned_router_test.exs
@@ -22,7 +22,7 @@ defmodule EWalletAPI.VersionedRouterTest do
           "object" => "error",
           "code" => "client:invalid_version",
           "description" =>
-            "Invalid API version Given: 'application/vnd.omisego.invalid_ver+json'.",
+            "Invalid API version. Given: 'application/vnd.omisego.invalid_ver+json'.",
           "messages" => nil
         }
       }


### PR DESCRIPTION
Closes #418.

# Overview

Add full stops to error descriptions that are missing them + one grammar typo

# Changes

- Updated `AdminAPI.V1.ErrorHandler`

# Implementation Details

N/A

# Usage

N/A

# Impact

Some error description strings are updated. No changes to DB or API format.