### PR TITLE
Fix error handling of /transaction.calculate

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/tranasction_calculation_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/tranasction_calculation_controller.ex
@@ -18,6 +18,9 @@ defmodule AdminAPI.V1.TransactionCalculationController do
       {:ok, calculation} ->
         render(conn, :calculation, %{calculation: calculation})
 
+      {:error, code} ->
+        handle_error(conn, code)
+
       {:error, code, description} ->
         handle_error(conn, code, description)
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_calculation_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_calculation_controller_test.exs
@@ -177,5 +177,24 @@ defmodule AdminAPI.V1.AdminAuth.TransactionCalculationControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
       assert response["data"]["description"] == "either `from_amount` or `to_amount` is required"
     end
+
+    test "returns an error when the exchange pair does not exist", context do
+      other_token = insert(:token)
+
+      response =
+        admin_user_request("/transaction.calculate", %{
+          "from_amount" => 100,
+          "from_token_id" => context.eth.id,
+          "to_amount" => 100 * context.pair.rate,
+          "to_token_id" => other_token.id
+        })
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "exchange:pair_not_found"
+
+      assert response["data"]["description"] ==
+               "There is no exchange pair corresponding to the provided tokens."
+    end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_calculation_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_calculation_controller_test.exs
@@ -177,5 +177,24 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionCalculationControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
       assert response["data"]["description"] == "either `from_amount` or `to_amount` is required"
     end
+
+    test "returns an error when the exchange pair does not exist", context do
+      other_token = insert(:token)
+
+      response =
+        admin_user_request("/transaction.calculate", %{
+          "from_amount" => 100,
+          "from_token_id" => context.eth.id,
+          "to_amount" => 100 * context.pair.rate,
+          "to_token_id" => other_token.id
+        })
+
+      assert response["success"] == false
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "exchange:pair_not_found"
+
+      assert response["data"]["description"] ==
+               "There is no exchange pair corresponding to the provided tokens."
+    end
   end
 end


### PR DESCRIPTION
Closes #410

# Overview

Fixes error 500 when requesting /transaction.calculate with tokens that do not have an exchange pair.

# Changes

- Added the missing error handling for `{:error, code}` which is needed for `{:error, :exchange_pair_not_found}`

# Implementation Details

The `{:error, code}` is missing, which is needed for `{:error, :exchange_pair_not_found}`

# Usage

Requesting `/transaction.calculate` with tokens that do not have an exchange pair together should return `exchange:pair_not_found` error instead of 500 internal server error.

# Impact

No changes to the DB or API.
