### PR TITLE
Stricter Redirect URL prefixes comparison

### DIFF
--- a/apps/ewallet/lib/ewallet/web/url_validator.ex
+++ b/apps/ewallet/lib/ewallet/web/url_validator.ex
@@ -4,7 +4,7 @@ defmodule EWallet.Web.UrlValidator do
   """
 
   @doc """
-  Checks that the given url is allowed as a redirect url.
+  Checks that the given url is allowed as a redirect url in the application settings.
   """
   def allowed_redirect_url?(url) do
     base_url = Application.get_env(:ewallet, :base_url)
@@ -14,6 +14,9 @@ defmodule EWallet.Web.UrlValidator do
     Enum.any?(allowed, fn prefix -> allowed_redirect_url?(url, prefix) end)
   end
 
+  @doc """
+  Checks that the given url is allowed by the given prefix
+  """
   def allowed_redirect_url?(url, prefix) do
     # Add trailing slashes to prevent urls such as 'https://example.comnotexample.com'
     # matching 'https://example.com'

--- a/apps/ewallet/lib/ewallet/web/url_validator.ex
+++ b/apps/ewallet/lib/ewallet/web/url_validator.ex
@@ -11,6 +11,19 @@ defmodule EWallet.Web.UrlValidator do
     prefixes = Application.get_env(:ewallet, :redirect_url_prefixes)
     allowed = [base_url | prefixes]
 
-    Enum.any?(allowed, fn prefix -> String.starts_with?(url, prefix) end)
+    Enum.any?(allowed, fn prefix -> allowed_redirect_url?(url, prefix) end)
+  end
+
+  def allowed_redirect_url?(url, prefix) do
+    # Add trailing slashes to prevent urls such as 'https://example.comnotexample.com'
+    # matching 'https://example.com'
+    url = trailing_slashed(url)
+    prefix = trailing_slashed(prefix)
+
+    String.starts_with?(url, prefix)
+  end
+
+  defp trailing_slashed(string) do
+    if String.ends_with?(string, "/"), do: string, else: string <> "/"
   end
 end

--- a/apps/ewallet/lib/ewallet/web/url_validator.ex
+++ b/apps/ewallet/lib/ewallet/web/url_validator.ex
@@ -18,15 +18,15 @@ defmodule EWallet.Web.UrlValidator do
   Checks that the given url is allowed by the given prefix
   """
   def allowed_redirect_url?(url, prefix) do
-    # Add trailing slashes to prevent urls such as 'https://example.comnotexample.com'
-    # matching 'https://example.com'
-    url = trailing_slashed(url)
-    prefix = trailing_slashed(prefix)
+    # Add trailing slashes to prevent urls such as "https://example.comnotexample.com"
+    # matching "https://example.com"
+    url = trailing_slash(url)
+    prefix = trailing_slash(prefix)
 
     String.starts_with?(url, prefix)
   end
 
-  defp trailing_slashed(string) do
-    if String.ends_with?(string, "/"), do: string, else: string <> "/"
+  defp trailing_slash(string) do
+    string |> URI.merge("/") |> to_string()
   end
 end

