### PR TITLE
Revert date format time zone serialization

### DIFF
--- a/apps/activity_logger/lib/activity_logger/activity_log.ex
+++ b/apps/activity_logger/lib/activity_logger/activity_log.ex
@@ -20,7 +20,7 @@ defmodule ActivityLogger.ActivityLog do
   use Utils.Types.ExternalID
   import Ecto.{Changeset, Query}
   alias Ecto.{Changeset, UUID}
-  alias Utils.Helpers.Assoc
+  alias Utils.Helpers.{Assoc, DateFormatter}
 
   alias ActivityLogger.{
     ActivityLog,
@@ -227,6 +227,20 @@ defmodule ActivityLogger.ActivityLog do
 
   defp format_value(%Changeset{} = value) do
     value.data.uuid
+  end
+
+  defp format_value(%DateTime{} = value) do
+    DateFormatter.to_iso8601(value)
+  end
+
+  defp format_value(%NaiveDateTime{} = value) do
+    DateFormatter.to_iso8601(value)
+  end
+
+  defp format_value(values) when is_map(values) do
+    Enum.into(values, %{}, fn {key, value} ->
+      {key, format_value(value)}
+    end)
   end
 
   defp format_value(value), do: value

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_controller_test.exs
@@ -16,6 +16,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWalletDB.{Account, Membership, Repo, Role, User}
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "/account.all" do
     test "returns a list of accounts and pagination data" do
@@ -634,7 +635,7 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
         changes: %{
           "avatar" => %{
             "file_name" => "test.jpg",
-            "updated_at" => NaiveDateTime.to_iso8601(account.avatar.updated_at)
+            "updated_at" => DateFormatter.to_iso8601(account.avatar.updated_at)
           }
         },
         encrypted_changes: %{}

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_membership_controller_test.exs
@@ -15,7 +15,7 @@
 defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
   use AdminAPI.ConnCase, async: true
   alias Ecto.UUID
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.{Account, User, Membership}
 
   @redirect_url "http://localhost:4000/invite?email={email}&token={token}"
@@ -46,8 +46,8 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                "email" => user.email,
                "metadata" => user.metadata,
                "encrypted_metadata" => %{},
-               "created_at" => Date.to_iso8601(user.inserted_at),
-               "updated_at" => Date.to_iso8601(user.updated_at),
+               "created_at" => DateFormatter.to_iso8601(user.inserted_at),
+               "updated_at" => DateFormatter.to_iso8601(user.updated_at),
                "account_role" => role.name,
                "status" => to_string(User.get_status(user)),
                "enabled" => user.enabled,
@@ -70,8 +70,8 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                  "object" => "account",
                  "parent_id" => account.parent.id,
                  "socket_topic" => "account:#{account.id}",
-                 "created_at" => Date.to_iso8601(account.inserted_at),
-                 "updated_at" => Date.to_iso8601(account.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(account.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(account.updated_at)
                }
              })
 
@@ -86,8 +86,8 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                "email" => admin.email,
                "metadata" => admin.metadata,
                "encrypted_metadata" => %{},
-               "created_at" => Date.to_iso8601(admin.inserted_at),
-               "updated_at" => Date.to_iso8601(admin.updated_at),
+               "created_at" => DateFormatter.to_iso8601(admin.inserted_at),
+               "updated_at" => DateFormatter.to_iso8601(admin.updated_at),
                "account_role" => "admin",
                "status" => to_string(User.get_status(admin)),
                "enabled" => admin.enabled,
@@ -110,8 +110,8 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                  "object" => "account",
                  "parent_id" => nil,
                  "socket_topic" => "account:#{master.id}",
-                 "created_at" => Date.to_iso8601(master.inserted_at),
-                 "updated_at" => Date.to_iso8601(master.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(master.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(master.updated_at)
                }
              })
     end
@@ -139,8 +139,8 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                        "email" => admin.email,
                        "metadata" => admin.metadata,
                        "encrypted_metadata" => %{},
-                       "created_at" => Date.to_iso8601(admin.inserted_at),
-                       "updated_at" => Date.to_iso8601(admin.updated_at),
+                       "created_at" => DateFormatter.to_iso8601(admin.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(admin.updated_at),
                        "account_role" => "admin",
                        "status" => to_string(User.get_status(admin)),
                        "enabled" => admin.enabled,
@@ -168,8 +168,8 @@ defmodule AdminAPI.V1.AdminAuth.AccountMembershipControllerTest do
                          "object" => "account",
                          "parent_id" => nil,
                          "socket_topic" => "account:#{master.id}",
-                         "created_at" => Date.to_iso8601(master.inserted_at),
-                         "updated_at" => Date.to_iso8601(master.updated_at)
+                         "created_at" => DateFormatter.to_iso8601(master.inserted_at),
+                         "updated_at" => DateFormatter.to_iso8601(master.updated_at)
                        }
                      }
                    ]

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.Helpers.Preloader
   alias EWalletDB.{Account, APIKey, Repo}
 
@@ -37,9 +37,9 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
                        "owner_app" => api_key1.owner_app,
                        "expired" => false,
                        "enabled" => true,
-                       "created_at" => Date.to_iso8601(api_key1.inserted_at),
-                       "updated_at" => Date.to_iso8601(api_key1.updated_at),
-                       "deleted_at" => Date.to_iso8601(api_key1.deleted_at)
+                       "created_at" => DateFormatter.to_iso8601(api_key1.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(api_key1.updated_at),
+                       "deleted_at" => DateFormatter.to_iso8601(api_key1.deleted_at)
                      },
                      %{
                        "object" => "api_key",
@@ -49,9 +49,9 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
                        "owner_app" => api_key2.owner_app,
                        "expired" => false,
                        "enabled" => true,
-                       "created_at" => Date.to_iso8601(api_key2.inserted_at),
-                       "updated_at" => Date.to_iso8601(api_key2.updated_at),
-                       "deleted_at" => Date.to_iso8601(api_key2.deleted_at)
+                       "created_at" => DateFormatter.to_iso8601(api_key2.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(api_key2.updated_at),
+                       "deleted_at" => DateFormatter.to_iso8601(api_key2.deleted_at)
                      }
                    ],
                    "pagination" => %{
@@ -92,9 +92,9 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
                        "owner_app" => api_key.owner_app,
                        "expired" => false,
                        "enabled" => true,
-                       "created_at" => Date.to_iso8601(api_key.inserted_at),
-                       "updated_at" => Date.to_iso8601(api_key.updated_at),
-                       "deleted_at" => Date.to_iso8601(api_key.deleted_at)
+                       "created_at" => DateFormatter.to_iso8601(api_key.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(api_key.updated_at),
+                       "deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)
                      }
                    ],
                    "pagination" => %{
@@ -128,9 +128,9 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
                  "owner_app" => "ewallet_api",
                  "expired" => false,
                  "enabled" => true,
-                 "created_at" => Date.to_iso8601(api_key.inserted_at),
-                 "updated_at" => Date.to_iso8601(api_key.updated_at),
-                 "deleted_at" => Date.to_iso8601(api_key.deleted_at)
+                 "created_at" => DateFormatter.to_iso8601(api_key.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(api_key.updated_at),
+                 "deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)
                }
              }
     end
@@ -219,9 +219,9 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
                  "enabled" => false,
                  "account_id" => api_key.account.id,
                  "owner_app" => api_key.owner_app,
-                 "created_at" => Date.to_iso8601(api_key.inserted_at),
-                 "updated_at" => Date.to_iso8601(updated.updated_at),
-                 "deleted_at" => Date.to_iso8601(api_key.deleted_at)
+                 "created_at" => DateFormatter.to_iso8601(api_key.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(updated.updated_at),
+                 "deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)
                }
              }
     end
@@ -401,7 +401,7 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
         action: "update",
         originator: get_test_admin(),
         target: api_key,
-        changes: %{"deleted_at" => NaiveDateTime.to_iso8601(api_key.deleted_at)},
+        changes: %{"deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/category_controller_test.exs
@@ -17,6 +17,7 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
   alias EWalletDB.{Category, Repo}
   alias EWalletDB.Helpers.Preloader
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "/category.all" do
     test "returns a list of categories and pagination data" do
@@ -322,7 +323,7 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
         action: "update",
         originator: get_test_admin(),
         target: category,
-        changes: %{"deleted_at" => NaiveDateTime.to_iso8601(category.deleted_at)},
+        changes: %{"deleted_at" => DateFormatter.to_iso8601(category.deleted_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
@@ -16,6 +16,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWalletDB.{ExchangePair, Repo}
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "/exchange_pair.all" do
     test "returns a list of exchange pairs and pagination data" do
@@ -531,7 +532,7 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
         originator: get_test_admin(),
         target: exchange_pair,
         changes: %{
-          "deleted_at" => NaiveDateTime.to_iso8601(exchange_pair.deleted_at)
+          "deleted_at" => DateFormatter.to_iso8601(exchange_pair.deleted_at)
         },
         encrypted_changes: %{}
       )

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/invite_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/invite_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.AdminAuth.InviteControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.{Invite, User, Repo}
   alias ActivityLogger.System
 
@@ -50,8 +50,8 @@ defmodule AdminAPI.V1.AdminAuth.InviteControllerTest do
           "last_name" => invite.user.metadata["last_name"]
         },
         "encrypted_metadata" => %{},
-        "created_at" => Date.to_iso8601(invite.user.inserted_at),
-        "updated_at" => Date.to_iso8601(invite.user.updated_at)
+        "created_at" => DateFormatter.to_iso8601(invite.user.inserted_at),
+        "updated_at" => DateFormatter.to_iso8601(invite.user.updated_at)
       }
 
       assert response["success"]
@@ -104,7 +104,7 @@ defmodule AdminAPI.V1.AdminAuth.InviteControllerTest do
         action: "update",
         originator: user,
         target: invite,
-        changes: %{"verified_at" => NaiveDateTime.to_iso8601(invite.verified_at)},
+        changes: %{"verified_at" => DateFormatter.to_iso8601(invite.verified_at)},
         encrypted_changes: %{}
       )
 

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.AdminAuth.KeyControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.{Account, Key, Repo}
 
   describe "/access_key.all" do
@@ -72,9 +72,9 @@ defmodule AdminAPI.V1.AdminAuth.KeyControllerTest do
       assert response["data"]["account_id"] == Account.get_master_account().id
       assert response["data"]["expired"] == !key.enabled
       assert response["data"]["enabled"] == key.enabled
-      assert response["data"]["created_at"] == Date.to_iso8601(key.inserted_at)
-      assert response["data"]["updated_at"] == Date.to_iso8601(key.updated_at)
-      assert response["data"]["deleted_at"] == Date.to_iso8601(key.deleted_at)
+      assert response["data"]["created_at"] == DateFormatter.to_iso8601(key.inserted_at)
+      assert response["data"]["updated_at"] == DateFormatter.to_iso8601(key.updated_at)
+      assert response["data"]["deleted_at"] == DateFormatter.to_iso8601(key.deleted_at)
 
       # We cannot know the `secret_key` from the controller call,
       # so we can only check that it is a string with some length.
@@ -342,7 +342,7 @@ defmodule AdminAPI.V1.AdminAuth.KeyControllerTest do
         action: "update",
         originator: get_test_admin(),
         target: key,
-        changes: %{"deleted_at" => NaiveDateTime.to_iso8601(key.deleted_at)},
+        changes: %{"deleted_at" => DateFormatter.to_iso8601(key.deleted_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/mint_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/mint_controller_test.exs
@@ -15,7 +15,7 @@
 defmodule AdminAPI.V1.AdminAuth.MintControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWallet.MintGate
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWallet.Web.V1.{AccountSerializer, TokenSerializer, TransactionSerializer}
   alias EWalletDB.{Mint, Account, Transaction, Wallet, Repo}
   alias ActivityLogger.System
@@ -70,8 +70,8 @@ defmodule AdminAPI.V1.AdminAuth.MintControllerTest do
         "transaction" =>
           inserted_mint.transaction |> TransactionSerializer.serialize() |> stringify_keys(),
         "transaction_id" => inserted_mint.transaction.id,
-        "created_at" => Date.to_iso8601(inserted_mint.inserted_at),
-        "updated_at" => Date.to_iso8601(inserted_mint.updated_at)
+        "created_at" => DateFormatter.to_iso8601(inserted_mint.inserted_at),
+        "updated_at" => DateFormatter.to_iso8601(inserted_mint.updated_at)
       })
 
       # Asserts pagination data

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/reset_password_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/reset_password_controller_test.exs
@@ -16,7 +16,7 @@ defmodule AdminAPI.V1.AdminAuth.ResetPasswordControllerTest do
   use AdminAPI.ConnCase, async: true
   use Bamboo.Test
   alias EWallet.ForgetPasswordEmail
-  alias Utils.Helpers.Crypto
+  alias Utils.Helpers.{Crypto, DateFormatter}
   alias EWalletDB.{ForgetPasswordRequest, Repo, User}
 
   @redirect_url "http://localhost:4000/reset_password?email={email}&token={token}"
@@ -148,7 +148,7 @@ defmodule AdminAPI.V1.AdminAuth.ResetPasswordControllerTest do
         changes: %{
           "token" => request.token,
           "user_uuid" => user.uuid,
-          "expires_at" => NaiveDateTime.to_iso8601(request.expires_at)
+          "expires_at" => DateFormatter.to_iso8601(request.expires_at)
         },
         encrypted_changes: %{}
       )

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/role_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/role_controller_test.exs
@@ -16,6 +16,7 @@ defmodule AdminAPI.V1.AdminAuth.RoleControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWalletDB.{Membership, Role, Repo}
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "/role.all" do
     test "returns a list of roles and pagination data" do
@@ -306,7 +307,7 @@ defmodule AdminAPI.V1.AdminAuth.RoleControllerTest do
         originator: get_test_admin(),
         target: role,
         changes: %{
-          "deleted_at" => NaiveDateTime.to_iso8601(role.deleted_at)
+          "deleted_at" => DateFormatter.to_iso8601(role.deleted_at)
         },
         encrypted_changes: %{}
       )

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/self_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/self_controller_test.exs
@@ -17,10 +17,9 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
   use Bamboo.Test
   import Ecto.Query
   alias AdminAPI.UpdateEmailAddressEmail
