### PR TITLE
URI encode the email address before rendering in the verification email

### DIFF
--- a/apps/ewallet_api/lib/ewallet_api/emails/verification_email.ex
+++ b/apps/ewallet_api/lib/ewallet_api/emails/verification_email.ex
@@ -11,7 +11,7 @@ defmodule EWalletAPI.VerificationEmail do
 
     link =
       redirect_url
-      |> String.replace("{email}", invite.user.email)
+      |> String.replace("{email}", URI.encode_www_form(invite.user.email))
       |> String.replace("{token}", invite.token)
 
     new_email()


### PR DESCRIPTION
Closes #467 

# Overview

The emails are already encoded in `InviteEmail` and `ForgetPasswordEmail` in #426, but not for `VerificationEmail`. This PR adds the email encoding to `VerificationEmail`.

# Changes

- Encode the user's email with `URI.encode_www_form/1` before rendering it in the verification email

# Implementation Details

N/A

# Usage

Try `/api/client/user.signup` with standalone mode enabled. Signing up with emails containing `+` sign should be able to verify their email address successfully.

For example, sign up with the following curl command, then navigate to the verification url provided in the email.

```sh
curl http://localhost:4000/api/client/user.signup -H "Accept: application/vnd.omisego.v1+json" -H "Content-Type: application/json" -d '{
"email": "testinvite+afterplus@example.com",
"password": "password",
"password_confirmation": "password"
}' -v -w "\n" | jq
```

# Impact

No API or DB changes.