### PR TITLE
Always preload tokens in exchange pair when doing /transaction.calculate

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_calculation_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_calculation_controller_test.exs
@@ -35,6 +35,9 @@ defmodule AdminAPI.V1.AdminAuth.TransactionCalculationControllerTest do
 
       assert response["data"]["exchange_pair"]["object"] == "exchange_pair"
       assert response["data"]["exchange_pair"]["id"] == context.pair.id
+
+      assert response["data"]["exchange_pair"]["from_token"]["id"] == context.eth.id
+      assert response["data"]["exchange_pair"]["to_token"]["id"] == context.omg.id
     end
 
     test "accepts integer strings", context do

--- a/apps/ewallet/lib/ewallet/exchange/exchange.ex
+++ b/apps/ewallet/lib/ewallet/exchange/exchange.ex
@@ -18,7 +18,11 @@ defmodule EWallet.Exchange do
   @spec get_rate(from_token :: %Token{}, to_token :: %Token{}) ::
           {:ok, Decimal.t(), %ExchangePair{}} | {:error, atom()}
   def get_rate(from_token, to_token) do
-    case ExchangePair.fetch_exchangable_pair(from_token, to_token) do
+    case ExchangePair.fetch_exchangable_pair(
+           from_token,
+           to_token,
+           preload: [:from_token, :to_token]
+         ) do
       {:ok, pair} ->
         rate = Decimal.new(pair.rate)
         subunit_scale = Decimal.div(to_token.subunit_to_unit, from_token.subunit_to_unit)


### PR DESCRIPTION
Issue/Task Number: #518
closes #518

# Overview

This PR always preloads tokens for the exchange pair when calling `/transaction.calculate`.

# Changes

- Add a test to ensure the exchange pair tokens are properly preloaded
- Add the preloading of the exchange pair tokens