### PR TITLE
Streamline docker setup guide

### DIFF
--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -1,14 +1,12 @@
 # Docker setup
 
-You can setup the eWallet server using either Docker Compose or roll your own Docker environment with our pre-built Docker image.
+You can setup the eWallet server using either 1) Docker Compose or 2) roll your own Docker environment with our pre-built Docker image.
 
-## Step 1: Set up the server
+## Option 1: Using Docker Compose
 
-### 1a: Quick start with Docker Compose
+Install [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/).
 
-_Prerequisite: You will need [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/) installed._
-
-First, create your `docker-compose.yml` file using the following script:
+Then, create your `docker-compose.yml` file using the following script.
 
 ```yaml
 version: "3"
@@ -34,6 +32,7 @@ services:
       - internal
 
   ewallet:
+    container_name: docker-local-ewallet
     image: omisego/ewallet:v1.0.0
     restart: always
     networks:
@@ -59,79 +58,65 @@ volumes:
   postgres-db:
 ```
 
-Notice that the values for `EWALLET_SECRET_KEY` and `LOCAL_LEDGER_SECRET_KEY` are missing. You can generate these secret keys by running:
+Notice that the values for `EWALLET_SECRET_KEY` and `LOCAL_LEDGER_SECRET_KEY` are missing. Replace the values with your own generated ones. We recommend that you generate a different secret key for each, using the command below:
 
 ```
 $ openssl rand -base64 32
 ```
 
-Replace the `EWALLET_SECRET_KEY` and `LOCAL_LEDGER_SECRET_KEY` values in your `docker-compose.yml` with the generated keys
-
-Then, run the following command to create and start the containers:
+Once the `EWALLET_SECRET_KEY` and `LOCAL_LEDGER_SECRET_KEY` are replaced, run the following command to create and start the containers:
 
 ```bash
 $ docker-compose up -d
 ```
 
