### PR TITLE
Add match_any filter to Orchestrator

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -204,10 +204,44 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       assert transaction_2["id"] == meta.init_transaction_1.id
     end
 
-    test "returns filtered transactions", meta do
+    test "returns match_all filtered transactions", meta do
       response =
         admin_user_request("/transaction.all", %{
           "match_all" => [
+            %{
+              "field" => "from_wallet.address",
+              "comparator" => "eq",
+              "value" => meta.wallet_4.address
+            },
+            %{
+              "field" => "status",
+              "comparator" => "eq",
+              "value" => "confirmed"
+            }
+          ]
+        })
+
+      transactions = response["data"]["data"]
+
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_1.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_2.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_3.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_4.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_5.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_6.id end)
+      assert Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_7.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_8.id end)
+    end
+
+    test "returns match_any filtered transactions", meta do
+      response =
+        admin_user_request("/transaction.all", %{
+          "match_any" => [
+            %{
+              "field" => "from_wallet.address",
+              "comparator" => "eq",
+              "value" => meta.wallet_2.address
+            },
             %{
               "field" => "from_wallet.address",
               "comparator" => "eq",
@@ -219,7 +253,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
       transactions = response["data"]["data"]
 
       refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_1.id end)
-      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_2.id end)
+      assert Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_2.id end)
       refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_3.id end)
       refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_4.id end)
       refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_5.id end)

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -204,10 +204,44 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
       assert transaction_2["id"] == meta.init_transaction_1.id
     end
 
-    test "returns filtered transactions", meta do
+    test "returns match_all filtered transactions", meta do
       response =
         provider_request("/transaction.all", %{
           "match_all" => [
+            %{
+              "field" => "from_wallet.address",
+              "comparator" => "eq",
+              "value" => meta.wallet_4.address
+            },
+            %{
+              "field" => "status",
+              "comparator" => "eq",
+              "value" => "confirmed"
+            }
+          ]
+        })
+
+      transactions = response["data"]["data"]
+
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_1.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_2.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_3.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_4.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_5.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_6.id end)
+      assert Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_7.id end)
+      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_8.id end)
+    end
+
+    test "returns match_any filtered transactions", meta do
+      response =
+        provider_request("/transaction.all", %{
+          "match_any" => [
+            %{
+              "field" => "from_wallet.address",
+              "comparator" => "eq",
+              "value" => meta.wallet_2.address
+            },
             %{
               "field" => "from_wallet.address",
               "comparator" => "eq",
@@ -219,7 +253,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
       transactions = response["data"]["data"]
 
       refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_1.id end)
-      refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_2.id end)
+      assert Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_2.id end)
       refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_3.id end)
       refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_4.id end)
       refute Enum.any?(transactions, fn txn -> txn["id"] == meta.transaction_5.id end)

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -7,7 +7,7 @@ defmodule EWallet.Web.Orchestrator do
     preloading and sorting.
   """
 
-  alias EWallet.Web.{MatchAllParser, Paginator, Preloader, SearchParser, SortParser}
+  alias EWallet.Web.{MatchAllParser, MatchAnyParser, Paginator, Preloader, SearchParser, SortParser}
 
   def query(query, overlay, attrs \\ nil) do
     query
@@ -19,6 +19,7 @@ defmodule EWallet.Web.Orchestrator do
     query
     |> preload_to_query(overlay, attrs)
     |> MatchAllParser.to_query(attrs, overlay.filter_fields())
+    |> MatchAnyParser.to_query(attrs, overlay.filter_fields())
     |> SearchParser.to_query(attrs, overlay.search_fields, default_mapped_fields())
     |> SortParser.to_query(attrs, overlay.sort_fields, default_mapped_fields())
   end

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -52,6 +52,8 @@ defmodule EWallet.Web.Orchestrator do
     Preloader.preload_one(record, overlay.default_preload_assocs())
   end
 
+  def preload_to_query(record, overlay, attrs \\ %{})
+
   def preload_to_query(query, _overlay, %{"preload" => preload}) when is_map(preload) do
     Preloader.to_query(query, preload)
   end

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -9,13 +9,13 @@ defmodule EWallet.Web.Orchestrator do
 
   alias EWallet.Web.{MatchAllParser, MatchAnyParser, Paginator, Preloader, SearchParser, SortParser}
 
-  def query(query, overlay, attrs \\ nil) do
+  def query(query, overlay, attrs \\ %{}) do
     query
     |> build_query(overlay, attrs)
     |> Paginator.paginate_attrs(attrs)
   end
 
-  def build_query(query, overlay, attrs \\ nil) do
+  def build_query(query, overlay, attrs \\ %{}) do
     query
     |> preload_to_query(overlay, attrs)
     |> MatchAllParser.to_query(attrs, overlay.filter_fields())
@@ -24,7 +24,7 @@ defmodule EWallet.Web.Orchestrator do
     |> SortParser.to_query(attrs, overlay.sort_fields, default_mapped_fields())
   end
 
-  def all(records, overlay, attrs \\ nil)
+  def all(records, overlay, attrs \\ %{})
 
   def all(records, _overlay, %{"preload" => preload}) when is_map(preload) do
     Preloader.preload_all(records, preload)
@@ -38,7 +38,7 @@ defmodule EWallet.Web.Orchestrator do
     Preloader.preload_all(records, overlay.default_preload_assocs())
   end
 
-  def one(record, overlay, attrs \\ nil)
+  def one(record, overlay, attrs \\ %{})
 
   def one(record, _overlay, %{"preload" => preload}) when is_map(preload) do
     Preloader.preload_one(record, preload)

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -7,7 +7,14 @@ defmodule EWallet.Web.Orchestrator do
     preloading and sorting.
   """
 
