### PR TITLE
Fix error 500 when trying to filter a disallowed field on /api/admin/account.get_wallets

### DIFF
--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -31,8 +31,10 @@ defmodule EWallet.Web.Orchestrator do
     with %Query{} = query <- preload_to_query(query, overlay, attrs),
          %Query{} = query <- MatchAllParser.to_query(query, attrs, overlay.filter_fields()),
          %Query{} = query <- MatchAnyParser.to_query(query, attrs, overlay.filter_fields()),
-         %Query{} = query <- SearchParser.to_query(query, attrs, overlay.search_fields, default_mapped_fields()),
-         %Query{} = query <- SortParser.to_query(query, attrs, overlay.sort_fields, default_mapped_fields()) do
+         %Query{} = query <-
+           SearchParser.to_query(query, attrs, overlay.search_fields, default_mapped_fields()),
+         %Query{} = query <-
+           SortParser.to_query(query, attrs, overlay.sort_fields, default_mapped_fields()) do
       query
     else
       error -> error

--- a/apps/ewallet/lib/ewallet/web/v1/overlays/wallet_overlay.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/overlays/wallet_overlay.ex
@@ -55,7 +55,7 @@ defmodule EWallet.Web.V1.WalletOverlay do
       enabled: nil,
       inserted_at: nil,
       created_at: nil,
-      user: UserOverlay.default_preload_assocs(),
-      account: AccountOverlay.default_preload_assocs()
+      user: UserOverlay.self_filter_fields(),
+      account: AccountOverlay.self_filter_fields()
     ]
 end


### PR DESCRIPTION
Closes #513

# Overview

This PR fixes the issue with filtering a disallowed field on `/api/admin/account.get_wallets`.

# Changes

- Updated `Orchestrator.build_query/3` to use `with` clause instead of pipes to catch errors mid-way.
- Fixed `WalletOverlay` that should use `self_filter_fields()` instead of `default_preload_assocs()` for figuring out the allowed filter fields.

# Implementation Details

Because `Orchestrator.build_query/3` was using pipes, this makes it hard to handle error if it is returned midway. This PR changed it to use `with` clauses.

Also, `WalletOverlay` was using `default_preload_assocs()` to build the filters instead of `self_filter_fields()`.

# Usage

Making a request like following should return the proper results:

```sh
curl 10.5.10.10:4000/api/admin/account.get_wallets \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGAdmin <truncated>" \
-H "Content-Type: application/json" \
-d '{
  "per_page":10,
  "sort_by":"created_at",
  "sort_dir":"desc",
  "id":"acc_01cvven6b8zchchcn3wpsk9h89",
  "owned":false,
  "match_any": [
    {"field":"address","comparator":"contains","value":"asasd"},
    {"field":"account.name","comparator":"contains","value":"asasd"}
  ]
}' \
-v -w "\n" | jq
```

# Impact

No DB or API changes