-  alias EWallet.Web.Date
   alias EWalletDB.{Account, Membership, Repo, User}
   alias EWalletDB.{Account, Membership, Repo, UpdateEmailRequest, User}
-  alias Utils.Helpers.{Crypto, Assoc}
+  alias Utils.Helpers.{Crypto, Assoc, DateFormatter}
   alias ActivityLogger.System
 
   @update_email_url "http://localhost:4000/update_email?email={email}&token={token}"
@@ -597,7 +596,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
         changes: %{
           "avatar" => %{
             "file_name" => "test.jpg",
-            "updated_at" => NaiveDateTime.to_iso8601(admin.avatar.updated_at)
+            "updated_at" => DateFormatter.to_iso8601(admin.avatar.updated_at)
           }
         },
         encrypted_changes: %{}
@@ -634,8 +633,8 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
                      "small" => nil,
                      "thumb" => nil
                    },
-                   "created_at" => Date.to_iso8601(account.inserted_at),
-                   "updated_at" => Date.to_iso8601(account.updated_at)
+                   "created_at" => DateFormatter.to_iso8601(account.inserted_at),
+                   "updated_at" => DateFormatter.to_iso8601(account.updated_at)
                  }
                }
     end
@@ -696,8 +695,8 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
                          "small" => nil,
                          "thumb" => nil
                        },
-                       "created_at" => Date.to_iso8601(account.inserted_at),
-                       "updated_at" => Date.to_iso8601(account.updated_at)
+                       "created_at" => DateFormatter.to_iso8601(account.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(account.updated_at)
                      }
                    ],
                    "pagination" => %{

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -28,8 +28,9 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
   }
 
   alias EWallet.{BalanceFetcher, TestEndpoint}
-  alias EWallet.Web.{Date, Orchestrator, V1.WebsocketResponseSerializer}
+  alias EWallet.Web.{Orchestrator, V1.WebsocketResponseSerializer}
   alias Phoenix.Socket.Broadcast
+  alias Utils.Helpers.DateFormatter
 
   alias EWallet.Web.V1.{
     AccountSerializer,
@@ -862,11 +863,11 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                  "metadata" => %{},
                  "encrypted_metadata" => %{},
                  "expiration_date" => nil,
-                 "created_at" => Date.to_iso8601(inserted_consumption.inserted_at),
-                 "approved_at" => Date.to_iso8601(inserted_consumption.approved_at),
-                 "rejected_at" => Date.to_iso8601(inserted_consumption.rejected_at),
-                 "confirmed_at" => Date.to_iso8601(inserted_consumption.confirmed_at),
-                 "failed_at" => Date.to_iso8601(inserted_consumption.failed_at),
+                 "created_at" => DateFormatter.to_iso8601(inserted_consumption.inserted_at),
+                 "approved_at" => DateFormatter.to_iso8601(inserted_consumption.approved_at),
+                 "rejected_at" => DateFormatter.to_iso8601(inserted_consumption.rejected_at),
+                 "confirmed_at" => DateFormatter.to_iso8601(inserted_consumption.confirmed_at),
+                 "failed_at" => DateFormatter.to_iso8601(inserted_consumption.failed_at),
                  "expired_at" => nil
                }
              }
@@ -990,11 +991,11 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
                  "metadata" => %{},
                  "encrypted_metadata" => %{},
                  "expiration_date" => nil,
-                 "created_at" => Date.to_iso8601(inserted_consumption.inserted_at),
-                 "approved_at" => Date.to_iso8601(inserted_consumption.approved_at),
-                 "rejected_at" => Date.to_iso8601(inserted_consumption.rejected_at),
-                 "confirmed_at" => Date.to_iso8601(inserted_consumption.confirmed_at),
-                 "failed_at" => Date.to_iso8601(inserted_consumption.failed_at),
+                 "created_at" => DateFormatter.to_iso8601(inserted_consumption.inserted_at),
+                 "approved_at" => DateFormatter.to_iso8601(inserted_consumption.approved_at),
+                 "rejected_at" => DateFormatter.to_iso8601(inserted_consumption.rejected_at),
+                 "confirmed_at" => DateFormatter.to_iso8601(inserted_consumption.confirmed_at),
+                 "failed_at" => DateFormatter.to_iso8601(inserted_consumption.failed_at),
                  "expired_at" => nil
                }
              }
@@ -2255,7 +2256,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
         target: transaction_consumption,
         changes: %{
           "account_uuid" => meta.account.uuid,
-          "estimated_at" => NaiveDateTime.to_iso8601(transaction_consumption.estimated_at),
+          "estimated_at" => DateFormatter.to_iso8601(transaction_consumption.estimated_at),
           "estimated_consumption_amount" => 10_000_000,
           "estimated_rate" => 1.0,
           "estimated_request_amount" => 10_000_000,
@@ -2274,7 +2275,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
         originator: :system,
         target: transaction_consumption,
         changes: %{
-          "approved_at" => NaiveDateTime.to_iso8601(transaction_consumption.approved_at),
+          "approved_at" => DateFormatter.to_iso8601(transaction_consumption.approved_at),
           "status" => "approved"
         },
         encrypted_changes: %{}
@@ -2287,7 +2288,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
         originator: transaction_consumption,
         target: transaction,
         changes: %{
-          "calculated_at" => NaiveDateTime.to_iso8601(transaction.calculated_at),
+          "calculated_at" => DateFormatter.to_iso8601(transaction.calculated_at),
           "from" => meta.account_wallet.address,
           "from_account_uuid" => meta.account.uuid,
           "from_amount" => 10_000_000,
@@ -2349,7 +2350,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
         originator: transaction,
         target: transaction_consumption,
         changes: %{
-          "confirmed_at" => NaiveDateTime.to_iso8601(transaction_consumption.confirmed_at),
+          "confirmed_at" => DateFormatter.to_iso8601(transaction_consumption.confirmed_at),
           "status" => "confirmed",
           "transaction_uuid" => transaction.uuid
         },
@@ -2372,7 +2373,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
         action: "update",
         originator: :system,
         target: transaction_request,
-        changes: %{"updated_at" => NaiveDateTime.to_iso8601(transaction_request.updated_at)},
+        changes: %{"updated_at" => DateFormatter.to_iso8601(transaction_request.updated_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_controller_test.exs
@@ -17,6 +17,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
   alias EWallet.TransactionGate
   alias EWalletDB.{Account, Repo, Token, Transaction, User}
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   # credo:disable-for-next-line
   setup do
@@ -1419,7 +1420,7 @@ defmodule AdminAPI.V1.AdminAuth.TransactionControllerTest do
           "from_amount" => 1000,
           "idempotency_token" => "12344",
           "to_amount" => 2000,
-          "calculated_at" => NaiveDateTime.to_iso8601(transaction.calculated_at),
+          "calculated_at" => DateFormatter.to_iso8601(transaction.calculated_at),
           "exchange_account_uuid" => account.uuid,
           "exchange_pair_uuid" => pair.uuid,
           "exchange_wallet_address" => account_wallet.address,

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWallet.Web.V1.{AccountSerializer, TokenSerializer, UserSerializer, WalletSerializer}
   alias EWalletDB.{Account, AccountUser, Repo, TransactionRequest, User, Wallet}
   alias ActivityLogger.System
@@ -206,8 +206,8 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
                    account_wallet
                    |> WalletSerializer.serialize_without_balances()
                    |> stringify_keys(),
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end
@@ -270,8 +270,8 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
                    account_wallet
                    |> WalletSerializer.serialize_without_balances()
                    |> stringify_keys(),
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end
@@ -328,8 +328,8 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
                  "max_consumptions" => nil,
                  "current_consumptions_count" => 0,
                  "max_consumptions_per_user" => nil,
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end
@@ -386,8 +386,8 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
                  "max_consumptions" => nil,
                  "current_consumptions_count" => 0,
                  "max_consumptions_per_user" => nil,
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.{Account, AccountUser, User, AuthToken, Role, Membership}
   alias ActivityLogger.System
 
@@ -247,8 +247,8 @@ defmodule AdminAPI.V1.AdminAuth.UserControllerTest do
             "last_name" => inserted_user.metadata["last_name"]
           },
           "encrypted_metadata" => %{},
-          "created_at" => Date.to_iso8601(inserted_user.inserted_at),
-          "updated_at" => Date.to_iso8601(inserted_user.updated_at),
+          "created_at" => DateFormatter.to_iso8601(inserted_user.inserted_at),
+          "updated_at" => DateFormatter.to_iso8601(inserted_user.updated_at),
           "email" => nil,
           "enabled" => inserted_user.enabled,
           "avatar" => %{

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/wallet_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWallet.Web.V1.UserSerializer
   alias EWalletDB.{Account, AccountUser, Repo, Token, User, Wallet}
   alias ActivityLogger.System
@@ -309,8 +309,8 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
                      "user" => user |> UserSerializer.serialize() |> stringify_keys(),
                      "user_id" => user.id,
                      "enabled" => true,
-                     "created_at" => Date.to_iso8601(user_wallet.inserted_at),
-                     "updated_at" => Date.to_iso8601(user_wallet.updated_at),
+                     "created_at" => DateFormatter.to_iso8601(user_wallet.inserted_at),
+                     "updated_at" => DateFormatter.to_iso8601(user_wallet.updated_at),
                      "balances" => [
                        %{
                          "object" => "balance",
@@ -324,8 +324,8 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "created_at" => Date.to_iso8601(btc.inserted_at),
-                           "updated_at" => Date.to_iso8601(btc.updated_at)
+                           "created_at" => DateFormatter.to_iso8601(btc.inserted_at),
+                           "updated_at" => DateFormatter.to_iso8601(btc.updated_at)
                          }
                        },
                        %{
@@ -340,8 +340,8 @@ defmodule AdminAPI.V1.AdminAuth.WalletControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "created_at" => Date.to_iso8601(omg.inserted_at),
-                           "updated_at" => Date.to_iso8601(omg.updated_at)
+                           "created_at" => DateFormatter.to_iso8601(omg.inserted_at),
+                           "updated_at" => DateFormatter.to_iso8601(omg.updated_at)
                          }
                        }
                      ]

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_controller_test.exs
@@ -15,6 +15,7 @@
 defmodule AdminAPI.V1.ProviderAuth.AccountControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWalletDB.{Account, Repo, User}
+  alias Utils.Helpers.DateFormatter
 
   describe "/account.all" do
     test "returns a list of accounts and pagination data" do
@@ -444,7 +445,7 @@ defmodule AdminAPI.V1.ProviderAuth.AccountControllerTest do
         changes: %{
           "avatar" => %{
             "file_name" => "test.jpg",
-            "updated_at" => NaiveDateTime.to_iso8601(account.avatar.updated_at)
+            "updated_at" => DateFormatter.to_iso8601(account.avatar.updated_at)
           }
         },
         encrypted_changes: %{}

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_membership_controller_test.exs
@@ -15,7 +15,7 @@
 defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
   use AdminAPI.ConnCase, async: true
   alias Ecto.UUID
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.{Account, User, Membership}
 
   @redirect_url "http://localhost:4000/invite?email={email}&token={token}"
@@ -46,8 +46,8 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
                "email" => user.email,
                "metadata" => user.metadata,
                "encrypted_metadata" => %{},
-               "created_at" => Date.to_iso8601(user.inserted_at),
-               "updated_at" => Date.to_iso8601(user.updated_at),
+               "created_at" => DateFormatter.to_iso8601(user.inserted_at),
+               "updated_at" => DateFormatter.to_iso8601(user.updated_at),
                "account_role" => role.name,
                "status" => to_string(User.get_status(user)),
                "enabled" => user.enabled,
@@ -70,8 +70,8 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
                  "object" => "account",
                  "parent_id" => account.parent.id,
                  "socket_topic" => "account:#{account.id}",
-                 "created_at" => Date.to_iso8601(account.inserted_at),
-                 "updated_at" => Date.to_iso8601(account.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(account.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(account.updated_at)
                }
              })
 
@@ -86,8 +86,8 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
                "email" => admin.email,
                "metadata" => admin.metadata,
                "encrypted_metadata" => %{},
-               "created_at" => Date.to_iso8601(admin.inserted_at),
-               "updated_at" => Date.to_iso8601(admin.updated_at),
+               "created_at" => DateFormatter.to_iso8601(admin.inserted_at),
+               "updated_at" => DateFormatter.to_iso8601(admin.updated_at),
                "account_role" => "admin",
                "status" => to_string(User.get_status(admin)),
                "enabled" => admin.enabled,
@@ -110,8 +110,8 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
                  "object" => "account",
                  "parent_id" => nil,
                  "socket_topic" => "account:#{master.id}",
-                 "created_at" => Date.to_iso8601(master.inserted_at),
-                 "updated_at" => Date.to_iso8601(master.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(master.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(master.updated_at)
                }
              })
     end
@@ -139,8 +139,8 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
                        "email" => admin.email,
                        "metadata" => admin.metadata,
                        "encrypted_metadata" => %{},
-                       "created_at" => Date.to_iso8601(admin.inserted_at),
-                       "updated_at" => Date.to_iso8601(admin.updated_at),
+                       "created_at" => DateFormatter.to_iso8601(admin.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(admin.updated_at),
                        "account_role" => "admin",
                        "status" => to_string(User.get_status(admin)),
                        "enabled" => admin.enabled,
@@ -168,8 +168,8 @@ defmodule AdminAPI.V1.ProviderAuth.AccountMembershipControllerTest do
                          "object" => "account",
                          "parent_id" => nil,
                          "socket_topic" => "account:#{master.id}",
-                         "created_at" => Date.to_iso8601(master.inserted_at),
-                         "updated_at" => Date.to_iso8601(master.updated_at)
+                         "created_at" => DateFormatter.to_iso8601(master.inserted_at),
+                         "updated_at" => DateFormatter.to_iso8601(master.updated_at)
                        }
                      }
                    ]

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.Helpers.Preloader
   alias EWalletDB.{Account, APIKey, Repo}
 
@@ -37,9 +37,9 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
                        "owner_app" => api_key1.owner_app,
                        "expired" => false,
                        "enabled" => true,