-### 1b: Using the pre-built Docker image
-
-Alternatively, to get the Docker image running without docker-compose would be (assuming [PostgreSQL](https://hub.docker.com/_/postgres/) is already setup):
+The eWallet should now be running in the background. If you see database errors, this is normal. Create and seed the database using the command below:
 
 ```bash
-# Pulls the omisego/ewallet image from https://hub.docker.com/r/omisego/ewallet/
-$ docker run \
-    -e DATABASE_URL="postgresql://postgres@127.0.0.1:5432/ewallet" \
-    -e LOCAL_LEDGER_DATABASE_URL="postgresql://postgres@127.0.0.1:5432/local_ledger" \
-    -p 4000:4000 \
-    omisego/ewallet:v1.0.0
+$ docker exec -it docker-local-ewallet env MIX_ENV=prod mix do local.hex --force, local.rebar --force, ecto.create, ecto.migrate, seed --sample
 ```
 
-The command above pulls the v1.0.0 image. If you wish, you can pick [other available tags from the Docker Hub](https://hub.docker.com/r/omisego/ewallet/tags/).
-
-## Step 2: Setup and seed the databases
-
-Run the following command to setup the database:
-
-```bash
-$ docker exec -it <container-id> \
-  env MIX_ENV=prod mix do \
-  local.hex --force, local.rebar --force, \
-  ecto.create, ecto.migrate
-```
-
-Some initial data is required to start the server. Either run the seed or the sample seed below:
-
-```bash
-# Option 2a: Run this command to set up the initial data
-$ docker exec -it <container-id> env MIX_ENV=prod mix seed
-
-# Option 2b: Run this command to set up the initial data and populate the database with more sample data
-$ docker exec -it <container-id> env MIX_ENV=prod mix seed --sample
-```
-
-## Step 3: Start the server
-
-Start the server using the following command:
-
-```bash
-$ docker exec <container-id> mix omg.server
-```
-
-You should see the following output:
-
-```elixir
-[info] Setting up websockets dispatchers...
-[info] Running UrlDispatcher.Plug with Cowboy http on port 4000
-```
-
-You can now access your eWallet server using the available APIs:
+You should now be able to access your eWallet server using the available APIs:
 
 ```bash
 $ curl http://localhost:4000
 {"status": true}
 ```
 
-### Next step
+## Option 2: Using pre-built Docker image
+
+To get the Docker image running without docker-compose would be (assuming [PostgreSQL](https://hub.docker.com/_/postgres/) is already setup):
+
+```bash
+# Pulls the omisego/ewallet image from https://hub.docker.com/r/omisego/ewallet/
+$ docker run \
+    --name docker-local-ewallet \
+    -e DATABASE_URL="postgresql://postgres@127.0.0.1:5432/ewallet" \
+    -e LOCAL_LEDGER_DATABASE_URL="postgresql://postgres@127.0.0.1:5432/local_ledger" \
+    -p 4000:4000 \
+    omisego/ewallet:v1.0.0
+```
+
+The command above pulls and starts an eWallet server with the v1.0.0 image. If you wish, you can pick [other available tags from the Docker Hub](https://hub.docker.com/r/omisego/ewallet/tags/).
+
+Now run the following command to setup and seed the database:
+
+```bash
+$ docker exec -it docker-local-ewallet \
+  env MIX_ENV=prod mix do \
+  local.hex --force, local.rebar --force, \
+  ecto.create, ecto.migrate, \
+  seed --sample
+```
+
+You should now be able to access your eWallet server using the available APIs:
+
+```bash
+$ curl http://localhost:4000
+{"status": true}
+```
+
+## Next step
 
 Read the [Documentation](/README.md/#documentation) to learn more and start using your eWallet!
 

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -32,7 +32,6 @@ services:
       - internal
 
   ewallet:
-    container_name: docker-local-ewallet
     image: omisego/ewallet:v1.0.0
     restart: always
     networks:
@@ -71,10 +70,13 @@ Once the `EWALLET_SECRET_KEY` and `LOCAL_LEDGER_SECRET_KEY` are replaced, run th
 $ docker-compose up -d
 ```
 
-The eWallet should now be running in the background. If you see database errors, this is normal. Create and seed the database using the command below:
+The eWallet should now be running in the background. Create and seed the database using the command below:
 
 ```bash
-$ docker exec -it docker-local-ewallet env MIX_ENV=prod mix do local.hex --force, local.rebar --force, ecto.create, ecto.migrate, seed --sample
+$ docker exec -it $(docker ps --filter ancestor="omisego/ewallet:v1.0.0" --format "{{.Names}}") \
+  env MIX_ENV=prod mix do \
+  local.hex --force, local.rebar --force, \
+  ecto.create, ecto.migrate, seed --sample
 ```
 
 You should now be able to access your eWallet server using the available APIs:
@@ -91,7 +93,6 @@ To get the Docker image running without docker-compose would be (assuming [Postg
 ```bash
 # Pulls the omisego/ewallet image from https://hub.docker.com/r/omisego/ewallet/
 $ docker run \
-    --name docker-local-ewallet \
     -e DATABASE_URL="postgresql://postgres@127.0.0.1:5432/ewallet" \
     -e LOCAL_LEDGER_DATABASE_URL="postgresql://postgres@127.0.0.1:5432/local_ledger" \
     -p 4000:4000 \
@@ -100,14 +101,13 @@ $ docker run \
 
 The command above pulls and starts an eWallet server with the v1.0.0 image. If you wish, you can pick [other available tags from the Docker Hub](https://hub.docker.com/r/omisego/ewallet/tags/).
 
-Now run the following command to setup and seed the database:
+If you see database errors at this step, this is normal. Now run the following command to setup and seed the database:
 
 ```bash
-$ docker exec -it docker-local-ewallet \
+$ docker exec -it $(docker ps --filter ancestor="omisego/ewallet:v1.0.0" --format "{{.Names}}") \
   env MIX_ENV=prod mix do \
   local.hex --force, local.rebar --force, \
-  ecto.create, ecto.migrate, \
-  seed --sample
+  ecto.create, ecto.migrate, seed --sample
 ```
 
 You should now be able to access your eWallet server using the available APIs:

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -58,10 +58,11 @@ volumes:
   postgres-db:
 ```
 
-Notice that the values for `EWALLET_SECRET_KEY` and `LOCAL_LEDGER_SECRET_KEY` are missing. Replace the values with your own generated ones. We recommend that you generate a different secret key for each, using the command below:
+Notice that the values for `EWALLET_SECRET_KEY` and `LOCAL_LEDGER_SECRET_KEY` are missing. Replace the values with your own generated ones. We recommend that you generate a different secret key for each. The commands below will generate the keys and replace them automatically:
 
 ```
-$ openssl rand -base64 32
+$ sed -i -e "s/<ewallet_secret_key_here>/$(openssl rand -base64 32 | sed 's/\//\\\//g')/" docker-compose.yml
+$ sed -i -e "s/<local_ledger_secret_key_here>/$(openssl rand -base64 32 | sed 's/\//\\\//g')/" docker-compose.yml
 ```
 
 Once the `EWALLET_SECRET_KEY` and `LOCAL_LEDGER_SECRET_KEY` are replaced, run the following command to create and start the containers:


### PR DESCRIPTION
Closes #442

# Overview

This PR streamlines the docker setup guide as per feedbacks from the various workshops, #439 and #442.

# Changes

- Updated docker setup guide

# Implementation Details

Before, the guide branches off at step one for the user to pick between docker compose and plain docker, then they converge back in step 2. This is difficult to follow so now the option branches off right at the beginning and there's no convergence in the middle.

The commands have so been updated with more default values to make the setup easier.

# Usage

Follow the commands in the changed guide.

# Impact

Changes to user documentation only.