### PR TITLE
Fix prefill address bug

### DIFF
--- a/apps/admin_panel/assets/src/omg-create-transaction-modal/index.js
+++ b/apps/admin_panel/assets/src/omg-create-transaction-modal/index.js
@@ -109,11 +109,6 @@ class CreateTransaction extends Component {
   }
   state = { fromAddress: this.props.fromAddress || '', toAddress: '' }
 
-  componentWillReceiveProps = nextProps => {
-    if (this.state.fromAddress !== nextProps.fromAddress && nextProps.fromAddress !== undefined) {
-      this.setState({ fromAddress: nextProps.fromAddress })
-    }
-  }
   onChangeInputFromAddress = e => {
     this.setState({
       fromAddress: e.target.value,

--- a/apps/admin_panel/assets/src/omg-page-users/index.js
+++ b/apps/admin_panel/assets/src/omg-page-users/index.js
@@ -90,6 +90,7 @@ class UsersPage extends Component {
   getColumns = () => {
     return [
       { key: 'id', title: 'ID', sort: true },
+      { key: 'email', title: 'EMAIL', sort: true },
       { key: 'username', title: 'USERNAME', sort: true },
       { key: 'created_at', title: 'CREATED DATE', sort: true },
       { key: 'updated_at', title: 'LAST UPDATED', sort: true },
@@ -114,6 +115,9 @@ class UsersPage extends Component {
           <Icon name='Profile' /> <span>{data}</span> <Copy data={data} />
         </UserIdContainer>
       )
+    }
+    if (key === 'email') {
+      return data || '-'
     }
 
     return data


### PR DESCRIPTION
Issue/Task Number: #470 

# Overview

When trying to transfer with pre-fill address of transaction modal, you cannot change that address due to react component lifecycle.

# Changes

- Fix prefill address bug
- Add email field in user

# Usage

Go to transfer modal from address detail page, and change address after pre-fill address.

# Impact

Deploy as usual.
