### PR TITLE
Fix /api/admin/account.get_members returning error 500 when filtering

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_membership_controller_test.exs
@@ -192,6 +192,91 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                  }
                }
     end
+
+    # This is a variation of `ConnCase.test_supports_match_any/5` that inserts
+    # an admin and a membership in order for the inserted admin to appear in the result.
+    test "supports match_any filtering" do
+      admin_1 = insert(:admin, username: "value_1")
+      admin_2 = insert(:admin, username: "value_2")
+      admin_3 = insert(:admin, username: "value_3")
+      admin_4 = insert(:admin, username: "value_4")
+      account = insert(:account)
+
+      _ = insert(:membership, %{user: admin_1, account: account})
+      _ = insert(:membership, %{user: admin_2, account: account})
+      _ = insert(:membership, %{user: admin_3, account: account})
+      _ = insert(:membership, %{user: admin_4, account: account})
+
+      attrs = %{
+        "id" => account.id,
+        "match_any" => [
+          %{
+            "field" => "username",
+            "comparator" => "eq",
+            "value" => "value_2"
+          },
+          %{
+            "field" => "username",
+            "comparator" => "eq",
+            "value" => "value_4"
+          }
+        ]
+      }
+
+      response = admin_user_request("/account.get_members", attrs)
+
+      assert response["success"]
+
+      records = response["data"]["data"]
+
+      refute Enum.any?(records, fn r -> r["id"] == admin_1.id end)
+      assert Enum.any?(records, fn r -> r["id"] == admin_2.id end)
+      refute Enum.any?(records, fn r -> r["id"] == admin_3.id end)
+      assert Enum.any?(records, fn r -> r["id"] == admin_4.id end)
+      assert Enum.count(records) == 2
+    end
+
+    # This is a variation of `ConnCase.test_supports_match_all/5` that inserts
+    # an admin and a membership in order for the inserted admin to appear in the result.
+    test "supports match_all filtering" do
+      admin_1 = insert(:admin, %{username: "this_should_almost_match"})
+      admin_2 = insert(:admin, %{username: "this_should_match"})
+      admin_3 = insert(:admin, %{username: "should_not_match"})
+      admin_4 = insert(:admin, %{username: "also_should_not_match"})
+      account = insert(:account)
+
+      _ = insert(:membership, %{user: admin_1, account: account})
+      _ = insert(:membership, %{user: admin_2, account: account})
+      _ = insert(:membership, %{user: admin_3, account: account})
+      _ = insert(:membership, %{user: admin_4, account: account})
+
+      attrs = %{
+        "id" => account.id,
+        "match_all" => [
+          %{
+            "field" => "username",
+            "comparator" => "starts_with",
+            "value" => "this_should"
+          },
+          %{
+            "field" => "username",
+            "comparator" => "contains",
+            "value" => "should_match"
+          }
+        ]
+      }
+
+      response = admin_user_request("/admin.all", attrs)
+
+      assert response["success"]
+
+      records = response["data"]["data"]
+      refute Enum.any?(records, fn r -> r["id"] == admin_1.id end)
+      assert Enum.any?(records, fn r -> r["id"] == admin_2.id end)
+      refute Enum.any?(records, fn r -> r["id"] == admin_3.id end)
+      refute Enum.any?(records, fn r -> r["id"] == admin_4.id end)
+      assert Enum.count(records) == 1
+    end
   end
 
   describe "/account.assign_user" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_membership_controller_test.exs
@@ -195,7 +195,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
 
     # This is a variation of `ConnCase.test_supports_match_any/5` that inserts
     # an admin and a membership in order for the inserted admin to appear in the result.
-    test "supports match_any filtering" do
+    test "supports match_any filtering on the user fields" do
       admin_1 = insert(:admin, username: "value_1")
       admin_2 = insert(:admin, username: "value_2")
       admin_3 = insert(:admin, username: "value_3")
