### PR TITLE
add account id based on wallet

### DIFF
--- a/apps/admin_panel/assets/src/omg-create-transaction-request-modal/index.js
+++ b/apps/admin_panel/assets/src/omg-create-transaction-request-modal/index.js
@@ -119,8 +119,8 @@ class CreateTransactionRequest extends Component {
         type: this.state.type ? 'send' : 'receive',
         amount: formatAmount(this.state.amount, _.get(this.state.selectedToken, 'subunit_to_unit')),
         tokenId: _.get(this.state, 'selectedToken.id'),
-        address: _.get(this.state, 'selectedWallet.id', this.props.primaryWallet.address),
-        accountId: this.props.match.params.accountId,
+        address: this.state.address || _.get(this.props, 'primaryWallet.address'),
+        accountId: _.get(this.state, 'selectedWallet.account_id'),
         expirationDate: this.state.expirationDate
           ? moment(this.state.expirationDate).toISOString()
           : null
@@ -160,7 +160,7 @@ class CreateTransactionRequest extends Component {
     this.setState({ address: wallet.address, selectedWallet: wallet })
   }
   onSelectExchangeWallet = exchangeWallet => {
-    this.setState({ exchangeAddress: exchangeWallet.address, selectedWallet: exchangeWallet })
+    this.setState({ exchangeAddress: exchangeWallet.address })
   }
   onDateTimeChange = date => {
     this.setState({ expirationDate: date.format('DD/MM/YYYY hh:mm:ss') })


### PR DESCRIPTION
Issue/Task Number: #458 

# Overview

When creating transaction request, the wallet form doesn't really work even choosing a wallet. 


# Changes

- Fix the submitted wallet id

# Usage

Try creating transaction request with a wallet.

# Impact

Deploy as usual.
