### PR TITLE
typo in admin API spec

### DIFF
--- a/apps/admin_api/priv/spec.json
+++ b/apps/admin_api/priv/spec.json
@@ -273,7 +273,7 @@
     "/role.all" : {
       "post" : {
         "tags" : [ "Role" ],
-        "summary" : "Get the list of tokens",
+        "summary" : "Get the list of roles",
         "operationId" : "role_all",
         "requestBody" : {
           "$ref" : "#/components/requestBodies/RoleAllBody"

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -177,7 +177,7 @@ paths:
     post:
       tags:
         - Role
-      summary: Get the list of tokens
+      summary: Get the list of roles
       operationId: role_all
       security:
         - ProviderAuth: []


### PR DESCRIPTION
# Overview

There is a small typo in the API specs

# Changes

- Updated the label in the YML file, as well as the JSON file

# Implementation Details

Changed both files, but if one is generated by the other, please let me know in case I find others