-                       "created_at" => Date.to_iso8601(api_key1.inserted_at),
-                       "updated_at" => Date.to_iso8601(api_key1.updated_at),
-                       "deleted_at" => Date.to_iso8601(api_key1.deleted_at)
+                       "created_at" => DateFormatter.to_iso8601(api_key1.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(api_key1.updated_at),
+                       "deleted_at" => DateFormatter.to_iso8601(api_key1.deleted_at)
                      },
                      %{
                        "object" => "api_key",
@@ -49,9 +49,9 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
                        "owner_app" => api_key2.owner_app,
                        "expired" => false,
                        "enabled" => true,
-                       "created_at" => Date.to_iso8601(api_key2.inserted_at),
-                       "updated_at" => Date.to_iso8601(api_key2.updated_at),
-                       "deleted_at" => Date.to_iso8601(api_key2.deleted_at)
+                       "created_at" => DateFormatter.to_iso8601(api_key2.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(api_key2.updated_at),
+                       "deleted_at" => DateFormatter.to_iso8601(api_key2.deleted_at)
                      }
                    ],
                    "pagination" => %{
@@ -92,9 +92,9 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
                        "owner_app" => api_key.owner_app,
                        "expired" => false,
                        "enabled" => true,
-                       "created_at" => Date.to_iso8601(api_key.inserted_at),
-                       "updated_at" => Date.to_iso8601(api_key.updated_at),
-                       "deleted_at" => Date.to_iso8601(api_key.deleted_at)
+                       "created_at" => DateFormatter.to_iso8601(api_key.inserted_at),
+                       "updated_at" => DateFormatter.to_iso8601(api_key.updated_at),
+                       "deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)
                      }
                    ],
                    "pagination" => %{
@@ -128,9 +128,9 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
                  "owner_app" => "ewallet_api",
                  "expired" => false,
                  "enabled" => true,
-                 "created_at" => Date.to_iso8601(api_key.inserted_at),
-                 "updated_at" => Date.to_iso8601(api_key.updated_at),
-                 "deleted_at" => Date.to_iso8601(api_key.deleted_at)
+                 "created_at" => DateFormatter.to_iso8601(api_key.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(api_key.updated_at),
+                 "deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)
                }
              }
     end
@@ -219,9 +219,9 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
                  "enabled" => false,
                  "account_id" => api_key.account.id,
                  "owner_app" => api_key.owner_app,
-                 "created_at" => Date.to_iso8601(api_key.inserted_at),
-                 "updated_at" => Date.to_iso8601(updated.updated_at),
-                 "deleted_at" => Date.to_iso8601(api_key.deleted_at)
+                 "created_at" => DateFormatter.to_iso8601(api_key.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(updated.updated_at),
+                 "deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)
                }
              }
     end
@@ -401,7 +401,7 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
         action: "update",
         originator: get_test_key(),
         target: api_key,
-        changes: %{"deleted_at" => NaiveDateTime.to_iso8601(api_key.deleted_at)},
+        changes: %{"deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/category_controller_test.exs
@@ -17,6 +17,7 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
   alias EWalletDB.{Category, Repo}
   alias EWalletDB.Helpers.Preloader
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "/category.all" do
     test "returns a list of categories and pagination data" do
@@ -322,7 +323,7 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
         action: "update",
         originator: get_test_key(),
         target: category,
-        changes: %{"deleted_at" => NaiveDateTime.to_iso8601(category.deleted_at)},
+        changes: %{"deleted_at" => DateFormatter.to_iso8601(category.deleted_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/exchange_pair_controller_test.exs
@@ -15,6 +15,7 @@
 defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWalletDB.{ExchangePair, Repo}
+  alias Utils.Helpers.DateFormatter
 
   describe "/exchange_pair.all" do
     test "returns a list of exchange pairs and pagination data" do
@@ -515,7 +516,7 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
         originator: get_test_key(),
         target: exchange_pair,
         changes: %{
-          "deleted_at" => NaiveDateTime.to_iso8601(exchange_pair.deleted_at)
+          "deleted_at" => DateFormatter.to_iso8601(exchange_pair.deleted_at)
         },
         encrypted_changes: %{}
       )

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.{Account, Key, Repo}
 
   describe "/access_key.all" do
@@ -72,9 +72,9 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
       assert response["data"]["account_id"] == Account.get_master_account().id
       assert response["data"]["expired"] == !key.enabled
       assert response["data"]["enabled"] == key.enabled
-      assert response["data"]["created_at"] == Date.to_iso8601(key.inserted_at)
-      assert response["data"]["updated_at"] == Date.to_iso8601(key.updated_at)
-      assert response["data"]["deleted_at"] == Date.to_iso8601(key.deleted_at)
+      assert response["data"]["created_at"] == DateFormatter.to_iso8601(key.inserted_at)
+      assert response["data"]["updated_at"] == DateFormatter.to_iso8601(key.updated_at)
+      assert response["data"]["deleted_at"] == DateFormatter.to_iso8601(key.deleted_at)
 
       # We cannot know the `secret_key` from the controller call,
       # so we can only check that it is a string with some length.
@@ -342,7 +342,7 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
         action: "update",
         originator: get_test_key(),
         target: key,
-        changes: %{"deleted_at" => NaiveDateTime.to_iso8601(key.deleted_at)},
+        changes: %{"deleted_at" => DateFormatter.to_iso8601(key.deleted_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/mint_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/mint_controller_test.exs
@@ -15,7 +15,7 @@
 defmodule AdminAPI.V1.ProviderAuth.MintControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWallet.MintGate
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWallet.Web.V1.{AccountSerializer, TokenSerializer, TransactionSerializer}
   alias EWalletDB.{Mint, Repo, Account, Wallet, Transaction}
   alias ActivityLogger.System
@@ -70,8 +70,8 @@ defmodule AdminAPI.V1.ProviderAuth.MintControllerTest do
         "transaction" =>
           inserted_mint.transaction |> TransactionSerializer.serialize() |> stringify_keys(),
         "transaction_id" => inserted_mint.transaction.id,
-        "created_at" => Date.to_iso8601(inserted_mint.inserted_at),
-        "updated_at" => Date.to_iso8601(inserted_mint.updated_at)
+        "created_at" => DateFormatter.to_iso8601(inserted_mint.inserted_at),
+        "updated_at" => DateFormatter.to_iso8601(inserted_mint.updated_at)
       })
 
       # Asserts pagination data

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/role_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/role_controller_test.exs
@@ -16,6 +16,7 @@ defmodule AdminAPI.V1.ProviderAuth.RoleControllerTest do
   use AdminAPI.ConnCase, async: true
   alias EWalletDB.{Membership, Role, Repo}
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "/role.all" do
     test "returns a list of roles and pagination data" do
@@ -306,7 +307,7 @@ defmodule AdminAPI.V1.ProviderAuth.RoleControllerTest do
         originator: get_test_key(),
         target: role,
         changes: %{
-          "deleted_at" => NaiveDateTime.to_iso8601(role.deleted_at)
+          "deleted_at" => DateFormatter.to_iso8601(role.deleted_at)
         },
         encrypted_changes: %{}
       )

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
@@ -26,8 +26,9 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
   }
 
   alias EWallet.{BalanceFetcher, TestEndpoint}
-  alias EWallet.Web.{Date, Orchestrator, V1.WebsocketResponseSerializer}
+  alias EWallet.Web.{Orchestrator, V1.WebsocketResponseSerializer}
   alias Phoenix.Socket.Broadcast
+  alias Utils.Helpers.DateFormatter
 
   alias EWallet.Web.V1.{
     AccountSerializer,
@@ -836,11 +837,11 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                  "metadata" => %{},
                  "encrypted_metadata" => %{},
                  "expiration_date" => nil,
-                 "created_at" => Date.to_iso8601(inserted_consumption.inserted_at),
-                 "approved_at" => Date.to_iso8601(inserted_consumption.approved_at),
-                 "rejected_at" => Date.to_iso8601(inserted_consumption.rejected_at),
-                 "confirmed_at" => Date.to_iso8601(inserted_consumption.confirmed_at),
-                 "failed_at" => Date.to_iso8601(inserted_consumption.failed_at),
+                 "created_at" => DateFormatter.to_iso8601(inserted_consumption.inserted_at),
+                 "approved_at" => DateFormatter.to_iso8601(inserted_consumption.approved_at),
+                 "rejected_at" => DateFormatter.to_iso8601(inserted_consumption.rejected_at),
+                 "confirmed_at" => DateFormatter.to_iso8601(inserted_consumption.confirmed_at),
+                 "failed_at" => DateFormatter.to_iso8601(inserted_consumption.failed_at),
                  "expired_at" => nil
                }
              }
@@ -964,11 +965,11 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
                  "metadata" => %{},
                  "encrypted_metadata" => %{},
                  "expiration_date" => nil,
-                 "created_at" => Date.to_iso8601(inserted_consumption.inserted_at),
-                 "approved_at" => Date.to_iso8601(inserted_consumption.approved_at),
-                 "rejected_at" => Date.to_iso8601(inserted_consumption.rejected_at),
-                 "confirmed_at" => Date.to_iso8601(inserted_consumption.confirmed_at),
-                 "failed_at" => Date.to_iso8601(inserted_consumption.failed_at),
+                 "created_at" => DateFormatter.to_iso8601(inserted_consumption.inserted_at),
+                 "approved_at" => DateFormatter.to_iso8601(inserted_consumption.approved_at),
+                 "rejected_at" => DateFormatter.to_iso8601(inserted_consumption.rejected_at),
+                 "confirmed_at" => DateFormatter.to_iso8601(inserted_consumption.confirmed_at),
+                 "failed_at" => DateFormatter.to_iso8601(inserted_consumption.failed_at),
                  "expired_at" => nil
                }
              }
@@ -2099,7 +2100,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
         target: transaction_consumption,
         changes: %{
           "account_uuid" => meta.account.uuid,
-          "estimated_at" => NaiveDateTime.to_iso8601(transaction_consumption.estimated_at),
+          "estimated_at" => DateFormatter.to_iso8601(transaction_consumption.estimated_at),
           "estimated_consumption_amount" => 10_000_000,
           "estimated_rate" => 1.0,
           "estimated_request_amount" => 10_000_000,
@@ -2118,7 +2119,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
         originator: :system,
         target: transaction_consumption,
         changes: %{
-          "approved_at" => NaiveDateTime.to_iso8601(transaction_consumption.approved_at),
+          "approved_at" => DateFormatter.to_iso8601(transaction_consumption.approved_at),
           "status" => "approved"
         },
         encrypted_changes: %{}
@@ -2131,7 +2132,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
         originator: transaction_consumption,
         target: transaction,
         changes: %{
-          "calculated_at" => NaiveDateTime.to_iso8601(transaction.calculated_at),
+          "calculated_at" => DateFormatter.to_iso8601(transaction.calculated_at),
           "from" => meta.account_wallet.address,
           "from_account_uuid" => meta.account.uuid,
           "from_amount" => 10_000_000,
@@ -2193,7 +2194,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
         originator: transaction,
         target: transaction_consumption,
         changes: %{
-          "confirmed_at" => NaiveDateTime.to_iso8601(transaction_consumption.confirmed_at),
+          "confirmed_at" => DateFormatter.to_iso8601(transaction_consumption.confirmed_at),
           "status" => "confirmed",
           "transaction_uuid" => transaction.uuid
         },
@@ -2216,7 +2217,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
         action: "update",
         originator: :system,
         target: transaction_request,
-        changes: %{"updated_at" => NaiveDateTime.to_iso8601(transaction_request.updated_at)},
+        changes: %{"updated_at" => DateFormatter.to_iso8601(transaction_request.updated_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_controller_test.exs
@@ -17,6 +17,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
   alias EWallet.TransactionGate
   alias EWalletDB.{Account, Repo, Transaction, User}
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   # credo:disable-for-next-line
   setup do
@@ -1386,7 +1387,7 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionControllerTest do
           "from_amount" => 1000,
           "idempotency_token" => "12344",
           "to_amount" => 2000,
-          "calculated_at" => NaiveDateTime.to_iso8601(transaction.calculated_at),
+          "calculated_at" => DateFormatter.to_iso8601(transaction.calculated_at),
           "exchange_account_uuid" => account.uuid,
           "exchange_pair_uuid" => pair.uuid,
           "exchange_wallet_address" => account_wallet.address,

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
@@ -14,9 +14,10 @@
 
 defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.{Date, V1.TokenSerializer, V1.UserSerializer}
+  alias EWallet.Web.{V1.TokenSerializer, V1.UserSerializer}
   alias EWalletDB.{Account, AccountUser, Repo, TransactionRequest, User}
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "/transaction_request.all" do
     setup do
@@ -193,8 +194,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
                  "current_consumptions_count" => 0,
                  "max_consumptions_per_user" => nil,
                  "metadata" => %{},
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end
@@ -251,8 +252,8 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
                  "max_consumptions" => nil,
                  "current_consumptions_count" => 0,
                  "max_consumptions_per_user" => nil,
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.{Account, AccountUser, User, AuthToken}
   alias ActivityLogger.System
 
@@ -131,8 +131,8 @@ defmodule AdminAPI.V1.ProviderAuth.UserControllerTest do
             "last_name" => inserted_user.metadata["last_name"]
           },
           "encrypted_metadata" => %{},
-          "created_at" => Date.to_iso8601(inserted_user.inserted_at),
-          "updated_at" => Date.to_iso8601(inserted_user.updated_at),
+          "created_at" => DateFormatter.to_iso8601(inserted_user.inserted_at),
+          "updated_at" => DateFormatter.to_iso8601(inserted_user.updated_at),
           "email" => nil,
           "avatar" => %{
             "large" => nil,

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/wallet_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
   use AdminAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWallet.Web.V1.UserSerializer
   alias EWalletDB.{Account, AccountUser, Repo, Token, User, Wallet}
   alias ActivityLogger.System
@@ -260,8 +260,8 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
                      "user" => user |> UserSerializer.serialize() |> stringify_keys(),
                      "user_id" => user.id,
                      "enabled" => true,
-                     "created_at" => Date.to_iso8601(user_wallet.inserted_at),
-                     "updated_at" => Date.to_iso8601(user_wallet.updated_at),
+                     "created_at" => DateFormatter.to_iso8601(user_wallet.inserted_at),
+                     "updated_at" => DateFormatter.to_iso8601(user_wallet.updated_at),
                      "balances" => [
                        %{
                          "object" => "balance",
@@ -275,8 +275,8 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "created_at" => Date.to_iso8601(btc.inserted_at),
-                           "updated_at" => Date.to_iso8601(btc.updated_at)
+                           "created_at" => DateFormatter.to_iso8601(btc.inserted_at),
+                           "updated_at" => DateFormatter.to_iso8601(btc.updated_at)
                          }
                        },
                        %{
@@ -291,8 +291,8 @@ defmodule AdminAPI.V1.ProviderAuth.WalletControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "created_at" => Date.to_iso8601(omg.inserted_at),
-                           "updated_at" => Date.to_iso8601(omg.updated_at)
+                           "created_at" => DateFormatter.to_iso8601(omg.inserted_at),
+                           "updated_at" => DateFormatter.to_iso8601(omg.updated_at)
                          }
                        }
                      ]

--- a/apps/admin_api/test/admin_api/v1/views/activity_log_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/activity_log_view_test.exs
@@ -1,8 +1,9 @@
 defmodule AdminAPI.V1.ActivityLogViewTest do
   use AdminAPI.ViewCase, :v1
   alias AdminAPI.V1.ActivityLogView
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.{AccountSerializer, ActivityLogSerializer, UserSerializer}
+  alias Utils.Helpers.DateFormatter
 
   describe "AdminAPI.V1.ActivityLogView.render/2" do
     test "renders activity_log.json with correct response format" do
@@ -24,7 +25,7 @@ defmodule AdminAPI.V1.ActivityLogViewTest do
           target_changes: activity_log.target_changes,
           target_encrypted_changes: activity_log.target_encrypted_changes,
           metadata: activity_log.metadata,
-          created_at: Date.to_iso8601(activity_log.inserted_at)
+          created_at: DateFormatter.to_iso8601(activity_log.inserted_at)
         }
       }
 

