### PR TITLE
Fix inviting a user failing on the 2nd time

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
@@ -103,7 +103,7 @@ defmodule AdminAPI.V1.AccountMembershipController do
       :pending_confirmation ->
         user
         |> User.get_invite()
-        |> Inviter.send_email(redirect_url, InviteEmail)
+        |> Inviter.send_email(redirect_url, &InviteEmail.create/2)
 
       :active ->
         Membership.assign(user, account, role)

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_membership_controller_test.exs
@@ -212,6 +212,37 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
       assert response["data"] == %{}
     end
 
+    test "returns empty success if the user has a pending confirmation" do
+      email = "user_pending_confirmation@example.com"
+      account = insert(:account)
+      role = insert(:role)
+
+      response =
+        provider_request("/account.assign_user", %{
+          email: email,
+          account_id: account.id,
+          role_name: role.name,
+          redirect_url: @redirect_url
+        })
+
+      # Make sure that the first attemps created the user with pending_confirmation status
+      assert response["success"] == true
+      user = User.get_by(email: email)
+      assert User.get_status(user) == :pending_confirmation
+
+      response =
+        provider_request("/account.assign_user", %{
+          email: email,
+          account_id: account.id,
+          role_name: role.name,
+          redirect_url: @redirect_url
+        })
+
+      # The second attempt should also be successful
+      assert response["success"] == true
+      assert response["data"] == %{}
+    end
+
     test "returns an error if the email format is invalid" do
       response =
         provider_request("/account.assign_user", %{


### PR DESCRIPTION
Closes #465

# Overview

This PR fixes the issue when a user invitation fails if the invite is retried. This would happen when an admin invites a user, did not receive the email or wants to resend the invitation for other reasons, the admin would receive an error instead.

# Changes

- Fixed the `Inviter.send_email/2` receiving a module instead of the email template function

# Implementation Details

N/A

# Usage

Try to invite a new user via the admin panel, then invite the same user for the second time, the invite should be successful now.

# Impact

No DB or API changes.