@@ -210,11 +210,13 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       attrs = %{
         "id" => account.id,
         "match_any" => [
+          # Filter for `user.username`
           %{
             "field" => "username",
             "comparator" => "eq",
             "value" => "value_2"
           },
+          # Filter for `user.username`
           %{
             "field" => "username",
             "comparator" => "eq",
@@ -236,9 +238,53 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert Enum.count(records) == 2
     end
 
+    # This is a variation of `ConnCase.test_supports_match_any/5` that inserts
+    # an admin and a membership in order for the inserted admin to appear in the result.
+    test "supports match_any filtering on the membership fields" do
+      admin_1 = insert(:admin, username: "value_1")
+      admin_2 = insert(:admin, username: "value_2")
+      admin_3 = insert(:admin, username: "value_3")
+      account = insert(:account)
+      role_1 = insert(:role)
+      role_2 = insert(:role)
+
+      _ = insert(:membership, %{user: admin_1, account: account, role: role_1})
+      _ = insert(:membership, %{user: admin_2, account: account, role: role_2})
+      _ = insert(:membership, %{user: admin_3, account: account, role: role_2})
+
+      attrs = %{
+        "id" => account.id,
+        "match_any" => [
+          # Filter for `membership.role.name`
+          %{
+            "field" => "role.name",
+            "comparator" => "eq",
+            "value" => role_1.name
+          },
+          # Filter for `user.username`
+          %{
+            "field" => "username",
+            "comparator" => "eq",
+            "value" => admin_3.username
+          }
+        ]
+      }
+
+      response = admin_user_request("/account.get_members", attrs)
+
+      assert response["success"]
+
+      records = response["data"]["data"]
+
+      assert Enum.any?(records, fn r -> r["id"] == admin_1.id end)
+      refute Enum.any?(records, fn r -> r["id"] == admin_2.id end)
+      assert Enum.any?(records, fn r -> r["id"] == admin_3.id end)
+      assert Enum.count(records) == 2
+    end
+
     # This is a variation of `ConnCase.test_supports_match_all/5` that inserts
     # an admin and a membership in order for the inserted admin to appear in the result.
-    test "supports match_all filtering" do
+    test "supports match_all filtering on user fields" do
       admin_1 = insert(:admin, %{username: "this_should_almost_match"})
       admin_2 = insert(:admin, %{username: "this_should_match"})
       admin_3 = insert(:admin, %{username: "should_not_match"})
@@ -253,11 +299,13 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       attrs = %{
         "id" => account.id,
         "match_all" => [
+          # Filter for `user.username`
           %{
             "field" => "username",
             "comparator" => "starts_with",
             "value" => "this_should"
           },
+          # Filter for `user.username`
           %{
             "field" => "username",
             "comparator" => "contains",
@@ -266,7 +314,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
         ]
       }
 
-      response = admin_user_request("/admin.all", attrs)
+      response = admin_user_request("/account.get_members", attrs)
 
       assert response["success"]
 
@@ -275,6 +323,49 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
       assert Enum.any?(records, fn r -> r["id"] == admin_2.id end)
       refute Enum.any?(records, fn r -> r["id"] == admin_3.id end)
       refute Enum.any?(records, fn r -> r["id"] == admin_4.id end)
+      assert Enum.count(records) == 1
+    end
+
+    # This is a variation of `ConnCase.test_supports_match_any/5` that inserts
+    # an admin and a membership in order for the inserted admin to appear in the result.
+    test "supports match_all filtering on membership fields" do
+      admin_1 = insert(:admin)
+      admin_2 = insert(:admin)
+      admin_3 = insert(:admin)
+      account = insert(:account)
+      role_1 = insert(:role)
+      role_2 = insert(:role)
+
+      _ = insert(:membership, %{user: admin_1, account: account, role: role_1})
+      _ = insert(:membership, %{user: admin_2, account: account, role: role_1})
+      _ = insert(:membership, %{user: admin_3, account: account, role: role_2})
+
+      attrs = %{
+        "id" => account.id,
+        "match_all" => [
+          # Filter for `membership.role.name`
+          %{
+            "field" => "role.name",
+            "comparator" => "eq",
+            "value" => role_1.name
+          },
+          # Filter for `membership.id`
+          %{
+            "field" => "id",
+            "comparator" => "eq",
+            "value" => admin_1.id
+          }
+        ]
+      }
+
+      response = admin_user_request("/account.get_members", attrs)
+
+      assert response["success"]
+
+      records = response["data"]["data"]
+      assert Enum.any?(records, fn r -> r["id"] == admin_1.id end)
+      refute Enum.any?(records, fn r -> r["id"] == admin_2.id end)
+      refute Enum.any?(records, fn r -> r["id"] == admin_3.id end)
       assert Enum.count(records) == 1
     end
   end


### PR DESCRIPTION
Issue/Task Number: #537 
Closes #537 

# Overview

This PR fixes the error 500 when filtering on `/api/admin/account.get_members`.

# Changes

- Add handling for `{:error, :not_allowed, field}` in `AccountMembershipController`
- Converts top level fields to query under `membership.user`

# Implementation Details

- Added handling for `{:error, :not_allowed, field}` which is handled in other controllers
- Note that before converting filter fields from `field: email` to `field: user.email`, there's an extra check to make sure the fields are allowed by the `UserOverlay`

# Usage

Example:

```sh
curl 10.5.10.10:4000/api/admin/account.get_members \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGAdmin <truncated>" \
-H "Content-Type: application/json" \
-d '{
  "id": "acc_01cwtpfkzkfdwb795aw5gmqzzv",
  "match_all": [
    {
      "field": "id",
      "comparator": "contains",
      "value": "usr_01cwtpf"
    },
    {
      "field": "email",
      "comparator": "contains",
      "value": "@"
    }
  ]
}' \
-v -w "\n"
```

# Impact

No changes to the API specs or DB schemas
