### PR TITLE
Supports nil value filtering

### DIFF
--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -364,6 +364,37 @@ defmodule AdminAPI.ConnCase do
         assert Enum.any?(records, fn r -> Map.get(r, field_name) == "value_4" end)
         assert Enum.count(records) == 2
       end
+
+      test "handles unsupported match_any comparator" do
+        endpoint = unquote(endpoint)
+        auth_type = unquote(auth_type)
+        field = unquote(field)
+        field_name = Atom.to_string(field)
+
+        attrs = %{
+          "match_any" => [
+            %{
+              "field" => field_name,
+              "comparator" => "starts_with",
+              "value" => nil
+            }
+          ]
+        }
+
+        response =
+          case auth_type do
+            :admin_auth -> admin_user_request(endpoint, attrs)
+            :provider_auth -> provider_request(endpoint, attrs)
+          end
+
+        refute response["success"]
+        assert response["data"]["object"] == "error"
+        assert response["data"]["code"] == "client:invalid_parameter"
+
+        assert response["data"]["description"] ==
+                 "Invalid parameter provided. " <>
+                   "Querying for '#{field_name}' 'starts_with' 'nil' is not supported."
+      end
     end
   end
 
@@ -413,6 +444,37 @@ defmodule AdminAPI.ConnCase do
         records = response["data"]["data"]
         assert Enum.any?(records, fn r -> Map.get(r, field_name) == "this_should_match" end)
         assert Enum.count(records) == 1
+      end
+
+      test "handles unsupported match_all comparator" do
+        endpoint = unquote(endpoint)
+        auth_type = unquote(auth_type)
+        field = unquote(field)
+        field_name = Atom.to_string(field)
+
+        attrs = %{
+          "match_all" => [
+            %{
+              "field" => field_name,
+              "comparator" => "starts_with",
+              "value" => nil
+            }
+          ]
+        }
+
+        response =
+          case auth_type do
+            :admin_auth -> admin_user_request(endpoint, attrs)
+            :provider_auth -> provider_request(endpoint, attrs)
+          end
+
+        refute response["success"]
+        assert response["data"]["object"] == "error"
+        assert response["data"]["code"] == "client:invalid_parameter"
+
+        assert response["data"]["description"] ==
+                 "Invalid parameter provided. " <>
+                   "Querying for '#{field_name}' 'starts_with' 'nil' is not supported."
       end
     end
   end

--- a/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
@@ -19,6 +19,17 @@ defmodule EWallet.Web.MatchAllQuery do
 
       "starts_with" ->
         dynamic([q], ilike(fragment("?::text", field(q, ^field)), ^"#{value}%") and ^dynamic)
+
+      _ ->
+        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter(dynamic, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q], is_nil(field(q, ^field)) and ^dynamic)
+      "neq" -> dynamic([q], not is_nil(field(q, ^field)) and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -32,6 +43,15 @@ defmodule EWallet.Web.MatchAllQuery do
       "lte" -> dynamic([q], field(q, ^field) <= ^value and ^dynamic)
       "contains" -> dynamic([q], ilike(field(q, ^field), ^"%#{value}%") and ^dynamic)
       "starts_with" -> dynamic([q], ilike(field(q, ^field), ^"#{value}%") and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 0, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, a], is_nil(field(a, ^field)) and ^dynamic)