--- a/apps/admin_api/test/admin_api/v1/views/api_key_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/api_key_view_test.exs
@@ -15,7 +15,8 @@
 defmodule AdminAPI.V1.APIKeyViewTest do
   use AdminAPI.ViewCase, :v1
   alias AdminAPI.V1.APIKeyView
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
+  alias Utils.Helpers.DateFormatter
 
   describe "render/2" do
     test "renders api_key.json with correct response format" do
@@ -32,9 +33,9 @@ defmodule AdminAPI.V1.APIKeyViewTest do
           owner_app: api_key.owner_app,
           expired: false,
           enabled: true,
-          created_at: Date.to_iso8601(api_key.inserted_at),
-          updated_at: Date.to_iso8601(api_key.updated_at),
-          deleted_at: Date.to_iso8601(api_key.deleted_at)
+          created_at: DateFormatter.to_iso8601(api_key.inserted_at),
+          updated_at: DateFormatter.to_iso8601(api_key.updated_at),
+          deleted_at: DateFormatter.to_iso8601(api_key.deleted_at)
         }
       }
 
@@ -69,9 +70,9 @@ defmodule AdminAPI.V1.APIKeyViewTest do
               owner_app: api_key1.owner_app,
               expired: false,
               enabled: true,
-              created_at: Date.to_iso8601(api_key1.inserted_at),
-              updated_at: Date.to_iso8601(api_key1.updated_at),
-              deleted_at: Date.to_iso8601(api_key1.deleted_at)
+              created_at: DateFormatter.to_iso8601(api_key1.inserted_at),
+              updated_at: DateFormatter.to_iso8601(api_key1.updated_at),
+              deleted_at: DateFormatter.to_iso8601(api_key1.deleted_at)
             },
             %{
               object: "api_key",
@@ -81,9 +82,9 @@ defmodule AdminAPI.V1.APIKeyViewTest do
               owner_app: api_key2.owner_app,
               expired: false,
               enabled: true,
-              created_at: Date.to_iso8601(api_key2.inserted_at),
-              updated_at: Date.to_iso8601(api_key2.updated_at),
-              deleted_at: Date.to_iso8601(api_key2.deleted_at)
+              created_at: DateFormatter.to_iso8601(api_key2.inserted_at),
+              updated_at: DateFormatter.to_iso8601(api_key2.updated_at),
+              deleted_at: DateFormatter.to_iso8601(api_key2.deleted_at)
             }
           ],
           pagination: %{

--- a/apps/admin_api/test/admin_api/v1/views/key_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/key_view_test.exs
@@ -15,8 +15,9 @@
 defmodule AdminAPI.V1.KeyViewTest do
   use AdminAPI.ViewCase, :v1
   alias AdminAPI.V1.KeyView
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWalletDB.Helpers.Preloader
+  alias Utils.Helpers.DateFormatter
 
   describe "render/2" do
     test "renders key.json with correct response format" do
@@ -33,9 +34,9 @@ defmodule AdminAPI.V1.KeyViewTest do
           account_id: key.account.id,
           expired: !key.enabled,
           enabled: key.enabled,
-          created_at: Date.to_iso8601(key.inserted_at),
-          updated_at: Date.to_iso8601(key.updated_at),
-          deleted_at: Date.to_iso8601(key.deleted_at)
+          created_at: DateFormatter.to_iso8601(key.inserted_at),
+          updated_at: DateFormatter.to_iso8601(key.updated_at),
+          deleted_at: DateFormatter.to_iso8601(key.deleted_at)
         }
       }
 
@@ -70,9 +71,9 @@ defmodule AdminAPI.V1.KeyViewTest do
               account_id: key1.account.id,
               expired: !key1.enabled,
               enabled: key1.enabled,
-              created_at: Date.to_iso8601(key1.inserted_at),
-              updated_at: Date.to_iso8601(key1.updated_at),
-              deleted_at: Date.to_iso8601(key1.deleted_at)
+              created_at: DateFormatter.to_iso8601(key1.inserted_at),
+              updated_at: DateFormatter.to_iso8601(key1.updated_at),
+              deleted_at: DateFormatter.to_iso8601(key1.deleted_at)
             },
             %{
               object: "key",
@@ -82,9 +83,9 @@ defmodule AdminAPI.V1.KeyViewTest do
               account_id: key2.account.id,
               expired: !key2.enabled,
               enabled: key2.enabled,
-              created_at: Date.to_iso8601(key2.inserted_at),
-              updated_at: Date.to_iso8601(key2.updated_at),
-              deleted_at: Date.to_iso8601(key2.deleted_at)
+              created_at: DateFormatter.to_iso8601(key2.inserted_at),
+              updated_at: DateFormatter.to_iso8601(key2.updated_at),
+              deleted_at: DateFormatter.to_iso8601(key2.deleted_at)
             }
           ],
           pagination: %{

--- a/apps/admin_api/test/admin_api/v1/views/self_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/self_view_test.exs
@@ -15,7 +15,7 @@
 defmodule AdminAPI.V1.SelfViewTest do
   use AdminAPI.ViewCase, :v1
   alias AdminAPI.V1.SelfView
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.User
 
   describe "render/2" do
@@ -49,8 +49,8 @@ defmodule AdminAPI.V1.SelfViewTest do
             "last_name" => user.metadata["last_name"]
           },
           encrypted_metadata: %{},
-          created_at: Date.to_iso8601(user.inserted_at),
-          updated_at: Date.to_iso8601(user.updated_at)
+          created_at: DateFormatter.to_iso8601(user.inserted_at),
+          updated_at: DateFormatter.to_iso8601(user.updated_at)
         }
       }
 

--- a/apps/admin_api/test/admin_api/v1/views/token_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/token_view_test.exs
@@ -15,7 +15,8 @@
 defmodule AdminAPI.V1.TokenViewTest do
   use AdminAPI.ViewCase, :v1
   alias AdminAPI.V1.TokenView
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
+  alias Utils.Helpers.DateFormatter
 
   describe "AdminAPI.V1.TokenView.render/2" do
     test "renders token.json with correct response structure" do
@@ -33,8 +34,8 @@ defmodule AdminAPI.V1.TokenViewTest do
           encrypted_metadata: %{},
           enabled: true,
           subunit_to_unit: token.subunit_to_unit,
-          created_at: Date.to_iso8601(token.inserted_at),
-          updated_at: Date.to_iso8601(token.updated_at)
+          created_at: DateFormatter.to_iso8601(token.inserted_at),
+          updated_at: DateFormatter.to_iso8601(token.updated_at)
         }
       }
 
@@ -70,8 +71,8 @@ defmodule AdminAPI.V1.TokenViewTest do
               encrypted_metadata: %{},
               enabled: true,
               subunit_to_unit: token1.subunit_to_unit,
-              created_at: Date.to_iso8601(token1.inserted_at),
-              updated_at: Date.to_iso8601(token1.updated_at)
+              created_at: DateFormatter.to_iso8601(token1.inserted_at),
+              updated_at: DateFormatter.to_iso8601(token1.updated_at)
             },
             %{
               object: "token",
@@ -82,8 +83,8 @@ defmodule AdminAPI.V1.TokenViewTest do
               encrypted_metadata: %{},
               enabled: true,
               subunit_to_unit: token2.subunit_to_unit,
-              created_at: Date.to_iso8601(token2.inserted_at),
-              updated_at: Date.to_iso8601(token2.updated_at)
+              created_at: DateFormatter.to_iso8601(token2.inserted_at),
+              updated_at: DateFormatter.to_iso8601(token2.updated_at)
             }
           ],
           pagination: %{

--- a/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/transaction_view_test.exs
@@ -15,8 +15,8 @@
 defmodule AdminAPI.V1.TransactionViewTest do
   use AdminAPI.ViewCase, :v1
   alias AdminAPI.V1.TransactionView
-  alias EWallet.Web.{Date, Paginator, V1.AccountSerializer, V1.TokenSerializer, V1.UserSerializer}
-  alias Utils.Helpers.Assoc
+  alias EWallet.Web.{Paginator, V1.AccountSerializer, V1.TokenSerializer, V1.UserSerializer}
+  alias Utils.Helpers.{Assoc, DateFormatter}
 
   describe "AdminAPI.V1.TransactionView.render/2" do
     test "renders transaction.json with correct response structure" do
@@ -69,8 +69,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
           status: transaction.status,
           error_code: nil,
           error_description: nil,
-          created_at: Date.to_iso8601(transaction.inserted_at),
-          updated_at: Date.to_iso8601(transaction.updated_at)
+          created_at: DateFormatter.to_iso8601(transaction.inserted_at),
+          updated_at: DateFormatter.to_iso8601(transaction.updated_at)
         }
       }
 
@@ -144,8 +144,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
               status: transaction1.status,
               error_code: nil,
               error_description: nil,
-              created_at: Date.to_iso8601(transaction1.inserted_at),
-              updated_at: Date.to_iso8601(transaction1.updated_at)
+              created_at: DateFormatter.to_iso8601(transaction1.inserted_at),
+              updated_at: DateFormatter.to_iso8601(transaction1.updated_at)
             },
             %{
               object: "transaction",
@@ -189,8 +189,8 @@ defmodule AdminAPI.V1.TransactionViewTest do
               status: transaction2.status,
               error_code: nil,
               error_description: nil,
-              created_at: Date.to_iso8601(transaction2.inserted_at),
-              updated_at: Date.to_iso8601(transaction2.updated_at)
+              created_at: DateFormatter.to_iso8601(transaction2.inserted_at),
+              updated_at: DateFormatter.to_iso8601(transaction2.updated_at)
             }
           ],
           pagination: %{

--- a/apps/admin_api/test/admin_api/v1/views/user_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/user_view_test.exs
@@ -15,8 +15,9 @@
 defmodule AdminAPI.V1.UserViewTest do
   use AdminAPI.ViewCase, :v1
   alias AdminAPI.V1.UserView
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWalletDB.User
+  alias Utils.Helpers.DateFormatter
 
   describe "AdminAPI.V1.UserView.render/2" do
     test "renders user.json with correct response structure" do
@@ -49,8 +50,8 @@ defmodule AdminAPI.V1.UserViewTest do
             "last_name" => user.metadata["last_name"]
           },
           encrypted_metadata: %{},
-          created_at: Date.to_iso8601(user.inserted_at),
-          updated_at: Date.to_iso8601(user.updated_at)
+          created_at: DateFormatter.to_iso8601(user.inserted_at),
+          updated_at: DateFormatter.to_iso8601(user.updated_at)
         }
       }
 
@@ -98,8 +99,8 @@ defmodule AdminAPI.V1.UserViewTest do
                 "last_name" => user1.metadata["last_name"]
               },
               encrypted_metadata: %{},
-              created_at: Date.to_iso8601(user1.inserted_at),
-              updated_at: Date.to_iso8601(user1.updated_at)
+              created_at: DateFormatter.to_iso8601(user1.inserted_at),
+              updated_at: DateFormatter.to_iso8601(user1.updated_at)
             },
             %{
               object: "user",
@@ -122,8 +123,8 @@ defmodule AdminAPI.V1.UserViewTest do
                 "last_name" => user2.metadata["last_name"]
               },
               encrypted_metadata: %{},