-  alias EWallet.Web.{MatchAllParser, MatchAnyParser, Paginator, Preloader, SearchParser, SortParser}
+  alias EWallet.Web.{
+    MatchAllParser,
+    MatchAnyParser,
+    Paginator,
+    Preloader,
+    SearchParser,
+    SortParser
+  }
 
   def query(query, overlay, attrs \\ %{}) do
     query

--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -1,0 +1,60 @@
+defmodule EWallet.Web.OrchestratorTest do
+  use EWallet.DBCase
+  import EWalletDB.Factory
+  alias EWallet.Web.Orchestrator
+  alias EWalletDB.{Account, Repo}
+
+  defmodule MockOverlay do
+    @behaviour EWallet.Web.V1.Overlay
+
+    def preload_assocs, do: []
+    def default_preload_assocs, do: []
+    def sort_fields, do: []
+    def search_fields, do: [:id]
+    def self_filter_fields, do: []
+    def filter_fields, do: []
+  end
+
+  describe "query/3" do
+    test "orchestrates and paginates query" do
+      _account1 = insert(:account)
+      account2 = insert(:account)
+      _account3 = insert(:account)
+
+      # The 3rd param should match `MockAccountOverlay.search_fields/0`
+      result = Orchestrator.query(Account, MockAccountOverlay, %{"search_term" => account2.id })
+
+      assert %EWallet.Web.Paginator{} = result
+      assert Enum.count(result.data) == 1
+      assert List.first(result.data).id == account2.id
+    end
+  end
+
+  describe "build_query/3" do
+    test "processes the query with the overlay and attributes, but does not paginate" do
+      _account1 = insert(:account)
+      account2 = insert(:account)
+      _account3 = insert(:account)
+
+      # The 3rd param should match `MockAccountOverlay.search_fields/0`
+      query = Orchestrator.build_query(Account, MockOverlay, %{"search_term" => account2.id})
+      result = Repo.all(query)
+
+      assert %Ecto.Query{} = query
+      assert Enum.count(result) == 1
+      assert List.first(result).id == account2.id
+    end
+  end
+
+  describe "all/3" do
+
+  end
+
+  describe "one/3" do
+
+  end
+
+  describe "preload_to_query/3" do
+
+  end
+end

--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -136,14 +136,104 @@ defmodule EWallet.Web.OrchestratorTest do
   end
 
   describe "all/3" do
+    test "preloads with the overlay's default preloads when 'preload' attribute is not given" do
+      _account = insert(:account)
 
+      {:ok, result} =
+        Account
+        |> Repo.all()
+        |> Orchestrator.all(MockOverlay)
+
+      # Preloaded fields must no longer be `%NotLoaded{}`
+      assert Enum.all?(result, fn acc ->
+        acc.parent == nil || acc.parent.__struct__ != NotLoaded
+      end)
+
+      # `categories` fields are not preloaded and so they should be `%NotLoaded{}`
+      assert Enum.all?(result, fn acc -> acc.categories.__struct__ == NotLoaded end)
+    end
+
+    test "preloads with the given 'preload' attribute when given" do
+      _account = insert(:account)
+
+      {:ok, result} =
+        Account
+        |> Repo.all()
+        |> Orchestrator.all(MockOverlay, %{"preload" => [:categories]})
+
+      # Preloaded categories must be a list
+      assert Enum.all?(result, fn acc -> is_list(acc.categories) end)
+
+      # `parent` is no longer preloaded because the "preload" attribute is specified
+      assert Enum.all?(result, fn acc -> acc.parent.__struct__ == NotLoaded end)
+    end
   end
 
   describe "one/3" do
