### PR TITLE
Fix Elixir 1.7.0 warnings

### DIFF
--- a/apps/admin_api/mix.exs
+++ b/apps/admin_api/mix.exs
@@ -16,7 +16,7 @@ defmodule AdminAPI.Mixfile do
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test

--- a/apps/admin_panel/mix.exs
+++ b/apps/admin_panel/mix.exs
@@ -16,7 +16,7 @@ defmodule AdminPanel.Mixfile do
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test

--- a/apps/ewallet/mix.exs
+++ b/apps/ewallet/mix.exs
@@ -16,7 +16,7 @@ defmodule EWallet.Mixfile do
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test

--- a/apps/ewallet_api/mix.exs
+++ b/apps/ewallet_api/mix.exs
@@ -16,7 +16,7 @@ defmodule EWalletAPI.Mixfile do
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test

--- a/apps/ewallet_db/mix.exs
+++ b/apps/ewallet_db/mix.exs
@@ -15,7 +15,7 @@ defmodule EWalletDB.Mixfile do
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test
@@ -76,7 +76,7 @@ defmodule EWalletDB.Mixfile do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      "test": ["ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
 end

--- a/apps/local_ledger/mix.exs
+++ b/apps/local_ledger/mix.exs
@@ -14,7 +14,7 @@ defmodule LocalLedger.Mixfile do
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test

--- a/apps/local_ledger_db/mix.exs
+++ b/apps/local_ledger_db/mix.exs
@@ -15,7 +15,7 @@ defmodule LocalLedgerDB.Mixfile do
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test

--- a/apps/url_dispatcher/mix.exs
+++ b/apps/url_dispatcher/mix.exs
@@ -14,7 +14,7 @@ defmodule UrlDispatcher.Mixfile do
       start_permanent: Mix.env == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test


### PR DESCRIPTION
Issue/Task Number: 431
closes #431

# Overview

This PR removes the warnings that came with the new version of Elixir (1.7.0).

# Changes

- Fix quoted atoms which were raising warnings