-              created_at: Date.to_iso8601(user2.inserted_at),
-              updated_at: Date.to_iso8601(user2.updated_at)
+              created_at: DateFormatter.to_iso8601(user2.inserted_at),
+              updated_at: DateFormatter.to_iso8601(user2.updated_at)
             }
           ],
           pagination: %{

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -33,10 +33,9 @@ defmodule AdminAPI.ConnCase do
   alias Ecto.Adapters.SQL.Sandbox
   alias Ecto.UUID
   alias EWallet.{MintGate, TransactionGate}
-  alias EWallet.Web.Date
   alias EWalletConfig.ConfigTestHelper
   alias EWalletDB.{Account, Key, Repo, User}
-  alias Utils.{Types.ExternalID, Helpers.Crypto}
+  alias Utils.{Types.ExternalID, Helpers.Crypto, Helpers.DateFormatter}
   alias ActivityLogger.System
 
   # Attributes required by Phoenix.ConnTest
@@ -183,7 +182,7 @@ defmodule AdminAPI.ConnCase do
   end
 
   def stringify_keys(%NaiveDateTime{} = value) do
-    Date.to_iso8601(value)
+    DateFormatter.to_iso8601(value)
   end
 
   def stringify_keys(map) when is_map(map) do

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/account_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/account_serializer.ex
@@ -17,10 +17,10 @@ defmodule EWallet.Web.V1.AccountSerializer do
   Serializes account(s) into V1 response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.{CategorySerializer, PaginatorSerializer}
   alias EWalletDB.Account
-  alias Utils.Helpers.Assoc
+  alias Utils.Helpers.{Assoc, DateFormatter}
   alias EWalletDB.Uploaders.Avatar
 
   def serialize(%Paginator{} = paginator) do
@@ -48,8 +48,8 @@ defmodule EWallet.Web.V1.AccountSerializer do
       avatar: Avatar.urls({account.avatar, account}),
       metadata: account.metadata || %{},
       encrypted_metadata: account.encrypted_metadata || %{},
-      created_at: Date.to_iso8601(account.inserted_at),
-      updated_at: Date.to_iso8601(account.updated_at)
+      created_at: DateFormatter.to_iso8601(account.inserted_at),
+      updated_at: DateFormatter.to_iso8601(account.updated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/activity_log_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/activity_log_serializer.ex
@@ -17,9 +17,10 @@ defmodule EWallet.Web.V1.ActivityLogSerializer do
   Serializes activity_logs into V1 response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.{PaginatorSerializer, ModuleMapper}
   alias ActivityLogger.ActivityLog
+  alias Utils.Helpers.DateFormatter
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -46,7 +47,7 @@ defmodule EWallet.Web.V1.ActivityLogSerializer do
       target_changes: activity_log.target_changes,
       target_encrypted_changes: activity_log.target_encrypted_changes,
       metadata: activity_log.metadata,
-      created_at: Date.to_iso8601(activity_log.inserted_at)
+      created_at: DateFormatter.to_iso8601(activity_log.inserted_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/api_key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/api_key_serializer.ex
@@ -17,9 +17,10 @@ defmodule EWallet.Web.V1.APIKeySerializer do
   Serializes API key(s) into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWalletDB.APIKey
+  alias Utils.Helpers.DateFormatter
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -33,9 +34,9 @@ defmodule EWallet.Web.V1.APIKeySerializer do
       account_id: api_key.account.id,
       owner_app: api_key.owner_app,
       enabled: api_key.enabled,
-      created_at: Date.to_iso8601(api_key.inserted_at),
-      updated_at: Date.to_iso8601(api_key.updated_at),
-      deleted_at: Date.to_iso8601(api_key.deleted_at),
+      created_at: DateFormatter.to_iso8601(api_key.inserted_at),
+      updated_at: DateFormatter.to_iso8601(api_key.updated_at),
+      deleted_at: DateFormatter.to_iso8601(api_key.deleted_at),
       # Attributes below are DEPRECATED and will be removed in the future:
       # "expired" has been replaced by "enabled" in PR #535
       expired: !api_key.enabled

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/category_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/category_serializer.ex
@@ -17,9 +17,10 @@ defmodule EWallet.Web.V1.CategorySerializer do
   Serializes categories into V1 response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.{AccountSerializer, PaginatorSerializer}
   alias EWalletDB.Category
+  alias Utils.Helpers.DateFormatter
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -40,8 +41,8 @@ defmodule EWallet.Web.V1.CategorySerializer do
       description: category.description,
       account_ids: AccountSerializer.serialize(category.accounts, :id),
       accounts: AccountSerializer.serialize(category.accounts),
-      created_at: Date.to_iso8601(category.inserted_at),
-      updated_at: Date.to_iso8601(category.updated_at)
+      created_at: DateFormatter.to_iso8601(category.inserted_at),
+      updated_at: DateFormatter.to_iso8601(category.updated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/configuration_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/configuration_serializer.ex
@@ -19,9 +19,10 @@ defmodule EWallet.Web.V1.ConfigurationSerializer do
   alias Ecto.Association.NotLoaded
   alias Ecto.Changeset
   alias EWallet.Web.V1.ErrorHandler
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWalletConfig.{Setting, StoredSetting}
+  alias Utils.Helpers.DateFormatter
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -53,8 +54,8 @@ defmodule EWallet.Web.V1.ConfigurationSerializer do
       parent_value: setting.parent_value,
       secret: setting.secret,
       position: setting.position,
-      created_at: Date.to_iso8601(setting.inserted_at),
-      updated_at: Date.to_iso8601(setting.updated_at)
+      created_at: DateFormatter.to_iso8601(setting.inserted_at),
+      updated_at: DateFormatter.to_iso8601(setting.updated_at)
     }
   end
 
@@ -87,8 +88,8 @@ defmodule EWallet.Web.V1.ConfigurationSerializer do
       parent_value: setting.parent_value,
       secret: setting.secret,
       position: setting.position,
-      created_at: Date.to_iso8601(setting.inserted_at),
-      updated_at: Date.to_iso8601(setting.updated_at)
+      created_at: DateFormatter.to_iso8601(setting.inserted_at),
+      updated_at: DateFormatter.to_iso8601(setting.updated_at)
     })
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/csv/transaction_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/csv/transaction_serializer.ex
@@ -23,8 +23,8 @@ defmodule EWallet.Web.V1.CSV.TransactionSerializer do
     PaginatorSerializer
   }
 
-  alias EWallet.Web.{Date, Paginator}
-  alias Utils.Helpers.Assoc
+  alias EWallet.Web.Paginator
+  alias Utils.Helpers.{Assoc, DateFormatter}
   alias EWalletDB.Transaction
 
   def columns do
@@ -77,7 +77,7 @@ defmodule EWallet.Web.V1.CSV.TransactionSerializer do
       to_amount: transaction.to_amount,
       to_token_id: Assoc.get(transaction, [:to_token, :id]),
       exchange_rate: transaction.rate,
-      exchange_rate_calculated_at: Date.to_iso8601(transaction.calculated_at),
+      exchange_rate_calculated_at: DateFormatter.to_iso8601(transaction.calculated_at),
       exchange_pair_id: Assoc.get(transaction, [:exchange_pair, :id]),
       exchange_account_id: Assoc.get(transaction, [:exchange_account, :id]),
       exchange_wallet_address: Assoc.get(transaction, [:exchange_wallet, :address]),
@@ -86,8 +86,8 @@ defmodule EWallet.Web.V1.CSV.TransactionSerializer do
       status: transaction.status,
       error_code: error[:code],
       error_description: error[:description],
-      created_at: Date.to_iso8601(transaction.inserted_at),
-      updated_at: Date.to_iso8601(transaction.updated_at)
+      created_at: DateFormatter.to_iso8601(transaction.inserted_at),
+      updated_at: DateFormatter.to_iso8601(transaction.updated_at)
     }
     |> Enum.into(%{}, fn {key, value} ->
       {key, format(value)}

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/exchange_pair_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/exchange_pair_serializer.ex
@@ -17,10 +17,10 @@ defmodule EWallet.Web.V1.ExchangePairSerializer do
   Serializes exchange pairs into V1 response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.{PaginatorSerializer, TokenSerializer}
   alias EWalletDB.ExchangePair
-  alias Utils.Helpers.Assoc
+  alias Utils.Helpers.{Assoc, DateFormatter}
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -43,9 +43,9 @@ defmodule EWallet.Web.V1.ExchangePairSerializer do
       to_token_id: Assoc.get(exchange_pair, [:to_token, :id]),
       to_token: TokenSerializer.serialize(exchange_pair.to_token),
       rate: exchange_pair.rate,
-      created_at: Date.to_iso8601(exchange_pair.inserted_at),
-      updated_at: Date.to_iso8601(exchange_pair.updated_at),
-      deleted_at: Date.to_iso8601(exchange_pair.deleted_at)
+      created_at: DateFormatter.to_iso8601(exchange_pair.inserted_at),
+      updated_at: DateFormatter.to_iso8601(exchange_pair.updated_at),
+      deleted_at: DateFormatter.to_iso8601(exchange_pair.deleted_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/export_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/export_serializer.ex
@@ -17,9 +17,9 @@ defmodule EWallet.Web.V1.ExportSerializer do
   Serializes exports data into V1 response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.PaginatorSerializer
-  alias Utils.Helpers.Assoc
+  alias Utils.Helpers.{Assoc, DateFormatter}
   alias EWalletDB.Export
 
   def serialize(%Paginator{} = paginator) do
@@ -43,8 +43,8 @@ defmodule EWallet.Web.V1.ExportSerializer do
       # It is returned to the client and could potentially be used to check
       # what's up with a process.
       pid: export.pid,
-      created_at: Date.to_iso8601(export.inserted_at),
-      updated_at: Date.to_iso8601(export.updated_at)
+      created_at: DateFormatter.to_iso8601(export.inserted_at),
+      updated_at: DateFormatter.to_iso8601(export.updated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/key_serializer.ex
@@ -17,9 +17,10 @@ defmodule EWallet.Web.V1.KeySerializer do
   Serializes key(s) into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWalletDB.Key
+  alias Utils.Helpers.DateFormatter
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -33,9 +34,9 @@ defmodule EWallet.Web.V1.KeySerializer do
       secret_key: key.secret_key,
       account_id: key.account.id,
       enabled: key.enabled,
-      created_at: Date.to_iso8601(key.inserted_at),
-      updated_at: Date.to_iso8601(key.updated_at),
-      deleted_at: Date.to_iso8601(key.deleted_at),
+      created_at: DateFormatter.to_iso8601(key.inserted_at),
+      updated_at: DateFormatter.to_iso8601(key.updated_at),
+      deleted_at: DateFormatter.to_iso8601(key.deleted_at),
       # Attributes below are DEPRECATED and will be removed in the future:
       # "expired" has been replaced by "enabled" in PR #535
       expired: !key.enabled

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/mint_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/mint_serializer.ex
@@ -17,7 +17,7 @@ defmodule EWallet.Web.V1.MintSerializer do
   Serializes address data into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
 
   alias EWallet.Web.V1.{
     AccountSerializer,
@@ -26,7 +26,7 @@ defmodule EWallet.Web.V1.MintSerializer do
     TransactionSerializer
   }
 
-  alias Utils.Helpers.Assoc
+  alias Utils.Helpers.{Assoc, DateFormatter}
   alias EWalletDB.Mint
 
   def serialize(%Paginator{} = paginator) do
@@ -53,8 +53,8 @@ defmodule EWallet.Web.V1.MintSerializer do
       account: AccountSerializer.serialize(mint.account),
       transaction_id: Assoc.get(mint, [:transaction, :id]),
       transaction: TransactionSerializer.serialize(mint.transaction),
-      created_at: Date.to_iso8601(mint.inserted_at),
-      updated_at: Date.to_iso8601(mint.updated_at)
+      created_at: DateFormatter.to_iso8601(mint.inserted_at),
+      updated_at: DateFormatter.to_iso8601(mint.updated_at)
     }
   end
 end

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/role_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/role_serializer.ex
@@ -17,9 +17,10 @@ defmodule EWallet.Web.V1.RoleSerializer do
   Serializes roles into V1 response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWalletDB.Role
+  alias Utils.Helpers.DateFormatter
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -39,8 +40,8 @@ defmodule EWallet.Web.V1.RoleSerializer do
       name: role.name,
       priority: role.priority,
       display_name: role.display_name,
-      created_at: Date.to_iso8601(role.inserted_at),
-      updated_at: Date.to_iso8601(role.updated_at)
+      created_at: DateFormatter.to_iso8601(role.inserted_at),
+      updated_at: DateFormatter.to_iso8601(role.updated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/token_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/token_serializer.ex
@@ -17,9 +17,10 @@ defmodule EWallet.Web.V1.TokenSerializer do
   Serializes token(s) into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWalletDB.Token
+  alias Utils.Helpers.DateFormatter
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -39,8 +40,8 @@ defmodule EWallet.Web.V1.TokenSerializer do
       metadata: token.metadata || %{},
       encrypted_metadata: token.encrypted_metadata || %{},
       enabled: token.enabled,
-      created_at: Date.to_iso8601(token.inserted_at),
-      updated_at: Date.to_iso8601(token.updated_at)
+      created_at: DateFormatter.to_iso8601(token.inserted_at),
+      updated_at: DateFormatter.to_iso8601(token.updated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_calculation_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_calculation_serializer.ex
@@ -17,7 +17,7 @@ defmodule EWallet.Web.V1.TransactionCalculationSerializer do
   Serializes a transaction calculation into V1 JSON response format.
   """
   alias EWallet.Exchange.Calculation
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWallet.Web.V1.ExchangePairSerializer
 
   def serialize(%Calculation{} = calculation) do
@@ -29,7 +29,7 @@ defmodule EWallet.Web.V1.TransactionCalculationSerializer do
       to_token_id: calculation.to_token.id,
       actual_rate: calculation.actual_rate,
       exchange_pair: ExchangePairSerializer.serialize(calculation.pair),
-      calculated_at: Date.to_iso8601(calculation.calculated_at)
+      calculated_at: DateFormatter.to_iso8601(calculation.calculated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_consumption_serializer.ex
@@ -17,7 +17,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
   Serializes transaction request consumption data into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
 
   alias EWallet.Web.V1.{
     AccountSerializer,
@@ -29,7 +29,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
     WalletSerializer
   }
 
-  alias Utils.Helpers.Assoc
+  alias Utils.Helpers.{Assoc, DateFormatter}
   alias EWalletDB.TransactionConsumption
 
   def serialize(%Paginator{} = paginator) do
@@ -69,14 +69,14 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializer do
       address: consumption.wallet_address,
       metadata: consumption.metadata || %{},
       encrypted_metadata: consumption.encrypted_metadata || %{},
-      expiration_date: Date.to_iso8601(consumption.expiration_date),
+      expiration_date: DateFormatter.to_iso8601(consumption.expiration_date),
       status: consumption.status,
-      approved_at: Date.to_iso8601(consumption.approved_at),
-      rejected_at: Date.to_iso8601(consumption.rejected_at),
-      confirmed_at: Date.to_iso8601(consumption.confirmed_at),
-      failed_at: Date.to_iso8601(consumption.failed_at),
-      expired_at: Date.to_iso8601(consumption.expired_at),
-      created_at: Date.to_iso8601(consumption.inserted_at)
+      approved_at: DateFormatter.to_iso8601(consumption.approved_at),
+      rejected_at: DateFormatter.to_iso8601(consumption.rejected_at),
+      confirmed_at: DateFormatter.to_iso8601(consumption.confirmed_at),
+      failed_at: DateFormatter.to_iso8601(consumption.failed_at),
+      expired_at: DateFormatter.to_iso8601(consumption.expired_at),
+      created_at: DateFormatter.to_iso8601(consumption.inserted_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_request_serializer.ex
@@ -26,8 +26,8 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
     WalletSerializer
   }
 
-  alias EWallet.Web.{Date, Paginator}
-  alias Utils.Helpers.Assoc
+  alias EWallet.Web.Paginator
+  alias Utils.Helpers.{Assoc, DateFormatter}
   alias EWalletDB.TransactionRequest
   alias ActivityLogger.System
 
@@ -69,10 +69,10 @@ defmodule EWallet.Web.V1.TransactionRequestSerializer do
       allow_amount_override: transaction_request.allow_amount_override,
       metadata: transaction_request.metadata || %{},
       encrypted_metadata: transaction_request.encrypted_metadata || %{},
-      expiration_date: Date.to_iso8601(transaction_request.expiration_date),
-      expired_at: Date.to_iso8601(transaction_request.expired_at),
-      created_at: Date.to_iso8601(transaction_request.inserted_at),
-      updated_at: Date.to_iso8601(transaction_request.updated_at)
+      expiration_date: DateFormatter.to_iso8601(transaction_request.expiration_date),
+      expired_at: DateFormatter.to_iso8601(transaction_request.expired_at),
+      created_at: DateFormatter.to_iso8601(transaction_request.inserted_at),
+      updated_at: DateFormatter.to_iso8601(transaction_request.updated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/transaction_serializer.ex
@@ -28,8 +28,8 @@ defmodule EWallet.Web.V1.TransactionSerializer do
     WalletSerializer
   }
 
-  alias EWallet.Web.{Date, Paginator}
-  alias Utils.Helpers.Assoc
+  alias EWallet.Web.Paginator
+  alias Utils.Helpers.{Assoc, DateFormatter}
   alias EWalletDB.Transaction
 
   def serialize(%Paginator{} = paginator) do
@@ -68,7 +68,7 @@ defmodule EWallet.Web.V1.TransactionSerializer do
       exchange: %{
         object: "exchange",
         rate: transaction.rate,
-        calculated_at: Date.to_iso8601(transaction.calculated_at),
+        calculated_at: DateFormatter.to_iso8601(transaction.calculated_at),
         exchange_pair_id: Assoc.get(transaction, [:exchange_pair, :id]),
         exchange_pair: ExchangePairSerializer.serialize(transaction.exchange_pair),
         exchange_account_id: Assoc.get(transaction, [:exchange_account, :id]),
@@ -81,8 +81,8 @@ defmodule EWallet.Web.V1.TransactionSerializer do
       status: transaction.status,
       error_code: error[:code],
       error_description: error[:description],
-      created_at: Date.to_iso8601(transaction.inserted_at),
-      updated_at: Date.to_iso8601(transaction.updated_at)
+      created_at: DateFormatter.to_iso8601(transaction.inserted_at),
+      updated_at: DateFormatter.to_iso8601(transaction.updated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/user_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/user_serializer.ex
@@ -17,9 +17,10 @@ defmodule EWallet.Web.V1.UserSerializer do
   Serializes user(s) into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator, V1.PaginatorSerializer}
+  alias EWallet.Web.{Paginator, V1.PaginatorSerializer}
   alias EWalletDB.Uploaders.Avatar
   alias EWalletDB.User
+  alias Utils.Helpers.DateFormatter
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -46,8 +47,8 @@ defmodule EWallet.Web.V1.UserSerializer do
       encrypted_metadata: user.encrypted_metadata || %{},
       avatar: Avatar.urls({user.avatar, user}),
       enabled: user.enabled,
-      created_at: Date.to_iso8601(user.inserted_at),
-      updated_at: Date.to_iso8601(user.updated_at)
+      created_at: DateFormatter.to_iso8601(user.inserted_at),
+      updated_at: DateFormatter.to_iso8601(user.updated_at)
     }
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/wallet_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/wallet_serializer.ex
@@ -17,7 +17,7 @@ defmodule EWallet.Web.V1.WalletSerializer do
   Serializes address data into V1 JSON response format.
   """
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
 
   alias EWallet.Web.V1.{
     AccountSerializer,
@@ -29,7 +29,7 @@ defmodule EWallet.Web.V1.WalletSerializer do
 
   alias EWallet.BalanceFetcher
   alias EWalletDB.{Wallet, Helpers.Preloader}
-  alias Utils.Helpers.Assoc
+  alias Utils.Helpers.{Assoc, DateFormatter}
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -61,8 +61,8 @@ defmodule EWallet.Web.V1.WalletSerializer do
       account: AccountSerializer.serialize(wallet.account),
       balances: serialize_balances(wallet.balances),
       enabled: wallet.enabled,
-      created_at: Date.to_iso8601(wallet.inserted_at),
-      updated_at: Date.to_iso8601(wallet.updated_at)
+      created_at: DateFormatter.to_iso8601(wallet.inserted_at),
+      updated_at: DateFormatter.to_iso8601(wallet.updated_at)
     }
   end
 
@@ -83,8 +83,8 @@ defmodule EWallet.Web.V1.WalletSerializer do
       account: AccountSerializer.serialize(wallet.account),
       balances: nil,
       enabled: wallet.enabled,
-      created_at: Date.to_iso8601(wallet.inserted_at),
-      updated_at: Date.to_iso8601(wallet.updated_at)
+      created_at: DateFormatter.to_iso8601(wallet.inserted_at),
+      updated_at: DateFormatter.to_iso8601(wallet.updated_at)
     }
   end
 

--- a/apps/ewallet/test/ewallet/web/v1/serializers/account_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/account_serializer_test.exs
@@ -15,10 +15,11 @@
 defmodule EWallet.Web.V1.AccountSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Orchestrator, Paginator}
+  alias EWallet.Web.{Orchestrator, Paginator}
   alias EWallet.Web.V1.{AccountOverlay, AccountSerializer, CategorySerializer}
   alias EWalletDB.Account
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "AccountSerializer.serialize/1" do
     test "serializes an account into V1 response format" do
@@ -45,8 +46,8 @@ defmodule EWallet.Web.V1.AccountSerializerTest do
                  small: nil,
                  thumb: nil
                },
-               created_at: Date.to_iso8601(account.inserted_at),
-               updated_at: Date.to_iso8601(account.updated_at)
+               created_at: DateFormatter.to_iso8601(account.inserted_at),
+               updated_at: DateFormatter.to_iso8601(account.updated_at)
              }
     end
 
