### PR TITLE
Make metadata optional everywhere

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_controller_test.exs
@@ -455,7 +455,7 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
       assert response["data"]["encrypted_metadata"] == %{}
     end
 
-    test "returns an 'invalid parameter' error when sending nil for metadata/encrypted_metadata" do
+    test "returns empty metadata when sending nil for metadata/encrypted_metadata" do
       {:ok, user} =
         :user
         |> params_for(%{
@@ -475,13 +475,9 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
           encrypted_metadata: nil
         })
 
-      assert response["success"] == false
-      assert response["data"]["code"] == "client:invalid_parameter"
-
-      assert response["data"]["messages"] == %{
-               "metadata" => ["required"],
-               "encrypted_metadata" => ["required"]
-             }
+      assert response["success"] == true
+      assert response["data"]["metadata"] == %{}
+      assert response["data"]["encrypted_metadata"] == %{}
     end
 
     test "returns an error if provider_user_id is not provided" do

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_controller_test.exs
@@ -338,7 +338,7 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
       assert response["data"]["encrypted_metadata"] == %{}
     end
 
-    test "returns an 'invalid parameter' error when sending nil for metadata/encrypted_metadata" do
+    test "returns empty metadata when sending nil for metadata/encrypted_metadata" do
       user =
         insert(:user, %{
           metadata: %{first_name: "updated_first_name"},
@@ -356,13 +356,9 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
           encrypted_metadata: nil
         })
 
-      assert response["success"] == false
-      assert response["data"]["code"] == "client:invalid_parameter"
-
-      assert response["data"]["messages"] == %{
-               "metadata" => ["required"],
-               "encrypted_metadata" => ["required"]
-             }
+      assert response["success"] == true
+      assert response["data"]["metadata"] == %{}
+      assert response["data"]["encrypted_metadata"] == %{}
     end
 
     test "returns an error if provider_user_id is not provided" do

--- a/apps/ewallet_db/lib/ewallet_db/account.ex
+++ b/apps/ewallet_db/lib/ewallet_db/account.ex
@@ -103,7 +103,7 @@ defmodule EWalletDB.Account do
   defp changeset(%Account{} = account, attrs) do
     account
     |> cast(attrs, [:name, :description, :parent_uuid, :metadata, :encrypted_metadata])
-    |> validate_required([:name, :metadata, :encrypted_metadata])
+    |> validate_required([:name])
     |> validate_parent_uuid()
     |> validate_account_level(@child_level_limit)
     |> unique_constraint(:name)

--- a/apps/ewallet_db/lib/ewallet_db/token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/token.ex
@@ -80,9 +80,7 @@ defmodule EWalletDB.Token do
       :symbol,
       :name,
       :subunit_to_unit,
-      :account_uuid,
-      :metadata,
-      :encrypted_metadata
+      :account_uuid
     ])
     |> validate_number(
       :subunit_to_unit,
@@ -114,9 +112,7 @@ defmodule EWalletDB.Token do
       :encrypted_metadata
     ])
     |> validate_required([
-      :name,
-      :metadata,
-      :encrypted_metadata
+      :name
     ])
     |> unique_constraint(:iso_code)
     |> unique_constraint(:name)

--- a/apps/ewallet_db/lib/ewallet_db/transaction.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction.ex
@@ -179,9 +179,7 @@ defmodule EWalletDB.Transaction do
       :to_amount,
       :to_token_uuid,
       :to,
-      :from,
-      :metadata,
-      :encrypted_metadata
+      :from
     ])
     |> validate_number(:from_amount, less_than: 100_000_000_000_000_000_000_000_000_000_000_000)
     |> validate_number(:to_amount, less_than: 100_000_000_000_000_000_000_000_000_000_000_000)

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -110,7 +110,7 @@ defmodule EWalletDB.User do
       :invite_uuid,
       :originator
     ])
-    |> validate_required([:metadata, :encrypted_metadata, :originator])
+    |> validate_required([:originator])
     |> validate_confirmation(:password, message: "does not match password")
     |> validate_immutable(:provider_user_id)
     |> unique_constraint(:username)
@@ -134,7 +134,7 @@ defmodule EWalletDB.User do
       :invite_uuid,
       :originator
     ])
-    |> validate_required([:metadata, :encrypted_metadata, :originator])
+    |> validate_required([:originator])
     |> validate_immutable(:provider_user_id)
     |> unique_constraint(:username)
     |> unique_constraint(:provider_user_id)
@@ -154,7 +154,7 @@ defmodule EWalletDB.User do
       :invite_uuid,
       :originator
     ])
-    |> validate_required([:metadata, :encrypted_metadata, :originator])
+    |> validate_required([:originator])
     |> unique_constraint(:email)
     |> assoc_constraint(:invite)
     |> validate_by_roles(attrs)

--- a/apps/ewallet_db/priv/repo/migrations/20181119111712_remove_nullable_from_metadata.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20181119111712_remove_nullable_from_metadata.exs
@@ -1,0 +1,9 @@
+defmodule EWalletDB.Repo.Migrations.RemoveNullableFromMetadata do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user) do
+      modify :metadata, :map, null: true
+    end
+  end
+end


### PR DESCRIPTION
Issue/Task Number: #445 
closes #445

# Overview

This PR changes `metadata` / `encrypted_metadata` to not be mandatory anywhere where it still was.

# Changes

- Remove `metadata` from the changeset required validations for `Account`, `Token`, `User`, `Transaction`
- Added a migration as well for users, since the `metadata` column had a `null: false` option