### PR TITLE
Fix internal server error when trying to filter a field that's not allowed

### DIFF
--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -17,9 +17,13 @@ defmodule EWallet.Web.Orchestrator do
   }
 
   def query(query, overlay, attrs \\ %{}) do
-    query
-    |> build_query(overlay, attrs)
-    |> Paginator.paginate_attrs(attrs)
+    with %Ecto.Query{} = query <- build_query(query, overlay, attrs),
+         paginated <- Paginator.paginate_attrs(query, attrs) do
+      paginated
+    else
+      {:error, :not_allowed, field} ->
+        {:error, :query_field_not_allowed, field_name: field}
+    end
   end
 
   def build_query(query, overlay, attrs \\ %{}) do

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -11,7 +11,8 @@ defmodule EWallet.Web.V1.ErrorHandler do
   @errors %{
     query_field_not_allowed: %{
       code: "client:invalid_parameter",
-      template: "Invalid parameter provided. The queried field is not allowed. Given: '%{field_name}'."
+      template:
+        "Invalid parameter provided. The queried field is not allowed. Given: '%{field_name}'."
     },
     missing_master_account: %{
       code: "account:missing_master_account",

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -9,6 +9,10 @@ defmodule EWallet.Web.V1.ErrorHandler do
   alias EWalletDB.Token
 
   @errors %{
+    query_field_not_allowed: %{
+      code: "client:invalid_parameter",
+      template: "Invalid parameter provided. The queried field is not allowed. Given: '%{field_name}'."
+    },
     missing_master_account: %{
       code: "account:missing_master_account",
       description: "Unable to find the master account."

--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -20,6 +20,24 @@ defmodule EWallet.Web.OrchestratorTest do
     test "returns an `EWallet.Web.Paginator`" do
       assert %EWallet.Web.Paginator{} = Orchestrator.query(Account, MockOverlay)
     end
+
+    test "returns :query_field_not_allowed error if the field is not in the allowed list" do
+      attrs = %{
+        "match_all" => [
+          %{
+            "field" => "status",
+            "comparator" => "eq",
+            "value" => "pending"
+          }
+        ]
+      }
+
+      {res, error, params} = Orchestrator.query(Account, MockOverlay, attrs)
+
+      assert res == :error
+      assert error == :query_field_not_allowed
+      assert params == [field_name: "status"]
+    end
   end
 
   describe "build_query/3" do


### PR DESCRIPTION
Closes #505

# Overview

This PR fixes the internal server error that is returned when attempting to filter records with a field that's not allowed.

This PR is based on the changes in #501 so it's based out of #501 until merged.

# Changes

- Handles when `{:error, :not_allowed, field}` is returned by the parser in `EWallet.Web.Orchestrator`

# Implementation Details

N/A

# Usage

```
curl 10.5.10.10:4000/api/admin/transaction.all -H "Accept: application/vnd.omisego.v1+json" -H "Authorization: OMGAdmin <truncated>" -H "Content-Type: application/json" -d '{
  "match_all": [
    {
      "comparator": "eq",
      "field": "1232131",
      "value": true
    }
  ],
  "page": 1,
  "per_page": 10,
  "sort_by": "name",
  "sort_dir": "asc"
}' -v -w "\n"
```

Should now return a `client:invalid_parameter` error rather than an `internal_server_error` error.

# Impact

No DB or API changes.