### PR TITLE
Fix log error for websocket

### DIFF
--- a/apps/admin_panel/assets/src/socket/connector.js
+++ b/apps/admin_panel/assets/src/socket/connector.js
@@ -1,7 +1,4 @@
-import {
-  appendParams,
-  isAbsoluteURL
-} from '../utils/url'
+import { appendParams, isAbsoluteURL } from '../utils/url'
 import urlJoin from 'url-join'
 import _ from 'lodash'
 import CONSTANT from '../constants'
@@ -178,12 +175,7 @@ class SocketConnector {
   leaveChannel = channel => {
     this.send(this.createLeaveChannelPayload(channel))
   }
-  createPayload = ({
-    topic,
-    event,
-    type,
-    data = {}
-  }) => {
+  createPayload = ({ topic, event, type, data = {} }) => {
     const payload = {
       topic,
       event,

--- a/apps/admin_panel/assets/src/socket/connector.js
+++ b/apps/admin_panel/assets/src/socket/connector.js
@@ -1,4 +1,7 @@
-import { appendParams, isAbsoluteURL } from '../utils/url'
+import {
+  appendParams,
+  isAbsoluteURL
+} from '../utils/url'
 import urlJoin from 'url-join'
 import _ from 'lodash'
 import CONSTANT from '../constants'
@@ -162,7 +165,11 @@ class SocketConnector {
       const payload = this.createJoinChannelPayload(channel)
       this.queue.push(payload)
       try {
-        this.send(payload)
+        if (!this.socket) {
+          console.log(`attempt to join channel : ${channel} when socket is not initialized, added to queue.`)
+        } else {
+          this.send(payload)
+        }
       } catch (error) {
         console.warn('something went wrong while joining channel with error', error)
       }
@@ -171,7 +178,12 @@ class SocketConnector {
   leaveChannel = channel => {
     this.send(this.createLeaveChannelPayload(channel))
   }
-  createPayload = ({ topic, event, type, data = {} }) => {
+  createPayload = ({
+    topic,
+    event,
+    type,
+    data = {}
+  }) => {
     const payload = {
       topic,
       event,


### PR DESCRIPTION
Issue/Task Number: #420 

# Overview

This PR fix websocket log connection error when connecting to websocket too fast.

# Changes

- handle case socket not init.

# Usage

Open browser first time, login and see logs saying websocket will be queued if socket is not connected yet.

# Impact

Deploy as usual.
