### PR TITLE
Fix admin not being able to login after accepting the invitation

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/invite_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/invite_controller.ex
@@ -3,7 +3,7 @@ defmodule AdminAPI.V1.InviteController do
   import AdminAPI.V1.ErrorHandler
   alias AdminAPI.V1.UserView
   alias EWallet.Web.Preloader
-  alias EWalletDB.Invite
+  alias EWalletDB.{Invite, User}
 
   @doc """
   Validates the user's invite token and activates the user.
@@ -18,7 +18,8 @@ defmodule AdminAPI.V1.InviteController do
     with %Invite{} = invite <- Invite.get(email, token) || {:error, :invite_not_found},
          true <- password == password_confirmation || {:error, :passwords_mismatch},
          {:ok, invite} <- Preloader.preload_one(invite, :user),
-         {:ok, _} <- Invite.accept(invite, password) do
+         {:ok, _} <- Invite.accept(invite, password),
+         {:ok, _} <- User.set_admin(invite.user, true) do
       render(conn, UserView, :user, %{user: invite.user})
     else
       {:error, error_code} when is_atom(error_code) ->

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -452,6 +452,16 @@ defmodule EWalletDB.User do
   end
 
   @doc """
+  Sets the user's admin status.
+  """
+  @spec set_admin(%User{}, boolean()) :: {:ok, %User{}} | {:error, Ecto.Changeset.t()}
+  def set_admin(user, boolean) do
+    user
+    |> change(is_admin: boolean)
+    |> Repo.update()
+  end
+
+  @doc """
   Checks if the user is an admin user.
   """
   @spec admin?(String.t() | %User{}) :: boolean()

--- a/apps/ewallet_db/test/ewallet_db/user_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/user_test.exs
@@ -283,6 +283,24 @@ defmodule EWalletDB.UserTest do
     end
   end
 
+  describe "set_admin/2" do
+    test "sets the user to admin status when given true" do
+      user = insert(:user)
+      refute User.admin?(user)
+
+      {:ok, user} = User.set_admin(user, true)
+      assert User.admin?(user)
+    end
+
+    test "sets the user to non-admin status when given false" do
+      user = insert(:admin)
+      assert User.admin?(user)
+
+      {:ok, user} = User.set_admin(user, false)
+      refute User.admin?(user)
+    end
+  end
+
   describe "admin?/1" do
     test "returns true if the user's `is_admin` is true" do
       user = insert(:user, is_admin: true)


### PR DESCRIPTION
Closes #472 

# Overview

This PR fixes the issue where an admin could not login after the invitation has been accepted.

# Changes

- Added a step so that user's `is_admin` flag is set to `true` right after the invitation is successfully accepted.

# Implementation Details

N/A

# Usage

Invite a new admin and follow the email verification process. After the email is verified successfully the admin should be able to login to the Admin Panel.

# Impact

No changes to the DB or API.