@@ -77,8 +78,8 @@ defmodule EWallet.Web.V1.AccountSerializerTest do
               small: nil,
               thumb: nil
             },
-            created_at: Date.to_iso8601(account1.inserted_at),
-            updated_at: Date.to_iso8601(account1.updated_at)
+            created_at: DateFormatter.to_iso8601(account1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(account1.updated_at)
           },
           %{
             object: "account",
@@ -98,8 +99,8 @@ defmodule EWallet.Web.V1.AccountSerializerTest do
               small: nil,
               thumb: nil
             },
-            created_at: Date.to_iso8601(account2.inserted_at),
-            updated_at: Date.to_iso8601(account2.updated_at)
+            created_at: DateFormatter.to_iso8601(account2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(account2.updated_at)
           }
         ]
       }
@@ -142,8 +143,8 @@ defmodule EWallet.Web.V1.AccountSerializerTest do
               small: nil,
               thumb: nil
             },
-            created_at: Date.to_iso8601(account1.inserted_at),
-            updated_at: Date.to_iso8601(account1.updated_at)
+            created_at: DateFormatter.to_iso8601(account1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(account1.updated_at)
           },
           %{
             object: "account",
@@ -163,8 +164,8 @@ defmodule EWallet.Web.V1.AccountSerializerTest do
               small: nil,
               thumb: nil
             },
-            created_at: Date.to_iso8601(account2.inserted_at),
-            updated_at: Date.to_iso8601(account2.updated_at)
+            created_at: DateFormatter.to_iso8601(account2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(account2.updated_at)
           }
         ],
         pagination: %{

--- a/apps/ewallet/test/ewallet/web/v1/serializers/activity_log_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/activity_log_serializer_test.exs
@@ -15,8 +15,9 @@
 defmodule EWallet.Web.V1.ActivityLogSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.{AccountSerializer, ActivityLogSerializer, UserSerializer}
+  alias Utils.Helpers.DateFormatter
 
   describe "ActivityLogSerializer.serialize/1" do
     test "serializes an activity_log into V1 response format" do
@@ -24,7 +25,7 @@ defmodule EWallet.Web.V1.ActivityLogSerializerTest do
 
       expected = %{
         action: activity_log.action,
-        created_at: Date.to_iso8601(activity_log.inserted_at),
+        created_at: DateFormatter.to_iso8601(activity_log.inserted_at),
         id: activity_log.id,
         metadata: activity_log.metadata,
         object: "activity_log",

--- a/apps/ewallet/test/ewallet/web/v1/serializers/category_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/category_serializer_test.exs
@@ -15,8 +15,9 @@
 defmodule EWallet.Web.V1.CategorySerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.{AccountSerializer, CategorySerializer}
+  alias Utils.Helpers.DateFormatter
 
   describe "CategorySerializer.serialize/1" do
     test "serializes a category into V1 response format" do
@@ -29,8 +30,8 @@ defmodule EWallet.Web.V1.CategorySerializerTest do
         description: category.description,
         account_ids: AccountSerializer.serialize(category.accounts, :id),
         accounts: AccountSerializer.serialize(category.accounts),
-        created_at: Date.to_iso8601(category.inserted_at),
-        updated_at: Date.to_iso8601(category.updated_at)
+        created_at: DateFormatter.to_iso8601(category.inserted_at),
+        updated_at: DateFormatter.to_iso8601(category.updated_at)
       }
 
       assert CategorySerializer.serialize(category) == expected
@@ -60,8 +61,8 @@ defmodule EWallet.Web.V1.CategorySerializerTest do
             description: category1.description,
             account_ids: AccountSerializer.serialize(category1.accounts, :id),
             accounts: AccountSerializer.serialize(category1.accounts),
-            created_at: Date.to_iso8601(category1.inserted_at),
-            updated_at: Date.to_iso8601(category1.updated_at)
+            created_at: DateFormatter.to_iso8601(category1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(category1.updated_at)
           },
           %{
             object: "category",
@@ -70,8 +71,8 @@ defmodule EWallet.Web.V1.CategorySerializerTest do
             description: category2.description,
             account_ids: AccountSerializer.serialize(category2.accounts, :id),
             accounts: AccountSerializer.serialize(category2.accounts),
-            created_at: Date.to_iso8601(category2.inserted_at),
-            updated_at: Date.to_iso8601(category2.updated_at)
+            created_at: DateFormatter.to_iso8601(category2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(category2.updated_at)
           }
         ],
         pagination: %{

--- a/apps/ewallet/test/ewallet/web/v1/serializers/exchange_pair_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/exchange_pair_serializer_test.exs
@@ -15,9 +15,10 @@
 defmodule EWallet.Web.V1.ExchangePairSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.{ExchangePairSerializer, TokenSerializer}
   alias EWalletDB.ExchangePair
+  alias Utils.Helpers.DateFormatter
 
   describe "serialize/1" do
     test "serializes an exchange pair into V1 response format" do
@@ -32,8 +33,8 @@ defmodule EWallet.Web.V1.ExchangePairSerializerTest do
         to_token_id: exchange_pair.to_token.id,
         to_token: TokenSerializer.serialize(exchange_pair.to_token),
         rate: exchange_pair.rate,
-        created_at: Date.to_iso8601(exchange_pair.inserted_at),
-        updated_at: Date.to_iso8601(exchange_pair.updated_at),
+        created_at: DateFormatter.to_iso8601(exchange_pair.inserted_at),
+        updated_at: DateFormatter.to_iso8601(exchange_pair.updated_at),
         deleted_at: nil
       }
 
@@ -66,8 +67,8 @@ defmodule EWallet.Web.V1.ExchangePairSerializerTest do
             to_token_id: exchange_pair1.to_token.id,
             to_token: TokenSerializer.serialize(exchange_pair1.to_token),
             rate: exchange_pair1.rate,
-            created_at: Date.to_iso8601(exchange_pair1.inserted_at),
-            updated_at: Date.to_iso8601(exchange_pair1.updated_at),
+            created_at: DateFormatter.to_iso8601(exchange_pair1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(exchange_pair1.updated_at),
             deleted_at: nil
           },
           %{
@@ -79,8 +80,8 @@ defmodule EWallet.Web.V1.ExchangePairSerializerTest do
             to_token_id: exchange_pair2.to_token.id,
             to_token: TokenSerializer.serialize(exchange_pair2.to_token),
             rate: exchange_pair2.rate,
-            created_at: Date.to_iso8601(exchange_pair2.inserted_at),
-            updated_at: Date.to_iso8601(exchange_pair2.updated_at),
+            created_at: DateFormatter.to_iso8601(exchange_pair2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(exchange_pair2.updated_at),
             deleted_at: nil
           }
         ],

--- a/apps/ewallet/test/ewallet/web/v1/serializers/key_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/key_serializer_test.exs
@@ -15,8 +15,9 @@
 defmodule EWallet.Web.V1.KeySerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.KeySerializer
+  alias Utils.Helpers.DateFormatter
 
   describe "serialize/1" do
     test "serializes a key into the correct response format" do
@@ -30,9 +31,9 @@ defmodule EWallet.Web.V1.KeySerializerTest do
         account_id: key.account.id,
         expired: !key.enabled,
         enabled: key.enabled,
-        created_at: Date.to_iso8601(key.inserted_at),
-        updated_at: Date.to_iso8601(key.updated_at),
-        deleted_at: Date.to_iso8601(key.deleted_at)
+        created_at: DateFormatter.to_iso8601(key.inserted_at),
+        updated_at: DateFormatter.to_iso8601(key.updated_at),
+        deleted_at: DateFormatter.to_iso8601(key.deleted_at)
       }
 
       assert KeySerializer.serialize(key) == expected
@@ -67,9 +68,9 @@ defmodule EWallet.Web.V1.KeySerializerTest do
             account_id: key1.account.id,
             expired: !key1.enabled,
             enabled: key1.enabled,