--- a/apps/ewallet/lib/ewallet/web/url_validator.ex
+++ b/apps/ewallet/lib/ewallet/web/url_validator.ex
@@ -18,15 +18,15 @@ defmodule EWallet.Web.UrlValidator do
   Checks that the given url is allowed by the given prefix
   """
   def allowed_redirect_url?(url, prefix) do
-    # Add trailing slashes to prevent urls such as "https://example.comnotexample.com"
-    # matching "https://example.com"
-    url = trailing_slash(url)
-    prefix = trailing_slash(prefix)
+    # Add trailing slashes to prevent urls such as 'https://example.comnotexample.com'
+    # matching 'https://example.com'
+    url = trailing_slashed(url)
+    prefix = trailing_slashed(prefix)
 
     String.starts_with?(url, prefix)
   end
 
-  defp trailing_slash(string) do
-    string |> URI.merge("/") |> to_string()
+  defp trailing_slashed(string) do
+    if String.ends_with?(string, "/"), do: string, else: string <> "/"
   end
 end

--- a/apps/ewallet/test/ewallet/web/url_validator_test.exs
+++ b/apps/ewallet/test/ewallet/web/url_validator_test.exs
@@ -5,25 +5,72 @@ defmodule EWallet.Web.UrlValidatorTest do
   alias ActivityLogger.System
 
   describe "allowed_redirect_url?/1" do
-    test "returns true if the given url has the whitelisted prefix", meta do
+    setup meta do
       {:ok, [redirect_url_prefixes: {:ok, _}]} =
         Config.update(
           [
-            redirect_url_prefixes: ["http://test_redirect_prefix"],
+            redirect_url_prefixes: [
+              "https://example.com/allowed",
+              "https://another.example.com/allowed"
+            ],
             originator: %System{}
           ],
           meta[:config_pid]
         )
 
-      assert UrlValidator.allowed_redirect_url?("http://test_redirect_prefix/allowed")
+      :ok
     end
 
-    test "returns true if the given url is prefixed with the base url" do
-      assert UrlValidator.allowed_redirect_url?("http://localhost:4000/allowed")
+    test "returns true if the given url matches at least one of the prefixes" do
+      assert UrlValidator.allowed_redirect_url?("https://example.com/allowed")
+      assert UrlValidator.allowed_redirect_url?("https://another.example.com/allowed")
     end
 
-    test "returns false if the given url is not in the whitelisted prefixes" do
-      refute UrlValidator.allowed_redirect_url?("http://something-else.com/allowed")
+    test "returns false if the given url matches none of the prefixes" do
+      refute UrlValidator.allowed_redirect_url?("https://example.com")
+      refute UrlValidator.allowed_redirect_url?("https://another.example.com")
+      refute UrlValidator.allowed_redirect_url?("https://example.com/not-allowed")
+      refute UrlValidator.allowed_redirect_url?("https://another.example.com/not-allowed")
+    end
+  end
+
+  describe "allowed_redirect_url?/2 with a non-trailing slashed prefix" do
+    setup do
+      {:ok, %{allowed: "https://example.com"}}
+    end
+
+    test "returns true if the given url matches the prefix", meta do
+      assert UrlValidator.allowed_redirect_url?("https://example.com", meta.allowed)
+      assert UrlValidator.allowed_redirect_url?("https://example.com/", meta.allowed)
+      assert UrlValidator.allowed_redirect_url?("https://example.com/segment", meta.allowed)
+      assert UrlValidator.allowed_redirect_url?("https://example.com/segment/", meta.allowed)
+    end
+
+    test "returns false if the given url does not match the prefix", meta do
+      refute UrlValidator.allowed_redirect_url?("https://something-else.com", meta.allowed)
+      refute UrlValidator.allowed_redirect_url?("https://example.com@fake.com", meta.allowed)
+      refute UrlValidator.allowed_redirect_url?("https://example.comfake.com", meta.allowed)
+      refute UrlValidator.allowed_redirect_url?("https://example.com.fake.com", meta.allowed)
+    end
+  end
+
+  describe "allowed_redirect_url?/2 with a trailing-slashed prefix" do
+    setup do
+      {:ok, %{allowed: "https://example.com/"}}
+    end
+
+    test "returns true if the given url matches the prefix", meta do
+      assert UrlValidator.allowed_redirect_url?("https://example.com", meta.allowed)
+      assert UrlValidator.allowed_redirect_url?("https://example.com/", meta.allowed)
+      assert UrlValidator.allowed_redirect_url?("https://example.com/segment", meta.allowed)
+      assert UrlValidator.allowed_redirect_url?("https://example.com/segment/", meta.allowed)
+    end
+
+    test "returns false if the given url does not match the prefix", meta do
+      refute UrlValidator.allowed_redirect_url?("https://something-else.com", meta.allowed)
+      refute UrlValidator.allowed_redirect_url?("https://example.com@fake.com", meta.allowed)
+      refute UrlValidator.allowed_redirect_url?("https://example.comfake.com", meta.allowed)
+      refute UrlValidator.allowed_redirect_url?("https://example.com.fake.com", meta.allowed)
     end
   end
 end


### PR DESCRIPTION
Issue/Task Number: #583
Closes #583 

# Overview

This PR imposes a stricter redirect URL prefixes to prevent bypassing the checks with a domain name that contains the whole prefix.

# Changes

- Updated `EWallet.Web.UrlValidator.allowed_redirect_url?/1` to add trailing slashes to both the given url and the allowed prefixes before the comparison.
- Add more tests with values as suggested by @jpopxfile

# Implementation Details

- `String.start_with/2` is used instead of regex as it should be more performant.
- Also the trailing slashes are added during the comparison instead of when the values are saved to the database. This should be safer as this makes the check independent of the functions that save the settings to the database.

# Usage

Set `redirect_url_prefixes` settings to "http://example.com". Then try reset password with `redirect_url: http://example.com.phishing.com/redirect_url?email={email}&token={token}`. The server should return a "redirect_url is not allowed" error.

# Impact

No changes to the DB schema or API specs
