### PR TITLE
Add the insertion of a normal user to the test seed

### DIFF
--- a/apps/ewallet/lib/ewallet/policies/transaction_request_policy.ex
+++ b/apps/ewallet/lib/ewallet/policies/transaction_request_policy.ex
@@ -3,10 +3,14 @@ defmodule EWallet.TransactionRequestPolicy do
   The authorization policy for accounts.
   """
   @behaviour Bodyguard.Policy
-  alias EWallet.WalletPolicy
-  alias EWalletDB.Wallet
+  alias EWallet.{WalletPolicy, AccountPolicy}
+  alias EWalletDB.{Wallet, Account}
 
   def authorize(:all, _admin_user_or_key, nil), do: true
+
+  def authorize(:all, params, %Account{} = account) do
+    AccountPolicy.authorize(:get, params, account.id)
+  end
 
   def authorize(:get, _params, _request) do
     true

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -51,7 +51,7 @@ config :ewallet_config,
     },
     "email_adapter" => %{
       key: "email_adapter",
-      value: nil,
+      value: "local",
       type: "string",
       position: 7,
       options: ["smtp", "local", "test"],

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -5,9 +5,9 @@ config :ewallet_config,
   settings_mappings: %{
     "email_adapter" => %{
       "smtp" => Bamboo.SMTPAdapter,
-      "local" => Bamboo.Bamboo.LocalAdapter,
+      "local" => Bamboo.LocalAdapter,
       "test" => Bamboo.TestAdapter,
-      "_" => Bamboo.Bamboo.LocalAdapter
+      "_" => Bamboo.LocalAdapter
     }
   },
   default_settings: %{

--- a/apps/ewallet_db/priv/repo/seeds_test/01_user.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/01_user.exs
@@ -20,11 +20,19 @@ defmodule EWalletDB.Repo.Seeds.UserSeed do
       is_admin: true,
       originator: %OriginatorSystem{}
     },
+    %{
+      email: System.get_env("E2E_TEST_USER_EMAIL") || "test_user@example.com",
+      password: System.get_env("E2E_TEST_USER_PASSWORD") || "password",
+      metadata: %{},
+      account_name: "master_account",
+      is_admin: false,
+      originator: %OriginatorSystem{}
+    },
   ]
 
   def seed do
     [
-      run_banner: "Seeding the 2 test admins",
+      run_banner: "Seeding the 2 test admins and the test user",
       argsline: [],
     ]
   end
@@ -50,11 +58,11 @@ defmodule EWalletDB.Repo.Seeds.UserSeed do
             """)
 
           {:error, changeset} ->
-            writer.error("  Admin Panel user #{data.email} could not be inserted:")
+            writer.error("  User #{data.email} could not be inserted:")
             writer.print_errors(changeset)
 
           _ ->
-            writer.error("  Admin Panel user #{data.email} could not be inserted:")
+            writer.error("  User #{data.email} could not be inserted:")
             writer.error("  Unknown error.")
         end
 

--- a/apps/ewallet_db/priv/repo/seeds_test/10_setting.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/10_setting.exs
@@ -1,6 +1,6 @@
 # credo:disable-for-this-file
 defmodule EWalletDB.Repo.Seeds.SettingsSeed do
-  alias EWalletConfig.Config
+  alias EWalletConfig.{Config, Setting}
 
   def seed do
     [
@@ -10,13 +10,12 @@ defmodule EWalletDB.Repo.Seeds.SettingsSeed do
   end
 
   def run(writer, _args) do
-    Config.update(%{
+    {:ok, [ok: %Setting{}]} = Config.update(%{
       enable_standalone: true
     })
 
     writer.warn("""
-      Settings updated.
-      Enable standalone is now: #{Config.get(:enable_standalone)}
+      Enable standalone : #{Config.get(:enable_standalone)}
     """)
   end
 end

--- a/apps/ewallet_db/priv/repo/seeds_test/10_setting.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/10_setting.exs
@@ -1,0 +1,22 @@
+# credo:disable-for-this-file
+defmodule EWalletDB.Repo.Seeds.SettingsSeed do
+  alias EWalletConfig.Config
+
+  def seed do
+    [
+      run_banner: "Updating settings",
+      argsline: [],
+    ]
+  end
+
+  def run(writer, _args) do
+    Config.update(%{
+      enable_standalone: true
+    })
+
+    writer.warn("""
+      Settings updated.
+      Enable standalone is now: #{Config.get(:enable_standalone)}
+    """)
+  end
+end

--- a/docs/setup/advanced/env.md
+++ b/docs/setup/advanced/env.md
@@ -109,3 +109,5 @@ Nothing else to set, files will be stored at the root of the project in `public/
 - `E2E_TEST_ADMIN_PASSWORD`: The password of the first test admin
 - `E2E_TEST_ADMIN_1_EMAIL`: The email of the second test admin
 - `E2E_TEST_ADMIN_1_PASSWORD`: The password of the second test admin
+- `E2E_TEST_USER_EMAIL`: The email of the test user (non-admin)
+- `E2E_TEST_USER_PASSWORD`: The password of the test user (non-admin)


### PR DESCRIPTION
Issue/Task Number: 525
Closes #525 

# Overview

This PR adds the insertion of a normal user in addition to the 2 test admins that were inserted.
This is required to test the standalone user login in the E2E test environment.

# Changes

- Insert a new user when running the test seeds
- Add 2 new environment variables that allow the user's admin and password to be specified:
  - `E2E_TEST_USER_EMAIL`
  - `E2E_TEST_USER_PASSWORD`

# Implementation Details

N/A

# Usage

Run the test seeds: `E2E_ENABLED=true mix seed --test --yes`

# Impact

New env variable to setup in the E2E environment
