### PR TITLE
Fix test seeds

### DIFF
--- a/apps/ewallet_db/priv/repo/seeds_test/10_setting.exs
+++ b/apps/ewallet_db/priv/repo/seeds_test/10_setting.exs
@@ -10,10 +10,9 @@ defmodule EWalletDB.Repo.Seeds.SettingsSeed do
   end
 
   def run(writer, _args) do
-    {:ok, [ok: %Setting{}]} = Config.update(%{
+    {:ok, [enable_standalone: {:ok, %Setting{}}]} = Config.update(%{
       enable_standalone: true
     })
-
     writer.warn("""
       Enable standalone : #{Config.get(:enable_standalone)}
     """)


### PR DESCRIPTION
Issue/Task Number: 564
Closes #564 

# Overview

This PR fixes the test seed that were crashing.

# Changes

-  Update the left hand side check to match the correct response of the setting update

# Usage

Run the test seeds

`E2E_ENABLED=true mix seed --test --yes`

# Impact

N/A