-            created_at: Date.to_iso8601(key1.inserted_at),
-            updated_at: Date.to_iso8601(key1.updated_at),
-            deleted_at: Date.to_iso8601(key1.deleted_at)
+            created_at: DateFormatter.to_iso8601(key1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(key1.updated_at),
+            deleted_at: DateFormatter.to_iso8601(key1.deleted_at)
           },
           %{
             object: "key",
@@ -79,9 +80,9 @@ defmodule EWallet.Web.V1.KeySerializerTest do
             account_id: key2.account.id,
             expired: !key2.enabled,
             enabled: key2.enabled,
-            created_at: Date.to_iso8601(key2.inserted_at),
-            updated_at: Date.to_iso8601(key2.updated_at),
-            deleted_at: Date.to_iso8601(key2.deleted_at)
+            created_at: DateFormatter.to_iso8601(key2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(key2.updated_at),
+            deleted_at: DateFormatter.to_iso8601(key2.deleted_at)
           }
         ],
         pagination: %{

--- a/apps/ewallet/test/ewallet/web/v1/serializers/membership_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/membership_serializer_test.exs
@@ -16,8 +16,9 @@ defmodule EWallet.Web.V1.MembershipSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias EWallet.Web.V1.MembershipSerializer
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Orchestrator, V1.MembershipOverlay}
+  alias EWallet.Web.{Orchestrator, V1.MembershipOverlay}
   alias EWalletDB.User
+  alias Utils.Helpers.DateFormatter
 
   describe "serialize/1" do
     test "serializes a membership into user json" do
@@ -48,8 +49,8 @@ defmodule EWallet.Web.V1.MembershipSerializerTest do
           small: nil,
           thumb: nil
         },
-        created_at: Date.to_iso8601(user.inserted_at),
-        updated_at: Date.to_iso8601(user.updated_at),
+        created_at: DateFormatter.to_iso8601(user.inserted_at),
+        updated_at: DateFormatter.to_iso8601(user.updated_at),
         account_role: role.name,
         status: User.get_status(user),
         account: %{
@@ -65,8 +66,8 @@ defmodule EWallet.Web.V1.MembershipSerializerTest do
           object: "account",
           parent_id: nil,
           socket_topic: "account:#{account.id}",
-          created_at: Date.to_iso8601(account.inserted_at),
-          updated_at: Date.to_iso8601(account.updated_at)
+          created_at: DateFormatter.to_iso8601(account.inserted_at),
+          updated_at: DateFormatter.to_iso8601(account.updated_at)
         }
       }
 
@@ -109,8 +110,8 @@ defmodule EWallet.Web.V1.MembershipSerializerTest do
           small: nil,
           thumb: nil
         },
-        created_at: Date.to_iso8601(user.inserted_at),
-        updated_at: Date.to_iso8601(user.updated_at),
+        created_at: DateFormatter.to_iso8601(user.inserted_at),
+        updated_at: DateFormatter.to_iso8601(user.updated_at),
         account_role: role.name,
         status: User.get_status(user),
         account: %{
@@ -126,8 +127,8 @@ defmodule EWallet.Web.V1.MembershipSerializerTest do
           object: "account",
           parent_id: nil,
           socket_topic: "account:#{account.id}",
-          created_at: Date.to_iso8601(account.inserted_at),
-          updated_at: Date.to_iso8601(account.updated_at)
+          created_at: DateFormatter.to_iso8601(account.inserted_at),
+          updated_at: DateFormatter.to_iso8601(account.updated_at)
         }
       }
 

--- a/apps/ewallet/test/ewallet/web/v1/serializers/role_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/role_serializer_test.exs
@@ -15,8 +15,9 @@
 defmodule EWallet.Web.V1.RoleSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.RoleSerializer
+  alias Utils.Helpers.DateFormatter
 
   describe "serialize/1" do
     test "serializes a role into V1 response format" do
@@ -28,8 +29,8 @@ defmodule EWallet.Web.V1.RoleSerializerTest do
         name: role.name,
         priority: role.priority,
         display_name: role.display_name,
-        created_at: Date.to_iso8601(role.inserted_at),
-        updated_at: Date.to_iso8601(role.updated_at)
+        created_at: DateFormatter.to_iso8601(role.inserted_at),
+        updated_at: DateFormatter.to_iso8601(role.updated_at)
       }
 
       assert RoleSerializer.serialize(role) == expected
@@ -58,8 +59,8 @@ defmodule EWallet.Web.V1.RoleSerializerTest do
             name: role1.name,
             priority: role1.priority,
             display_name: role1.display_name,
-            created_at: Date.to_iso8601(role1.inserted_at),
-            updated_at: Date.to_iso8601(role1.updated_at)
+            created_at: DateFormatter.to_iso8601(role1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(role1.updated_at)
           },
           %{
             object: "role",
@@ -67,8 +68,8 @@ defmodule EWallet.Web.V1.RoleSerializerTest do
             name: role2.name,
             priority: role2.priority,
             display_name: role2.display_name,
-            created_at: Date.to_iso8601(role2.inserted_at),
-            updated_at: Date.to_iso8601(role2.updated_at)
+            created_at: DateFormatter.to_iso8601(role2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(role2.updated_at)
           }
         ],
         pagination: %{

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_calculation_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_calculation_serializer_test.exs
@@ -15,7 +15,7 @@
 defmodule EWallet.Web.V1.TransactionCalculationSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias EWallet.Exchange.Calculation
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWallet.Web.V1.{ExchangePairSerializer, TransactionCalculationSerializer}
 
   describe "serialize/1" do
@@ -40,7 +40,7 @@ defmodule EWallet.Web.V1.TransactionCalculationSerializerTest do
         to_token_id: calculation.to_token.id,
         actual_rate: calculation.actual_rate,
         exchange_pair: ExchangePairSerializer.serialize(calculation.pair),
-        calculated_at: Date.to_iso8601(calculation.calculated_at)
+        calculated_at: DateFormatter.to_iso8601(calculation.calculated_at)
       }
 
       assert TransactionCalculationSerializer.serialize(calculation) == expected

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_consumption_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_consumption_serializer_test.exs
@@ -14,7 +14,7 @@
 
 defmodule EWallet.Web.V1.TransactionConsumptionSerializerTest do
   use EWallet.Web.SerializerCase, :v1
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias Utils.Helpers.Assoc
   alias EWalletDB.TransactionConsumption
 
@@ -75,12 +75,12 @@ defmodule EWallet.Web.V1.TransactionConsumptionSerializerTest do
         metadata: %{},
         encrypted_metadata: %{},
         expiration_date: nil,
-        approved_at: Date.to_iso8601(consumption.approved_at),
-        rejected_at: Date.to_iso8601(consumption.rejected_at),
-        confirmed_at: Date.to_iso8601(consumption.confirmed_at),
-        failed_at: Date.to_iso8601(consumption.failed_at),
-        expired_at: Date.to_iso8601(consumption.expired_at),
-        created_at: Date.to_iso8601(consumption.inserted_at)
+        approved_at: DateFormatter.to_iso8601(consumption.approved_at),
+        rejected_at: DateFormatter.to_iso8601(consumption.rejected_at),
+        confirmed_at: DateFormatter.to_iso8601(consumption.confirmed_at),
+        failed_at: DateFormatter.to_iso8601(consumption.failed_at),
+        expired_at: DateFormatter.to_iso8601(consumption.expired_at),
+        created_at: DateFormatter.to_iso8601(consumption.inserted_at)
       }
 
       assert TransactionConsumptionSerializer.serialize(consumption) == expected

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_request_serializer_test.exs
@@ -25,7 +25,7 @@ defmodule EWallet.Web.V1.TransactionRequestSerializerTest do
     UserSerializer
   }
 
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
 
   describe "serialize/1 for single transaction request" do
     test "serializes into correct V1 transaction_request format" do
@@ -68,8 +68,8 @@ defmodule EWallet.Web.V1.TransactionRequestSerializerTest do
         max_consumptions: nil,
         max_consumptions_per_user: nil,
         current_consumptions_count: 0,
-        created_at: Date.to_iso8601(transaction_request.inserted_at),
-        updated_at: Date.to_iso8601(transaction_request.updated_at)
+        created_at: DateFormatter.to_iso8601(transaction_request.inserted_at),
+        updated_at: DateFormatter.to_iso8601(transaction_request.updated_at)
       }
 
       assert TransactionRequestSerializer.serialize(transaction_request) == expected

--- a/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/transaction_serializer_test.exs
@@ -15,7 +15,7 @@
 defmodule EWallet.Web.V1.TransactionSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWallet.Web.V1.{AccountSerializer, TokenSerializer, TransactionSerializer, UserSerializer}
   alias Utils.Helpers.Assoc
   alias EWalletDB.{Repo, Token}
@@ -70,8 +70,8 @@ defmodule EWallet.Web.V1.TransactionSerializerTest do
         status: transaction.status,
         error_code: nil,
         error_description: nil,
-        created_at: Date.to_iso8601(transaction.inserted_at),
-        updated_at: Date.to_iso8601(transaction.updated_at)
+        created_at: DateFormatter.to_iso8601(transaction.inserted_at),
+        updated_at: DateFormatter.to_iso8601(transaction.updated_at)
       }
 
       assert TransactionSerializer.serialize(transaction) == expected

--- a/apps/ewallet/test/ewallet/web/v1/serializers/user_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/user_serializer_test.exs
@@ -15,8 +15,9 @@
 defmodule EWallet.Web.V1.UserSerializerTest do
   use EWallet.Web.SerializerCase, :v1
   alias Ecto.Association.NotLoaded
-  alias EWallet.Web.{Date, Paginator}
+  alias EWallet.Web.Paginator
   alias EWallet.Web.V1.UserSerializer
+  alias Utils.Helpers.DateFormatter
 
   describe "serialize/1" do
     test "serializes a user into correct JSON format" do
@@ -43,8 +44,8 @@ defmodule EWallet.Web.V1.UserSerializerTest do
           "last_name" => user.metadata["last_name"]
         },
         encrypted_metadata: %{},
-        created_at: Date.to_iso8601(user.inserted_at),
-        updated_at: Date.to_iso8601(user.updated_at)
+        created_at: DateFormatter.to_iso8601(user.inserted_at),
+        updated_at: DateFormatter.to_iso8601(user.updated_at)
       }
 
       assert UserSerializer.serialize(user) == expected
@@ -96,8 +97,8 @@ defmodule EWallet.Web.V1.UserSerializerTest do
               "last_name" => user1.metadata["last_name"]
             },
             encrypted_metadata: %{},
-            created_at: Date.to_iso8601(user1.inserted_at),
-            updated_at: Date.to_iso8601(user1.updated_at)
+            created_at: DateFormatter.to_iso8601(user1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(user1.updated_at)
           },
           %{
             object: "user",
@@ -120,8 +121,8 @@ defmodule EWallet.Web.V1.UserSerializerTest do
               "last_name" => user2.metadata["last_name"]
             },
             encrypted_metadata: %{},
-            created_at: Date.to_iso8601(user2.inserted_at),
-            updated_at: Date.to_iso8601(user2.updated_at)
+            created_at: DateFormatter.to_iso8601(user2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(user2.updated_at)
           }
         ],
         pagination: %{
@@ -165,8 +166,8 @@ defmodule EWallet.Web.V1.UserSerializerTest do
             },
             encrypted_metadata: %{},
             enabled: user1.enabled,
-            created_at: Date.to_iso8601(user1.inserted_at),
-            updated_at: Date.to_iso8601(user1.updated_at)
+            created_at: DateFormatter.to_iso8601(user1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(user1.updated_at)
           },
           %{
             object: "user",
@@ -189,8 +190,8 @@ defmodule EWallet.Web.V1.UserSerializerTest do
             },
             encrypted_metadata: %{},
             enabled: user2.enabled,
-            created_at: Date.to_iso8601(user2.inserted_at),
-            updated_at: Date.to_iso8601(user2.updated_at)
+            created_at: DateFormatter.to_iso8601(user2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(user2.updated_at)
           }
         ]
       }

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/reset_password_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/reset_password_controller_test.exs
@@ -16,7 +16,7 @@ defmodule EWalletAPI.V1.ResetPasswordControllerTest do
   use EWalletAPI.ConnCase, async: true
   use Bamboo.Test
   alias EWallet.ForgetPasswordEmail
-  alias Utils.Helpers.Crypto
+  alias Utils.Helpers.{Crypto, DateFormatter}
   alias EWalletDB.{ForgetPasswordRequest, Repo, User}
 
   @redirect_url "http://localhost:4000/reset_password?email={email}&token={token}"
@@ -146,7 +146,7 @@ defmodule EWalletAPI.V1.ResetPasswordControllerTest do
         originator: :system,
         target: request,
         changes: %{
-          "expires_at" => NaiveDateTime.to_iso8601(request.expires_at),
+          "expires_at" => DateFormatter.to_iso8601(request.expires_at),
           "token" => request.token,
           "user_uuid" => user.uuid
         },

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
@@ -14,7 +14,7 @@
 
 defmodule EWalletAPI.V1.SelfControllerTest do
   use EWalletAPI.ConnCase, async: true
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
   alias EWalletDB.{Account, User}
 
   describe "/me.get" do
@@ -70,8 +70,8 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                      "metadata" => %{},
                      "name" => "primary",
                      "enabled" => true,
-                     "created_at" => Date.to_iso8601(user_wallet.inserted_at),
-                     "updated_at" => Date.to_iso8601(user_wallet.updated_at),
+                     "created_at" => DateFormatter.to_iso8601(user_wallet.inserted_at),
+                     "updated_at" => DateFormatter.to_iso8601(user_wallet.updated_at),
                      "user" => %{
                        "avatar" => %{
                          "large" => nil,
@@ -79,7 +79,7 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                          "small" => nil,
                          "thumb" => nil
                        },
-                       "created_at" => Date.to_iso8601(user.inserted_at),
+                       "created_at" => DateFormatter.to_iso8601(user.inserted_at),
                        "email" => nil,
                        "encrypted_metadata" => %{},
                        "id" => user.id,
@@ -87,7 +87,7 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                        "object" => "user",
                        "provider_user_id" => user.provider_user_id,
                        "socket_topic" => "user:#{user.id}",
-                       "updated_at" => Date.to_iso8601(user.updated_at),
+                       "updated_at" => DateFormatter.to_iso8601(user.updated_at),
                        "username" => user.username,
                        "full_name" => user.full_name,
                        "calling_name" => user.calling_name,
@@ -107,8 +107,8 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "created_at" => Date.to_iso8601(btc.inserted_at),
-                           "updated_at" => Date.to_iso8601(btc.updated_at)
+                           "created_at" => DateFormatter.to_iso8601(btc.inserted_at),
+                           "updated_at" => DateFormatter.to_iso8601(btc.updated_at)
                          }
                        },
                        %{
@@ -123,8 +123,8 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "created_at" => Date.to_iso8601(omg.inserted_at),
-                           "updated_at" => Date.to_iso8601(omg.updated_at)
+                           "created_at" => DateFormatter.to_iso8601(omg.inserted_at),
+                           "updated_at" => DateFormatter.to_iso8601(omg.updated_at)
                          }
                        }
                      ]

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/signup_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/signup_controller_test.exs
@@ -20,6 +20,7 @@ defmodule EWalletAPI.V1.SignupControllerTest do
   alias EWallet.VerificationEmail
   alias EWalletDB.{Invite, User, AccountUser, Repo}
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   describe "/user.signup" do
     test "returns success with an empty response" do