+      "neq" -> dynamic([q, a], not is_nil(field(a, ^field)) and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -45,6 +65,15 @@ defmodule EWallet.Web.MatchAllQuery do
       "lte" -> dynamic([q, a], field(a, ^field) <= ^value and ^dynamic)
       "contains" -> dynamic([q, a], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
       "starts_with" -> dynamic([q, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 1, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, _, a], is_nil(field(a, ^field)) and ^dynamic)
+      "neq" -> dynamic([q, _, a], not is_nil(field(a, ^field)) and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -58,6 +87,15 @@ defmodule EWallet.Web.MatchAllQuery do
       "lte" -> dynamic([q, _, a], field(a, ^field) <= ^value and ^dynamic)
       "contains" -> dynamic([q, _, a], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
       "starts_with" -> dynamic([q, _, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 2, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, _, _, a], is_nil(field(a, ^field)) and ^dynamic)
+      "neq" -> dynamic([q, _, _, a], not is_nil(field(a, ^field)) and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -71,6 +109,15 @@ defmodule EWallet.Web.MatchAllQuery do
       "lte" -> dynamic([q, _, _, a], field(a, ^field) <= ^value and ^dynamic)
       "contains" -> dynamic([q, _, _, a], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
       "starts_with" -> dynamic([q, _, _, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 3, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, _, _, _, a], is_nil(field(a, ^field)) and ^dynamic)
+      "neq" -> dynamic([q, _, _, _, a], not is_nil(field(a, ^field)) and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -99,6 +146,17 @@ defmodule EWallet.Web.MatchAllQuery do
 
       "starts_with" ->
         dynamic([q, _, _, _, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
+
+      _ ->
+        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 4, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, _, _, _, _, a], is_nil(field(a, ^field)) and ^dynamic)
+      "neq" -> dynamic([q, _, _, _, _, a], not is_nil(field(a, ^field)) and ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -127,6 +185,9 @@ defmodule EWallet.Web.MatchAllQuery do
 
       "starts_with" ->
         dynamic([q, _, _, _, _, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
+
+      _ ->
+        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 end

--- a/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
@@ -19,6 +19,17 @@ defmodule EWallet.Web.MatchAnyQuery do
 
       "starts_with" ->
         dynamic([q], ilike(fragment("?::text", field(q, ^field)), ^"#{value}%") or ^dynamic)
+
+      _ ->
+        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter(dynamic, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q], is_nil(field(q, ^field)) or ^dynamic)
+      "neq" -> dynamic([q], not is_nil(field(q, ^field)) or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -32,6 +43,15 @@ defmodule EWallet.Web.MatchAnyQuery do
       "lte" -> dynamic([q], field(q, ^field) <= ^value or ^dynamic)
       "contains" -> dynamic([q], ilike(field(q, ^field), ^"%#{value}%") or ^dynamic)
       "starts_with" -> dynamic([q], ilike(field(q, ^field), ^"#{value}%") or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 0, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, a], is_nil(field(a, ^field)) or ^dynamic)
+      "neq" -> dynamic([q, a], not is_nil(field(a, ^field)) or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -45,6 +65,15 @@ defmodule EWallet.Web.MatchAnyQuery do
       "lte" -> dynamic([q, a], field(a, ^field) <= ^value or ^dynamic)
       "contains" -> dynamic([q, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
       "starts_with" -> dynamic([q, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 1, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, _, a], is_nil(field(a, ^field)) or ^dynamic)
+      "neq" -> dynamic([q, _, a], not is_nil(field(a, ^field)) or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -58,6 +87,15 @@ defmodule EWallet.Web.MatchAnyQuery do
       "lte" -> dynamic([q, _, a], field(a, ^field) <= ^value or ^dynamic)
       "contains" -> dynamic([q, _, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
       "starts_with" -> dynamic([q, _, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 2, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, _, _, a], is_nil(field(a, ^field)) or ^dynamic)
+      "neq" -> dynamic([q, _, _, a], not is_nil(field(a, ^field)) or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -71,6 +109,15 @@ defmodule EWallet.Web.MatchAnyQuery do
       "lte" -> dynamic([q, _, _, a], field(a, ^field) <= ^value or ^dynamic)
       "contains" -> dynamic([q, _, _, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
       "starts_with" -> dynamic([q, _, _, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 3, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, _, _, _, a], is_nil(field(a, ^field)) or ^dynamic)
+      "neq" -> dynamic([q, _, _, _, a], not is_nil(field(a, ^field)) or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -84,6 +131,15 @@ defmodule EWallet.Web.MatchAnyQuery do
       "lte" -> dynamic([q, _, _, _, a], field(a, ^field) <= ^value or ^dynamic)
       "contains" -> dynamic([q, _, _, _, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
       "starts_with" -> dynamic([q, _, _, _, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+    end
+  end
+
+  def do_filter_assoc(dynamic, 4, field, nil, comparator, nil = value) do
+    case comparator do
+      "eq" -> dynamic([q, _, _, _, _, a], is_nil(field(a, ^field)) or ^dynamic)
+      "neq" -> dynamic([q, _, _, _, _, a], not is_nil(field(a, ^field)) or ^dynamic)
+      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
@@ -112,6 +168,9 @@ defmodule EWallet.Web.MatchAnyQuery do
 
       "starts_with" ->
         dynamic([q, _, _, _, _, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
+
+      _ ->
+        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 end

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -26,6 +26,9 @@ defmodule EWallet.Web.Orchestrator do
     else
       {:error, :not_allowed, field} ->
         {:error, :query_field_not_allowed, field_name: field}
+
+      {:error, _, _} = error ->
+        error
     end
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -345,6 +345,11 @@ defmodule EWallet.Web.V1.ErrorHandler do
     setting_not_found: %{
       code: "setting:not_found",
       description: "There is no setting corresponding to the provided key."
+    },
+    comparator_not_supported: %{
+      code: "client:invalid_parameter",
+      template:
+        "Invalid parameter provided. Querying for '%{field}' '%{comparator}' '%{value}' is not supported."
     }
   }
 
@@ -472,11 +477,19 @@ defmodule EWallet.Web.V1.ErrorHandler do
   end
 
   defp build_template(data, template) do
-    Enum.reduce(data, template, fn {k, v}, description ->
+    Enum.reduce(data, template, fn {pattern, replacement}, description ->
       description
-      |> String.replace("%{#{k}}", "#{v}")
+      |> template_replace(pattern, replacement)
       |> replace_uuids()
     end)
+  end
+
+  defp template_replace(template, pattern, nil) do
+    String.replace(template, "%{#{pattern}}", "nil")
+  end
+
+  defp template_replace(template, pattern, replacement) do
+    String.replace(template, "%{#{pattern}}", "#{replacement}")
   end
 
   defp stringify_errors(changeset, description) do

--- a/apps/ewallet/test/ewallet/web/filters/match_all_query_test.exs
+++ b/apps/ewallet/test/ewallet/web/filters/match_all_query_test.exs
@@ -131,6 +131,19 @@ defmodule EWallet.Web.MatchAllQueryTest do
       refute contains?(result, token_1)
       assert contains?(result, token_2)
     end
+
+    test "matches a nil value" do
+      user_1 = insert(:user, username: "not_nil")
+      user_2 = insert(:user, username: nil)
+
+      result =
+        true
+        |> MatchAllQuery.do_filter(:username, nil, "eq", nil)
+        |> on_all(User)
+
+      refute contains?(result, user_1)
+      assert contains?(result, user_2)
+    end
   end
 
   describe "do_filter/5 with 'neq' comparator" do
@@ -185,6 +198,19 @@ defmodule EWallet.Web.MatchAllQueryTest do
       assert contains?(result, token_1)
       refute contains?(result, token_2)
     end
+
+    test "matches a not nil value" do
+      user_1 = insert(:user, username: "not_nil")
+      user_2 = insert(:user, username: nil)
+
+      result =
+        true
+        |> MatchAllQuery.do_filter(:username, nil, "neq", nil)
+        |> on_all(User)
+
+      assert contains?(result, user_1)
+      refute contains?(result, user_2)
+    end
   end
 
   describe "do_filter/5 with 'gt' comparator" do
@@ -225,6 +251,14 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       refute contains?(result, token_1)
       assert contains?(result, token_2)
+    end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAllQuery.do_filter(true, :username, nil, "gt", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "gt", value: nil]
     end
   end
 
@@ -267,6 +301,14 @@ defmodule EWallet.Web.MatchAllQueryTest do
       refute contains?(result, token_1)
       assert contains?(result, token_2)
     end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAllQuery.do_filter(true, :username, nil, "gte", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "gte", value: nil]
+    end
   end
 
   describe "do_filter/5 with 'lt' comparator" do
@@ -307,6 +349,14 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       assert contains?(result, token_1)
       refute contains?(result, token_2)
+    end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAllQuery.do_filter(true, :username, nil, "lt", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "lt", value: nil]
     end
   end
 
@@ -349,6 +399,14 @@ defmodule EWallet.Web.MatchAllQueryTest do
       assert contains?(result, token_1)
       refute contains?(result, token_2)
     end
+
+    test "returns :not_supported error with a nil value" do
+      {res, code, meta} = MatchAllQuery.do_filter(true, :username, nil, "lte", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "lte", value: nil]
+    end
   end
 
   describe "do_filter/5 with 'contains' comparator" do
@@ -364,6 +422,14 @@ defmodule EWallet.Web.MatchAllQueryTest do
       refute contains?(result, user_1)
       assert contains?(result, user_2)
     end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAllQuery.do_filter(true, :username, nil, "contains", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "contains", value: nil]
+    end
   end
 
   describe "do_filter/5 with 'starts_with' comparator" do
@@ -378,6 +444,14 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       refute contains?(result, user_1)
       assert contains?(result, user_2)
+    end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAllQuery.do_filter(true, :username, nil, "starts_with", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "starts_with", value: nil]
     end
   end
 end

--- a/apps/ewallet/test/ewallet/web/filters/match_any_query_test.exs
+++ b/apps/ewallet/test/ewallet/web/filters/match_any_query_test.exs
@@ -77,6 +77,21 @@ defmodule EWallet.Web.MatchAnyQueryTest do
       refute contains?(result, user_2)
       refute contains?(result, user_3)
     end
+
+    test "matches a nil value" do
+      user_1 = insert(:user, username: "not_nil")
+      user_2 = insert(:user, username: nil)
+      user_3 = insert(:user, username: nil)
+
+      result =
+        false
+        |> MatchAnyQuery.do_filter(:username, nil, "eq", nil)
+        |> on_all(User)
+
+      refute contains?(result, user_1)
+      assert contains?(result, user_2)
+      assert contains?(result, user_3)
+    end
   end
 
   describe "do_filter/5 with 'eq' comparator" do
@@ -130,6 +145,21 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       refute contains?(result, token_1)
       assert contains?(result, token_2)
+    end
+
+    test "matches a not nil value" do
+      user_1 = insert(:user, username: "not_nil")
+      user_2 = insert(:user, username: nil)
+      user_3 = insert(:user, username: "another_not_nil")
+
+      result =
+        false
+        |> MatchAnyQuery.do_filter(:username, nil, "neq", nil)
+        |> on_all(User)
+
+      assert contains?(result, user_1)
+      refute contains?(result, user_2)
+      assert contains?(result, user_3)
     end
   end
 
@@ -185,6 +215,21 @@ defmodule EWallet.Web.MatchAnyQueryTest do
       assert contains?(result, token_1)
       refute contains?(result, token_2)
     end
+
+    test "matches a not nil value" do
+      user_1 = insert(:user, username: "not_nil")
+      user_2 = insert(:user, username: nil)
+      user_3 = insert(:user, username: nil)
+
+      result =
+        false
+        |> MatchAnyQuery.do_filter(:username, nil, "neq", nil)
+        |> on_all(User)
+
+      assert contains?(result, user_1)
+      refute contains?(result, user_2)
+      refute contains?(result, user_3)
+    end
   end
 
   describe "do_filter/5 with 'gt' comparator" do
@@ -225,6 +270,14 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       refute contains?(result, token_1)
       assert contains?(result, token_2)
+    end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAnyQuery.do_filter(false, :username, nil, "gt", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "gt", value: nil]
     end
   end
 
@@ -267,6 +320,14 @@ defmodule EWallet.Web.MatchAnyQueryTest do
       refute contains?(result, token_1)
       assert contains?(result, token_2)
     end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAnyQuery.do_filter(false, :username, nil, "gte", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "gte", value: nil]
+    end
   end
 
   describe "do_filter/5 with 'lt' comparator" do
@@ -307,6 +368,14 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       assert contains?(result, token_1)
       refute contains?(result, token_2)
+    end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAnyQuery.do_filter(false, :username, nil, "lt", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "lt", value: nil]
     end
   end
 
@@ -349,6 +418,14 @@ defmodule EWallet.Web.MatchAnyQueryTest do
       assert contains?(result, token_1)
       refute contains?(result, token_2)
     end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAnyQuery.do_filter(false, :username, nil, "lte", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "lte", value: nil]
+    end
   end
 
   describe "do_filter/5 with 'contains' comparator" do
@@ -364,6 +441,14 @@ defmodule EWallet.Web.MatchAnyQueryTest do
       refute contains?(result, user_1)
       assert contains?(result, user_2)
     end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAnyQuery.do_filter(false, :username, nil, "contains", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "contains", value: nil]
+    end
   end
 
   describe "do_filter/5 with 'starts_with' comparator" do
@@ -378,6 +463,14 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       refute contains?(result, user_1)
       assert contains?(result, user_2)
+    end
+
+    test "returns :not_supported error when given a nil value" do
+      {res, code, meta} = MatchAnyQuery.do_filter(false, :username, nil, "starts_with", nil)
+
+      assert res == :error
+      assert code == :comparator_not_supported
+      assert meta == [field: :username, comparator: "starts_with", value: nil]
     end
   end
 end


### PR DESCRIPTION
Issue/Task Number: #531
Closes #531

# Overview

This adds support for nil value to `match_any` and `match_all` filtering

# Changes

- Adds supports for nil value filtering
- Add proper error handling when filtering certain types of values is not supported

# Implementation Details

This is simple addition to MatchAnyQuery and MatchAllQuery to support `nil` value comparison, which is required by Ecto to use `is_nil/1` and not `== nil`

# Usage

Try requesting with `match_all`, `match_any` with nil values

# Impact

No changes to the API specs or DB schemas.