### PR TITLE
Preload exchange pair in consumptions

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -1022,6 +1022,10 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response["data"]["transaction_request"]["address"] == meta.alice_wallet.address
       assert response["data"]["transaction_request"]["user_id"] == meta.alice.id
 
+      assert response["data"]["transaction"] != nil
+      assert response["data"]["transaction"]["exchange"]["exchange_pair"]["to_token_id"] != nil
+      assert response["data"]["transaction"]["exchange"]["exchange_pair"]["from_token_id"] != nil
+
       assert inserted_transaction.from_amount == 100_000 * meta.token.subunit_to_unit
       assert inserted_transaction.from_token_uuid == meta.token.uuid
       assert inserted_transaction.to_amount == 200_000 * token_2.subunit_to_unit

--- a/apps/ewallet/lib/ewallet/web/v1/overlays/transaction_consumption_overlay.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/overlays/transaction_consumption_overlay.ex
@@ -30,7 +30,6 @@ defmodule EWallet.Web.V1.TransactionConsumptionOverlay do
       transaction: [
         :from_token,
         :to_token,
-        :exchange_pair,
         :to_wallet,
         :from_wallet,
         :from_account,
@@ -41,6 +40,10 @@ defmodule EWallet.Web.V1.TransactionConsumptionOverlay do
         :exchange_wallet,
         :from_account,
         :to_account,
+        exchange_pair: [
+          :to_token,
+          :from_token
+        ],
         exchange_account: []
       ],
       transaction_request: [


### PR DESCRIPTION
Issue/Task Number: 496
closes #496

# Overview

Exchange pair tokens weren't properly loaded in transaction consumptions > transactions. This PR fixes it.

# Changes

- Preload exchange pair from transaction consumptions
- Add test 