### PR TITLE
Preload all required fields for consumptions

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -25,7 +25,39 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
   def always_embed, do: [:token]
 
   @mapped_fields %{"created_at" => "inserted_at"}
-  @preload_fields [:account, :user, :wallet, :token, :transaction_request, :transaction]
+  @preload_fields [
+    :account,
+    :user,
+    :wallet,
+    :token,
+    :exchange_account,
+    account: [:categories],
+    exchange_account: [:categories],
+    transaction: [
+      :from_token,
+      :to_token,
+      :exchange_pair,
+      :to_wallet,
+      :from_wallet,
+      :from_account,
+      :to_account,
+      :from_user,
+      :to_user,
+      :exchange_account,
+      :exchange_wallet,
+      from_account: [:categories],
+      to_account: [:categories],
+      exchange_account: [:categories]
+    ],
+    transaction_request: [
+      :consumptions,
+      :token,
+      :user,
+      :exchange_wallet,
+      account: [:categories],
+      exchange_account: [:categories]
+    ]
+  ]
   @search_fields [:id, :status, :correlation_id, :idempotency_token]
   @sort_fields [
     :id,


### PR DESCRIPTION
Issue/Task Number: 460

# Overview

This is a small fix to improve the performances of consumption loading. It was slowed down due to the huge amount of data loaded to have accurate consumptions. Preloading fixes the problem, but the overall preloading handling should be refactored in a cleaner way.

I'm thinking we might want to put the actual list of fields to preload in the serializers, and build the final list for an endpoint depending on which serializer it uses (and the ones nested under it).

# Changes

- Preload everything for consumptions.