@@ -292,7 +293,7 @@ defmodule EWalletAPI.V1.SignupControllerTest do
         action: "update",
         originator: context.user,
         target: invite,
-        changes: %{"verified_at" => NaiveDateTime.to_iso8601(invite.verified_at)},
+        changes: %{"verified_at" => DateFormatter.to_iso8601(invite.verified_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_consumption_controller_test.exs
@@ -15,9 +15,10 @@
 defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
   use EWalletAPI.ConnCase, async: true
   alias EWallet.TestEndpoint
-  alias EWallet.Web.{Date, Orchestrator}
+  alias EWallet.Web.Orchestrator
   alias EWalletDB.{Account, Repo, Transaction, TransactionConsumption, User, TransactionRequest}
   alias Phoenix.Socket.Broadcast
+  alias Utils.Helpers.DateFormatter
 
   alias EWallet.Web.V1.{
     TokenSerializer,
@@ -123,11 +124,11 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
                  "exchange_wallet_address" => nil,
                  "exchange_wallet" => nil,
                  "exchange_account" => nil,
-                 "created_at" => Date.to_iso8601(inserted_consumption.inserted_at),
-                 "approved_at" => Date.to_iso8601(inserted_consumption.approved_at),
-                 "rejected_at" => Date.to_iso8601(inserted_consumption.rejected_at),
-                 "confirmed_at" => Date.to_iso8601(inserted_consumption.confirmed_at),
-                 "failed_at" => Date.to_iso8601(inserted_consumption.failed_at),
+                 "created_at" => DateFormatter.to_iso8601(inserted_consumption.inserted_at),
+                 "approved_at" => DateFormatter.to_iso8601(inserted_consumption.approved_at),
+                 "rejected_at" => DateFormatter.to_iso8601(inserted_consumption.rejected_at),
+                 "confirmed_at" => DateFormatter.to_iso8601(inserted_consumption.confirmed_at),
+                 "failed_at" => DateFormatter.to_iso8601(inserted_consumption.failed_at),
                  "expired_at" => nil
                }
              }
@@ -209,11 +210,11 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
                  "exchange_wallet_address" => nil,
                  "exchange_wallet" => nil,
                  "exchange_account" => nil,
-                 "created_at" => Date.to_iso8601(inserted_consumption.inserted_at),
-                 "approved_at" => Date.to_iso8601(inserted_consumption.approved_at),
-                 "rejected_at" => Date.to_iso8601(inserted_consumption.rejected_at),
-                 "confirmed_at" => Date.to_iso8601(inserted_consumption.confirmed_at),
-                 "failed_at" => Date.to_iso8601(inserted_consumption.failed_at),
+                 "created_at" => DateFormatter.to_iso8601(inserted_consumption.inserted_at),
+                 "approved_at" => DateFormatter.to_iso8601(inserted_consumption.approved_at),
+                 "rejected_at" => DateFormatter.to_iso8601(inserted_consumption.rejected_at),
+                 "confirmed_at" => DateFormatter.to_iso8601(inserted_consumption.confirmed_at),
+                 "failed_at" => DateFormatter.to_iso8601(inserted_consumption.failed_at),
                  "expired_at" => nil
                }
              }
@@ -292,11 +293,11 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
                  "exchange_wallet_address" => nil,
                  "exchange_wallet" => nil,
                  "exchange_account" => nil,
-                 "created_at" => Date.to_iso8601(inserted_consumption.inserted_at),
-                 "approved_at" => Date.to_iso8601(inserted_consumption.approved_at),
-                 "rejected_at" => Date.to_iso8601(inserted_consumption.rejected_at),
-                 "confirmed_at" => Date.to_iso8601(inserted_consumption.confirmed_at),
-                 "failed_at" => Date.to_iso8601(inserted_consumption.failed_at),
+                 "created_at" => DateFormatter.to_iso8601(inserted_consumption.inserted_at),
+                 "approved_at" => DateFormatter.to_iso8601(inserted_consumption.approved_at),
+                 "rejected_at" => DateFormatter.to_iso8601(inserted_consumption.rejected_at),
+                 "confirmed_at" => DateFormatter.to_iso8601(inserted_consumption.confirmed_at),
+                 "failed_at" => DateFormatter.to_iso8601(inserted_consumption.failed_at),
                  "expired_at" => nil
                }
              }
@@ -380,11 +381,11 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
                  "exchange_wallet_address" => nil,
                  "exchange_wallet" => nil,
                  "exchange_account" => nil,
-                 "created_at" => Date.to_iso8601(inserted_consumption.inserted_at),
-                 "approved_at" => Date.to_iso8601(inserted_consumption.approved_at),
-                 "rejected_at" => Date.to_iso8601(inserted_consumption.rejected_at),
-                 "confirmed_at" => Date.to_iso8601(inserted_consumption.confirmed_at),
-                 "failed_at" => Date.to_iso8601(inserted_consumption.failed_at),
+                 "created_at" => DateFormatter.to_iso8601(inserted_consumption.inserted_at),
+                 "approved_at" => DateFormatter.to_iso8601(inserted_consumption.approved_at),
+                 "rejected_at" => DateFormatter.to_iso8601(inserted_consumption.rejected_at),
+                 "confirmed_at" => DateFormatter.to_iso8601(inserted_consumption.confirmed_at),
+                 "failed_at" => DateFormatter.to_iso8601(inserted_consumption.failed_at),
                  "expired_at" => nil
                }
              }
@@ -672,7 +673,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
         originator: meta.bob,
         target: transaction_consumption,
         changes: %{
-          "estimated_at" => NaiveDateTime.to_iso8601(transaction_consumption.estimated_at),
+          "estimated_at" => DateFormatter.to_iso8601(transaction_consumption.estimated_at),
           "estimated_consumption_amount" => 100,
           "estimated_rate" => 1.0,
           "estimated_request_amount" => 100,
@@ -693,7 +694,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
         originator: :system,
         target: transaction_consumption,
         changes: %{
-          "approved_at" => NaiveDateTime.to_iso8601(transaction_consumption.approved_at),
+          "approved_at" => DateFormatter.to_iso8601(transaction_consumption.approved_at),
           "status" => "approved"
         },
         encrypted_changes: %{}
@@ -706,7 +707,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
         originator: transaction_consumption,
         target: transaction,
         changes: %{
-          "calculated_at" => NaiveDateTime.to_iso8601(transaction.calculated_at),
+          "calculated_at" => DateFormatter.to_iso8601(transaction.calculated_at),
           "from" => meta.alice_wallet.address,
           "from_user_uuid" => meta.alice.uuid,
           "from_amount" => 100,
@@ -757,7 +758,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
         originator: transaction,
         target: transaction_consumption,
         changes: %{
-          "confirmed_at" => NaiveDateTime.to_iso8601(transaction_consumption.confirmed_at),
+          "confirmed_at" => DateFormatter.to_iso8601(transaction_consumption.confirmed_at),
           "status" => "confirmed",
           "transaction_uuid" => transaction.uuid
         },
@@ -780,7 +781,7 @@ defmodule EWalletAPI.V1.TransactionConsumptionControllerTest do
         action: "update",
         originator: :system,
         target: transaction_request,
-        changes: %{"updated_at" => NaiveDateTime.to_iso8601(transaction_request.updated_at)},
+        changes: %{"updated_at" => DateFormatter.to_iso8601(transaction_request.updated_at)},
         encrypted_changes: %{}
       )
     end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -14,8 +14,9 @@
 
 defmodule EWalletAPI.V1.TransactionRequestControllerTest do
   use EWalletAPI.ConnCase, async: true
-  alias EWallet.Web.{Date, V1.TokenSerializer, V1.UserSerializer}
+  alias EWallet.Web.V1.{TokenSerializer, UserSerializer}
   alias EWalletDB.{Repo, TransactionRequest, User}
+  alias Utils.Helpers.DateFormatter
 
   describe "/me.create_transaction_request" do
     test "creates a transaction request with all the params" do
@@ -70,8 +71,8 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "max_consumptions" => 3,
                  "max_consumptions_per_user" => 1,
                  "current_consumptions_count" => 0,
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end
@@ -123,8 +124,8 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "exchange_account_id" => nil,
                  "exchange_wallet" => nil,
                  "exchange_wallet_address" => nil,
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end
@@ -177,8 +178,8 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
                  "exchange_account_id" => nil,
                  "exchange_wallet" => nil,
                  "exchange_wallet_address" => nil,
-                 "created_at" => Date.to_iso8601(request.inserted_at),
-                 "updated_at" => Date.to_iso8601(request.updated_at)
+                 "created_at" => DateFormatter.to_iso8601(request.inserted_at),
+                 "updated_at" => DateFormatter.to_iso8601(request.updated_at)
                }
              }
     end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/transaction_view_test.exs
@@ -14,9 +14,9 @@
 
 defmodule EWalletAPI.V1.TransactionViewTest do
   use EWalletAPI.ViewCase, :v1
-  alias EWallet.Web.{Date, V1.AccountSerializer, V1.TokenSerializer, V1.UserSerializer}
+  alias EWallet.Web.V1.{AccountSerializer, TokenSerializer, UserSerializer}
   alias EWalletAPI.V1.TransactionView
-  alias Utils.Helpers.Assoc
+  alias Utils.Helpers.{Assoc, DateFormatter}
 
   describe "EWalletAPI.V1.TransactionView.render/2" do
     test "renders transaction.json with correct structure" do
@@ -69,8 +69,8 @@ defmodule EWalletAPI.V1.TransactionViewTest do
           status: transaction.status,
           error_code: nil,
           error_description: nil,
-          created_at: Date.to_iso8601(transaction.inserted_at),
-          updated_at: Date.to_iso8601(transaction.updated_at)
+          created_at: DateFormatter.to_iso8601(transaction.inserted_at),
+          updated_at: DateFormatter.to_iso8601(transaction.updated_at)
         }
       }
 

--- a/apps/ewallet_api/test/support/conn_case.ex
+++ b/apps/ewallet_api/test/support/conn_case.ex
@@ -36,6 +36,7 @@ defmodule EWalletAPI.ConnCase do
   alias EWalletDB.{Account, Repo, User}
   alias EWalletConfig.ConfigTestHelper
   alias ActivityLogger.System
+  alias Utils.Helpers.DateFormatter
 
   # Attributes required by Phoenix.ConnTest
   @endpoint EWalletAPI.Endpoint
@@ -133,7 +134,7 @@ defmodule EWalletAPI.ConnCase do
   end
 
   def stringify_keys(%NaiveDateTime{} = value) do
-    Date.to_iso8601(value)
+    DateFormatter.to_iso8601(value)
   end
 
   def stringify_keys(map) when is_map(map) do

--- a/apps/utils/lib/helpers/date_formatter.ex
+++ b/apps/utils/lib/helpers/date_formatter.ex
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule EWallet.Web.Date do
+defmodule Utils.Helpers.DateFormatter do
   @moduledoc """
   This module allows formatting of a date (naive or date time) into an iso8601 string.
   """
@@ -30,7 +30,9 @@ defmodule EWallet.Web.Date do
   Parses the given NaiveDateTime to an iso8601 string.
   """
   def to_iso8601(%NaiveDateTime{} = date) do
-    NaiveDateTime.to_iso8601(date)
+    date
+    |> DateTime.from_naive!("Etc/UTC")
+    |> to_iso8601()
   end
 
   @doc """

--- a/apps/utils/test/utils/helpers/date_formatter_test.exs
+++ b/apps/utils/test/utils/helpers/date_formatter_test.exs
@@ -12,29 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule EWallet.Web.DateTest do
+defmodule Utils.Helpers.DateFormatterTest do
   use ExUnit.Case
   alias EWallet.Errors.InvalidDateFormatError
-  alias EWallet.Web.Date
+  alias Utils.Helpers.DateFormatter
 
-  describe "EWallet.Web.Date.to_iso8601/1" do
+  describe "to_iso8601/1" do
     test "formats a valid naive date time" do
       naive_date = ~N[2000-01-01 10:01:02]
-      formatted_date = Date.to_iso8601(naive_date)
+      formatted_date = DateFormatter.to_iso8601(naive_date)
 
-      assert formatted_date == "2000-01-01T10:01:02"
+      assert formatted_date == "2000-01-01T10:01:02Z"
     end
 
     test "formats a normal date time" do
       {:ok, date, 0} = DateTime.from_iso8601("2000-01-01T10:01:02Z")
-      formatted_date = Date.to_iso8601(date)
+      formatted_date = DateFormatter.to_iso8601(date)
 
       assert formatted_date == "2000-01-01T10:01:02Z"
     end
 
     test "Raise an exception if the type is not supported" do
       assert_raise InvalidDateFormatError, fn ->
-        Date.to_iso8601("an invalid type")
+        DateFormatter.to_iso8601("an invalid type")
       end
     end
   end


### PR DESCRIPTION
Issue/Task Number: 609
Closes #609 

# Overview

This PR reverts the change that was made in [this file](https://github.com/omisego/ewallet/pull/575/files#diff-69b92cef564b8c1958bd9cdc03f08dbaL11) that removed the `Z` at the end when serializing the date which introduced compatibility issues.

Also improved the serialization of the `target_changes` of `activity_logs` by using the same date formatter as the controller serializers and supporting multiple levels.

# Changes

- Use`DateTime.to_iso8601(date)` always instead of `NaiveDateTime.to_iso8601(date)` to serialize the dates
- Moved and renamed `date.ex` from the eWallet sub-app to `helpers/date_formatters.ex`

# Impact

Date format is now unchanged from `1.0.0`