+    test "preloads with the overlay's default preloads when 'preload' attribute is not given" do
+      _account = insert(:account)
 
+      {:ok, result} =
+        Account
+        |> Repo.all()
+        |> List.first()
+        |> Orchestrator.one(MockOverlay)
+
+      # Preloaded fields must no longer be `%NotLoaded{}`
+      assert result.parent == nil || result.parent.__struct__ != NotLoaded
+
+      # `categories` fields are not preloaded and so they should be `%NotLoaded{}`
+      assert result.categories.__struct__ == NotLoaded
+    end
+
+    test "preloads with the given 'preload' attribute when given" do
+      _account = insert(:account)
+
+      {:ok, result} =
+        Account
+        |> Repo.all()
+        |> List.first()
+        |> Orchestrator.one(MockOverlay, %{"preload" => [:categories]})
+
+      # Preloaded categories must be a list
+      assert is_list(result.categories)
+
+      # `parent` is no longer preloaded because the "preload" attribute is specified
+      assert result.parent.__struct__ == NotLoaded
+    end
   end
 
   describe "preload_to_query/3" do
+    test "preloads with the overlay's default preloads when 'preload' attribute is not given" do
+      _account = insert(:account)
 
+      result =
+        Account
+        |> Orchestrator.preload_to_query(MockOverlay)
+        |> Repo.all()
+
+      # Preloaded fields must no longer be `%NotLoaded{}`
+      assert Enum.all?(result, fn acc ->
+        acc.parent == nil || acc.parent.__struct__ != NotLoaded
+      end)
+
+      # `categories` fields are not preloaded and so they should be `%NotLoaded{}`
+      assert Enum.all?(result, fn acc -> acc.categories.__struct__ == NotLoaded end)
+    end
+
+    test "preloads with the given 'preload' attribute when given" do
+      _account = insert(:account)
+
+      result =
+        Account
+        |> Orchestrator.preload_to_query(MockOverlay, %{"preload" => [:categories]})
+        |> Repo.all()
+
+      # Preloaded categories must be a list
+      assert Enum.all?(result, fn acc -> is_list(acc.categories) end)
+
+      # `parent` is no longer preloaded because the "preload" attribute is specified
+      assert Enum.all?(result, fn acc -> acc.parent.__struct__ == NotLoaded end)
+    end
   end
 end

--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -1,48 +1,137 @@
 defmodule EWallet.Web.OrchestratorTest do
   use EWallet.DBCase
   import EWalletDB.Factory
+  alias Ecto.Association.NotLoaded
   alias EWallet.Web.Orchestrator
   alias EWalletDB.{Account, Repo}
 
   defmodule MockOverlay do
     @behaviour EWallet.Web.V1.Overlay
 
-    def preload_assocs, do: []
-    def default_preload_assocs, do: []
-    def sort_fields, do: []
+    def preload_assocs, do: [:categories]
+    def default_preload_assocs, do: [:parent]
+    def sort_fields, do: [:id]
     def search_fields, do: [:id]
     def self_filter_fields, do: []
-    def filter_fields, do: []
+    def filter_fields, do: [:id, :name, :description]
   end
 
   describe "query/3" do
-    test "orchestrates and paginates query" do
-      _account1 = insert(:account)
-      account2 = insert(:account)
-      _account3 = insert(:account)
-
-      # The 3rd param should match `MockAccountOverlay.search_fields/0`
-      result = Orchestrator.query(Account, MockAccountOverlay, %{"search_term" => account2.id })
-
-      assert %EWallet.Web.Paginator{} = result
-      assert Enum.count(result.data) == 1
-      assert List.first(result.data).id == account2.id
+    test "returns an `EWallet.Web.Paginator`" do
+      assert %EWallet.Web.Paginator{} = Orchestrator.query(Account, MockOverlay)
     end
   end
 
   describe "build_query/3" do
