### PR TITLE
isAbsouluteURL Scheme Whitelist

### DIFF
--- a/apps/admin_panel/assets/src/utils/url.js
+++ b/apps/admin_panel/assets/src/utils/url.js
@@ -25,5 +25,12 @@ export function appendParams (url, params) {
 }
 
 export function isAbsoluteURL (url) {
-  return /^([a-z][a-z\d+\-.]*:)?\/\//i.test(url)
+	let schemeWhitelist =  ["http://", "https://", "ws://", "wss://"];
+	for (let i = 0; i < schemeWhitelist.length; i++) {
+		let scheme =  schemeWhitelist[i];
+		if (url.startsWith(scheme)) {
+			return true;
+		}
+	}
+	return false;
 };


### PR DESCRIPTION
Restrict url schemes to http, https, ws and wss

Issue/Task Number: https://github.com/omisego/ewallet/issues/599

# Overview

Restrict url schemes to http, https, ws and wss.

# Changes

Check if url starts with any of the whitelist schemes.

# Implementation Details

Previous check allowed any scheme, so I added an array of schemes to check against for the start of a url.

# Usage

False Example:
isAbsoluteURL("javascript://example.com")
=> 
false

True Example:
isAbsoluteURL("https://example.com")
=>
true

# Impact

Should not have any impact as this function is currently only used for parsing of the url before websocket connection here. https://github.com/omisego/ewallet/blob/master/apps/admin_panel/assets/src/socket/connector.js#L32
