### PR TITLE
Fix unencoded email invite url

### DIFF
--- a/apps/admin_api/lib/admin_api/emails/forget_password_email.ex
+++ b/apps/admin_api/lib/admin_api/emails/forget_password_email.ex
@@ -9,7 +9,7 @@ defmodule AdminAPI.ForgetPasswordEmail do
 
     link =
       redirect_url
-      |> String.replace("{email}", request.user.email)
+      |> String.replace("{email}", URI.encode_www_form(request.user.email))
       |> String.replace("{token}", request.token)
 
     new_email()

--- a/apps/admin_api/lib/admin_api/invites/invite_email.ex
+++ b/apps/admin_api/lib/admin_api/invites/invite_email.ex
@@ -9,7 +9,7 @@ defmodule AdminAPI.InviteEmail do
 
     link =
       redirect_url
-      |> String.replace("{email}", invite.user.email)
+      |> String.replace("{email}", URI.encode_www_form(invite.user.email))
       |> String.replace("{token}", invite.token)
 
     new_email()

--- a/apps/admin_api/test/admin_api/emails/forget_password_email_test.exs
+++ b/apps/admin_api/test/admin_api/emails/forget_password_email_test.exs
@@ -3,34 +3,50 @@ defmodule AdminAPI.ForgetPasswordEmailTest do
   alias AdminAPI.ForgetPasswordEmail
   alias EWalletDB.ForgetPasswordRequest
 
-  setup do
-    user = insert(:user, email: "example@mail.com")
-    _request = insert(:forget_password_request, token: "the_token", user_uuid: user.uuid)
-    request = ForgetPasswordRequest.get(user, "the_token")
+  defp create_email(email, token) do
+    user = insert(:user, email: email)
+    _request = insert(:forget_password_request, token: token, user_uuid: user.uuid)
+    request = ForgetPasswordRequest.get(user, token)
     email = ForgetPasswordEmail.create(request, "https://reset_url/?email={email}&token={token}")
 
-    %{user: user, request: request, email: email}
+    email
   end
 
   describe "ForgetPasswordEmail.create/2" do
-    test "creates an email with correct from and to addresses", meta do
+    test "creates an email with correct from and to addresses" do
+      email = create_email("forgetpassword@example.com", "the_token")
+
       # `from` should be the one set in the config
-      assert meta.email.from == Application.get_env(:admin_api, :sender_email)
+      assert email.from == Application.get_env(:admin_api, :sender_email)
 
       # `to` should be the user's email
-      assert meta.email.to == meta.user.email
+      assert email.to == "forgetpassword@example.com"
     end
 
-    test "creates an email with non-empty subject", meta do
-      assert String.length(meta.email.subject) > 0
+    test "creates an email with non-empty subject" do
+      email = create_email("forgetpassword@example.com", "the_token")
+      assert String.length(email.subject) > 0
     end
 
-    test "creates an email with email and token in the html body", meta do
-      assert meta.email.html_body =~ "https://reset_url/?email=example@mail.com&token=the_token"
+    test "creates an email with email and token in the html body" do
+      email = create_email("forgetpassword@example.com", "the_token")
+
+      assert email.html_body =~
+               "https://reset_url/?email=forgetpassword%40example.com&token=the_token"
     end
 
-    test "creates an email with email and token in the text body", meta do
-      assert meta.email.text_body =~ "https://reset_url/?email=example@mail.com&token=the_token"
+    test "creates an email with email and token in the text body" do
+      email = create_email("forgetpassword@example.com", "the_token")
+
+      assert email.text_body =~
+               "https://reset_url/?email=forgetpassword%40example.com&token=the_token"
+    end
+
+    test "creates an email with properly encoded plus sign" do
+      email = create_email("forgetpassword+test@example.com", "the_token")
+
+      assert email.html_body =~
+               "https://reset_url/?email=forgetpassword%2Btest%40example.com&token=the_token"
     end
   end
 end

--- a/apps/admin_api/test/admin_api/invites/invite_email_test.exs
+++ b/apps/admin_api/test/admin_api/invites/invite_email_test.exs
@@ -14,28 +14,35 @@ defmodule AdminAPI.InviteEmailTest do
 
   describe "InviteEmail.create/2" do
     test "creates an email with correct from and to addresses" do
-      email = create_email("test@omise.co", "the_token")
+      email = create_email("test@example.com", "the_token")
 
       # `from` should be the one set in the config
       assert email.from == Application.get_env(:admin_api, :sender_email)
 
       # `to` should be the user's email
-      assert email.to == "test@omise.co"
+      assert email.to == "test@example.com"
     end
 
     test "creates an email with non-empty subject" do
-      email = create_email("test@omise.co", "the_token")
+      email = create_email("test@example.com", "the_token")
       assert String.length(email.subject) > 0
     end
 
     test "creates an email with email and token in the html body" do
-      email = create_email("test@omise.co", "the_token")
-      assert email.html_body =~ "https://invite_url/?email=test@omise.co&token=the_token"
+      email = create_email("test@example.com", "the_token")
+      assert email.html_body =~ "https://invite_url/?email=test%40example.com&token=the_token"
     end
 
     test "creates an email with email and token in the text body" do
-      email = create_email("test@omise.co", "the_token")
-      assert email.text_body =~ "https://invite_url/?email=test@omise.co&token=the_token"
+      email = create_email("test@example.com", "the_token")
+      assert email.text_body =~ "https://invite_url/?email=test%40example.com&token=the_token"
+    end
+
+    test "creates an email with properly encoded plus sign" do
+      email = create_email("test+plus@example.com", "the_token")
+
+      assert email.text_body =~
+               "https://invite_url/?email=test%2Bplus%40example.com&token=the_token"
     end
   end
 end


### PR DESCRIPTION
Closes #425 

# Overview

Encodes the email address before putting it into the `redirect_url`.

# Changes

- Do a `URI.encode_www_form/1` before replacing the email address into the `redirect_url`.
- Changed test email addresses to `@example.com` to be more neutral
- Changed `ForgetPasswordEmailTest` to use `create_email/2` instead of `setup()` so different emails can be tested

# Implementation Details

N/A

# Usage

Invite a new admin user or forget password from an email with `+` sign. The password should be able to set successfully with the url in the email.

# Impact

No changes to the API or DB.