-    test "processes the query with the overlay and attributes, but does not paginate" do
+    test "returns an `Ecto.Query`" do
+      assert %Ecto.Query{} = Orchestrator.build_query(Account, MockOverlay)
+    end
+
+    test "preloads with the overlay's default preloads when 'preload' attribute is not given" do
+      _account = insert(:account)
+
+      result =
+        Account
+        |> Orchestrator.build_query(MockOverlay)
+        |> Repo.all()
+
+      # Preloaded fields must no longer be `%NotLoaded{}`
+      assert Enum.all?(result, fn acc ->
+        acc.parent == nil || acc.parent.__struct__ != NotLoaded
+      end)
+
+      # `categories` fields are not preloaded and so they should be `%NotLoaded{}`
+      assert Enum.all?(result, fn acc -> acc.categories.__struct__ == NotLoaded end)
+    end
+
+    test "preloads with the given 'preload' attribute when given" do
+      _account = insert(:account)
+
+      result =
+        Account
+        |> Orchestrator.build_query(MockOverlay, %{"preload" => [:categories]})
+        |> Repo.all()
+
+      # Preloaded categories must be a list
+      assert Enum.all?(result, fn acc -> is_list(acc.categories) end)
+
+      # `parent` is no longer preloaded because the "preload" attribute is specified
+      assert Enum.all?(result, fn acc -> acc.parent.__struct__ == NotLoaded end)
+    end
+
+    test "performs match_all with the given overlay and attributes" do
+      account1 = insert(:account, name: "Name Matched 1", description: "Description 1")
+      account2 = insert(:account, name: "Name Unmatched 2", description: "Description 2")
+      account3 = insert(:account, name: "Name Matched 3", description: "Description 3")
+
+      attrs =
+        %{
+          "match_all" => [
+            %{
+              "field" => "name",
+              "comparator" => "contains",
+              "value" => "Name Matched"
+            },
+            %{
+              "field" => "description",
+              "comparator" => "neq",
+              "value" => "Description 1"
+            }
+          ]
+        }
+
+      result =
+        Account
+        |> Orchestrator.build_query(MockOverlay, attrs)
+        |> Repo.all()
+
+      refute Enum.any?(result, fn account -> account.id == account1.id end)
+      refute Enum.any?(result, fn account -> account.id == account2.id end)
+      assert Enum.any?(result, fn account -> account.id == account3.id end)
+    end
+
+    test "perform match_any filter with the given overlay and attributes" do
+      account1 = insert(:account, name: "Name Matched 1", description: "Description 1")
+      account2 = insert(:account, name: "Name Unmatched 2", description: "Description 2")
+      account3 = insert(:account, name: "Name Matched 3", description: "Description 3")
+
+      attrs =
+        %{
+          "match_any" => [
+            %{
+              "field" => "name",
+              "comparator" => "contains",
+              "value" => "Matched 2"
+            },
+            %{
+              "field" => "description",
+              "comparator" => "contains",
+              "value" => "Description 3"
+            }
+          ]
+        }
+
+      result =
+        Account
+        |> Orchestrator.build_query(MockOverlay, attrs)
+        |> Repo.all()
+
+      refute Enum.any?(result, fn account -> account.id == account1.id end)
+      assert Enum.any?(result, fn account -> account.id == account2.id end)
+      assert Enum.any?(result, fn account -> account.id == account3.id end)
+    end
+
+    test "performs search with the given overlay and attributes" do
       _account1 = insert(:account)
       account2 = insert(:account)
       _account3 = insert(:account)
 
-      # The 3rd param should match `MockAccountOverlay.search_fields/0`
-      query = Orchestrator.build_query(Account, MockOverlay, %{"search_term" => account2.id})
-      result = Repo.all(query)
+      # The 3rd param should match `MockOverlay.search_fields/0`
+      result = Orchestrator.query(Account, MockOverlay, %{"search_term" => account2.id })
 
-      assert %Ecto.Query{} = query
-      assert Enum.count(result) == 1
-      assert List.first(result).id == account2.id
+      assert %EWallet.Web.Paginator{} = result
+      assert Enum.count(result.data) == 1
+      assert List.first(result.data).id == account2.id
     end
   end
 

--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -37,8 +37,8 @@ defmodule EWallet.Web.OrchestratorTest do
 
       # Preloaded fields must no longer be `%NotLoaded{}`
       assert Enum.all?(result, fn acc ->
-        acc.parent == nil || acc.parent.__struct__ != NotLoaded
-      end)
+               acc.parent == nil || acc.parent.__struct__ != NotLoaded
+             end)
 
       # `categories` fields are not preloaded and so they should be `%NotLoaded{}`
       assert Enum.all?(result, fn acc -> acc.categories.__struct__ == NotLoaded end)
@@ -64,21 +64,20 @@ defmodule EWallet.Web.OrchestratorTest do
       account2 = insert(:account, name: "Name Unmatched 2", description: "Description 2")
       account3 = insert(:account, name: "Name Matched 3", description: "Description 3")
 
