### PR TITLE
Prevent 500 when sending same correlation ID with consumptions

### DIFF
--- a/apps/ewallet_db/priv/repo/migrations/20181008085802_rename_unicity_constraint_for_consumption_correlation_id.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20181008085802_rename_unicity_constraint_for_consumption_correlation_id.exs
@@ -1,0 +1,9 @@
+defmodule EWalletDB.Repo.Migrations.RenameUnicityConstraintForConsumptionCorrelationID do
+  use Ecto.Migration
+
+  def change do
+    drop index(:transaction_consumption, [:correlation_id],
+               name: :transaction_request_consumption_correlation_id_index)
+    create unique_index(:transaction_consumption, [:correlation_id])
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/transaction_consumption_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_consumption_test.exs
@@ -144,6 +144,21 @@ defmodule EWalletDB.TransactionConsumptionTest do
 
       assert inserted.status == "pending"
     end
+
+    test "fails with a duplicated correlation ID" do
+      {:ok, _consumption_1} =
+        :transaction_consumption
+        |> params_for(correlation_id: "123")
+        |> TransactionConsumption.insert()
+
+      {res, changeset} =
+        :transaction_consumption
+        |> params_for(correlation_id: "123")
+        |> TransactionConsumption.insert()
+
+      assert res == :error
+      assert changeset.errors == [correlation_id: {"has already been taken", []}]
+    end
   end
 
   describe "approve/1" do


### PR DESCRIPTION
Issue/Task Number: #491
closes #491

# Overview

This PR fixes the error below, which was due to a unicity constraint improperly named on the `transaction_consumption` table.

```
Request: POST /api/admin/transaction_request.consume
** (exit) an exception was raised:
    ** (Ecto.ConstraintError) constraint error when attempting to insert struct:

    * unique: transaction_request_consumption_correlation_id_index

If you would like to convert this constraint into an error, please
...
```

# Changes

- Rename the unique index for `correlation_id`