### PR TITLE
Fix email adapter config mappings

### DIFF
--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -5,9 +5,9 @@ config :ewallet_config,
   settings_mappings: %{
     "email_adapter" => %{
       "smtp" => Bamboo.SMTPAdapter,
-      "local" => Bamboo.Bamboo.LocalAdapter,
+      "local" => Bamboo.LocalAdapter,
       "test" => Bamboo.TestAdapter,
-      "_" => Bamboo.Bamboo.LocalAdapter
+      "_" => Bamboo.LocalAdapter
     }
   },
   default_settings: %{
@@ -51,7 +51,7 @@ config :ewallet_config,
     },
     "email_adapter" => %{
       key: "email_adapter",
-      value: nil,
+      value: "local",
       type: "string",
       position: 7,
       options: ["smtp", "local", "test"],


### PR DESCRIPTION
Issue/Task Number: 528
closes #528 

# Overview

This PR fixes a wrongly named mapping for the email local adapter setting.