-      attrs =
-        %{
-          "match_all" => [
-            %{
-              "field" => "name",
-              "comparator" => "contains",
-              "value" => "Name Matched"
-            },
-            %{
-              "field" => "description",
-              "comparator" => "neq",
-              "value" => "Description 1"
-            }
-          ]
-        }
+      attrs = %{
+        "match_all" => [
+          %{
+            "field" => "name",
+            "comparator" => "contains",
+            "value" => "Name Matched"
+          },
+          %{
+            "field" => "description",
+            "comparator" => "neq",
+            "value" => "Description 1"
+          }
+        ]
+      }
 
       result =
         Account
@@ -95,21 +94,20 @@ defmodule EWallet.Web.OrchestratorTest do
       account2 = insert(:account, name: "Name Unmatched 2", description: "Description 2")
       account3 = insert(:account, name: "Name Matched 3", description: "Description 3")
 
-      attrs =
-        %{
-          "match_any" => [
-            %{
-              "field" => "name",
-              "comparator" => "contains",
-              "value" => "Matched 2"
-            },
-            %{
-              "field" => "description",
-              "comparator" => "contains",
-              "value" => "Description 3"
-            }
-          ]
-        }
+      attrs = %{
+        "match_any" => [
+          %{
+            "field" => "name",
+            "comparator" => "contains",
+            "value" => "Matched 2"
+          },
+          %{
+            "field" => "description",
+            "comparator" => "contains",
+            "value" => "Description 3"
+          }
+        ]
+      }
 
       result =
         Account
@@ -127,7 +125,7 @@ defmodule EWallet.Web.OrchestratorTest do
       _account3 = insert(:account)
 
       # The 3rd param should match `MockOverlay.search_fields/0`
-      result = Orchestrator.query(Account, MockOverlay, %{"search_term" => account2.id })
+      result = Orchestrator.query(Account, MockOverlay, %{"search_term" => account2.id})
 
       assert %EWallet.Web.Paginator{} = result
       assert Enum.count(result.data) == 1
@@ -146,8 +144,8 @@ defmodule EWallet.Web.OrchestratorTest do
 
       # Preloaded fields must no longer be `%NotLoaded{}`
       assert Enum.all?(result, fn acc ->
-        acc.parent == nil || acc.parent.__struct__ != NotLoaded
-      end)
+               acc.parent == nil || acc.parent.__struct__ != NotLoaded
+             end)
 
       # `categories` fields are not preloaded and so they should be `%NotLoaded{}`
       assert Enum.all?(result, fn acc -> acc.categories.__struct__ == NotLoaded end)
@@ -214,8 +212,8 @@ defmodule EWallet.Web.OrchestratorTest do
 
       # Preloaded fields must no longer be `%NotLoaded{}`
       assert Enum.all?(result, fn acc ->
-        acc.parent == nil || acc.parent.__struct__ != NotLoaded
-      end)
+               acc.parent == nil || acc.parent.__struct__ != NotLoaded
+             end)
 
       # `categories` fields are not preloaded and so they should be `%NotLoaded{}`
       assert Enum.all?(result, fn acc -> acc.categories.__struct__ == NotLoaded end)


### PR DESCRIPTION
Closes #501

# Overview

This PR adds the missing `MatchAnyParser` to `EWallet.Web.Orchestrator.build_query/3`.

# Changes

- Add `MatchAnyParser.to_query/3` to `Orchestrator.build_query/3`'s flow
- Changed the default arguments for `Orchestrator` functions from `attrs \\ nil` to `attrs \\ %{}`
- Add tests for `EWallet.Web.Orchestrator`

# Implementation Details

- Straightforward adding of `MatchAnyParser.to_query(...)` to `Orchestrator.build_query/3` pipe.
- The default arguments for `Orchestrator` functions are changed from `attrs \\ nil` to `attrs \\ %{}` since the implementation expects an attribute map.

# Usage

```
curl 10.5.10.10:4000/api/admin/transaction.all \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGAdmin dXNyXzAxY3Y2cm0xZTZzNnFmZjcwcHBnMnAwdmZzOm1CQjVfTzhTTnVXYjAxWFZ6eDdRVTBJUTRuUXc1S1htQ1JzbkVNMHZGaUU=" \
-H "Content-Type: application/json" \
-d '{
  "match_any": [
    {
      "field": "id",
      "comparator": "eq",
      "value": "txn_01cv6rm3sdn84j10sggkkx1dpg"
    },
    {
      "field": "id",
      "comparator": "eq",
      "value": "txn_01cv6rm3rcc9bmmenjgxhkhfsq"
    }
  ]
}' \
-v -w "\n" | jq
```

# Impact

Adds "match_any" request param to `*.all` endpoints. No DB changes.