### PR TITLE
Add tests for ActivityLogger

### DIFF
--- a/apps/activity_logger/test/activity_logger/activity_logging_test.exs
+++ b/apps/activity_logger/test/activity_logger/activity_logging_test.exs
@@ -65,7 +65,9 @@ defmodule ActivityLogger.ActivityLoggingTest do
 
     test "invalidates the changeset if originator is not provided", meta do
       attrs = Map.put(meta.attrs, :originator, nil)
-      changeset = ActivityLogging.cast_and_validate_required_for_activity_log(%TestDocument{}, attrs)
+
+      changeset =
+        ActivityLogging.cast_and_validate_required_for_activity_log(%TestDocument{}, attrs)
 
       refute changeset.valid?
       assert changeset.errors == [originator: {"can't be blank", [validation: :required]}]

--- a/apps/activity_logger/test/activity_logger/activity_logging_test.exs
+++ b/apps/activity_logger/test/activity_logger/activity_logging_test.exs
@@ -1,0 +1,89 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule ActivityLogger.ActivityLoggingTest do
+  use ExUnit.Case
+  import ActivityLogger.Factory
+  alias ActivityLogger.ActivityLogging
+  alias ActivityLogger.TestDocument
+  alias Ecto.Adapters.SQL.Sandbox
+
+  setup do
+    :ok = Sandbox.checkout(ActivityLogger.Repo)
+
+    attrs = %{
+      title: "A title",
+      body: "some body that we don't want to save",
+      secret_data: %{something: "secret"},
+      originator: insert(:test_user)
+    }
+
+    %{attrs: attrs}
+  end
+
+  describe "cast_and_validate_required_for_activity_log/3" do
+    test "returns a valid changeset", meta do
+      changeset =
+        %TestDocument{}
+        |> ActivityLogging.cast_and_validate_required_for_activity_log(
+          meta.attrs,
+          cast: [:title, :body, :secret_data],
+          required: [:title],
+          prevent_saving: [:body],
+          encrypted: [:secret_data]
+        )
+
+      assert changeset.valid?
+      assert changeset.changes.encrypted_fields == [:secret_data]
+      assert changeset.changes.encrypted_changes == %{secret_data: %{something: "secret"}}
+      assert changeset.changes.prevent_saving == [:body]
+    end
+
+    test "does not cast fields outside :cast opts", meta do
+      changeset =
+        %TestDocument{}
+        |> ActivityLogging.cast_and_validate_required_for_activity_log(
+          meta.attrs,
+          cast: [:title]
+        )
+
+      assert Map.has_key?(changeset.changes, :title)
+      refute Map.has_key?(changeset.changes, :body)
+      refute Map.has_key?(changeset.changes, :secret_data)
+    end
+
+    test "invalidates the changeset if originator is not provided", meta do
+      attrs = Map.put(meta.attrs, :originator, nil)
+      changeset = ActivityLogging.cast_and_validate_required_for_activity_log(%TestDocument{}, attrs)
+
+      refute changeset.valid?
+      assert changeset.errors == [originator: {"can't be blank", [validation: :required]}]
+    end
+
+    test "invalidates the changeset if the required field is missing", meta do
+      attrs = Map.put(meta.attrs, :title, nil)
+
+      changeset =
+        %TestDocument{}
+        |> ActivityLogging.cast_and_validate_required_for_activity_log(
+          attrs,
+          cast: [:title],
+          required: [:title]
+        )
+
+      refute changeset.valid?
+      assert changeset.errors == [title: {"can't be blank", [validation: :required]}]
+    end
+  end
+end

--- a/apps/activity_logger/test/activity_logger/activity_repo_test.exs
+++ b/apps/activity_logger/test/activity_logger/activity_repo_test.exs
@@ -1,0 +1,113 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule ActivityLogger.ActivityRepoTest do
+  use ExUnit.Case
+  use ActivityLogger.ActivityLogging
+  import ActivityLogger.Factory
+  alias ActivityLogger.{ActivityLog, TestDocument}
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Ecto.Changeset
+
+  defmodule TestRepo do
+    use ActivityLogger.ActivityRepo, repo: ActivityLogger.Repo
+  end
+
+  setup do
+    :ok = Sandbox.checkout(ActivityLogger.Repo)
+
+    ActivityLogger.configure(%{
+      ActivityLogger.System => %{type: "system", identifier: nil},
+      ActivityLogger.TestDocument => %{type: "test_document", identifier: :id},
+      ActivityLogger.TestUser => %{type: "test_user", identifier: :id}
+    })
+
+    attrs = %{
+      title: "A title",
+      body: "some body that we don't want to save",
+      secret_data: %{something: "secret"},
+      originator: insert(:test_user)
+    }
+
+    %{attrs: attrs}
+  end
+
+  describe "insert_record_with_activity_log/3" do
+    test "inserts the record and the activity log", meta do
+      changeset = Changeset.cast(%TestDocument{}, meta.attrs, [:title, :originator])
+
+      # Test for the inserted record
+      {res, record} = TestRepo.insert_record_with_activity_log(changeset)
+
+      assert res == :ok
+      assert %TestDocument{} = record
+      assert record.title == meta.attrs.title
+
+      # Test for the inserted activity log
+      activity_logs = ActivityLog.all_for_target(TestDocument, record.uuid)
+
+      assert length(activity_logs) == 1
+      assert Enum.any?(activity_logs, fn a ->
+        a.action == "insert" && a.originator_uuid == meta.attrs.originator.uuid
+      end)
+    end
+  end
+
+  describe "update_record_with_activity_log/3" do
+    test "updates the record and inserts the activity log", meta do
+      {:ok, document} = :test_document |> params_for() |> TestDocument.insert()
+      changeset = Changeset.cast(document, meta.attrs, [:title, :originator])
+
+      # Test for the updated record
+      {res, record} = TestRepo.update_record_with_activity_log(changeset)
+
+      assert res == :ok
+      assert record.title == meta.attrs.title
+
+      # Test for the inserted activity log
+      activity_logs = ActivityLog.all_for_target(TestDocument, record.uuid)
+
+      assert length(activity_logs) == 2
+      assert Enum.any?(activity_logs, fn a ->
+        a.action == "insert" && a.originator_type == "system"
+      end)
+      assert Enum.any?(activity_logs, fn a ->
+        a.action == "update" && a.originator_uuid == meta.attrs.originator.uuid
+      end)
+    end
+  end
+
+  describe "delete_record_with_activity_log/3" do
+    test "deletes the record and inserts the activity log", meta do
+      {:ok, document} = :test_document |> params_for() |> TestDocument.insert()
+      changeset = Changeset.cast(document, meta.attrs, [:originator])
+
+      # Test for the deleted record
+      {res, record} = TestRepo.delete_record_with_activity_log(changeset)
+
+      assert res == :ok
+
+      # Test for the deleted activity log
+      activity_logs = ActivityLog.all_for_target(TestDocument, record.uuid)
+
+      assert length(activity_logs) == 2
+      assert Enum.any?(activity_logs, fn a ->
+        a.action == "insert" && a.originator_type == "system"
+      end)
+      assert Enum.any?(activity_logs, fn a ->
+        a.action == "delete" && a.originator_uuid == meta.attrs.originator.uuid
+      end)
+    end
+  end
+end

--- a/apps/activity_logger/test/activity_logger/activity_repo_test.exs
+++ b/apps/activity_logger/test/activity_logger/activity_repo_test.exs
@@ -58,9 +58,10 @@ defmodule ActivityLogger.ActivityRepoTest do
       activity_logs = ActivityLog.all_for_target(TestDocument, record.uuid)
 
       assert length(activity_logs) == 1
+
       assert Enum.any?(activity_logs, fn a ->
-        a.action == "insert" && a.originator_uuid == meta.attrs.originator.uuid
-      end)
+               a.action == "insert" && a.originator_uuid == meta.attrs.originator.uuid
+             end)
     end
   end
 
@@ -79,12 +80,14 @@ defmodule ActivityLogger.ActivityRepoTest do
       activity_logs = ActivityLog.all_for_target(TestDocument, record.uuid)
 
       assert length(activity_logs) == 2
+
       assert Enum.any?(activity_logs, fn a ->
-        a.action == "insert" && a.originator_type == "system"
-      end)
+               a.action == "insert" && a.originator_type == "system"
+             end)
+
       assert Enum.any?(activity_logs, fn a ->
-        a.action == "update" && a.originator_uuid == meta.attrs.originator.uuid
-      end)
+               a.action == "update" && a.originator_uuid == meta.attrs.originator.uuid
+             end)
     end
   end
 
@@ -102,12 +105,14 @@ defmodule ActivityLogger.ActivityRepoTest do
       activity_logs = ActivityLog.all_for_target(TestDocument, record.uuid)
 
       assert length(activity_logs) == 2
+
       assert Enum.any?(activity_logs, fn a ->
-        a.action == "insert" && a.originator_type == "system"
-      end)
+               a.action == "insert" && a.originator_type == "system"
+             end)
+
       assert Enum.any?(activity_logs, fn a ->
-        a.action == "delete" && a.originator_uuid == meta.attrs.originator.uuid
-      end)
+               a.action == "delete" && a.originator_uuid == meta.attrs.originator.uuid
+             end)
     end
   end
 end

--- a/apps/activity_logger/test/activity_logger_test.exs
+++ b/apps/activity_logger/test/activity_logger_test.exs
@@ -1,0 +1,39 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule ActivityLoggerTest do
+  use ExUnit.Case, async: false
+
+  describe "configure/1" do
+    test "appends the config's activity log <-> schemas mapping with the given map" do
+      _ =
+        ActivityLogger.configure(%{
+          ActivityLoggerTest => %{type: "activity_logger_test", identifier: nil}
+        })
+
+      schemas_to_activity_log =
+        Application.get_env(:activity_logger, :schemas_to_activity_log_config)
+
+      activity_log_types_to_schemas =
+        Application.get_env(:activity_logger, :activity_log_types_to_schemas)
+
+      assert Map.get(schemas_to_activity_log, ActivityLoggerTest) == %{
+               identifier: nil,
+               type: "activity_logger_test"
+             }
+
+      assert Map.get(activity_log_types_to_schemas, "activity_logger_test") == ActivityLoggerTest
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/originator_test.exs
+++ b/apps/ewallet/test/ewallet/web/originator_test.exs
@@ -1,0 +1,75 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.OriginatorTest do
+  use EWallet.DBCase
+  import EWalletDB.Factory
+  alias EWallet.Web.Originator
+  alias EWalletDB.{Account, Key, User}
+  alias Plug.Conn
+
+  setup do
+    ActivityLogger.configure(%{
+      EWalletDB.User => %{type: "user", identifier: :id}
+    })
+
+    :ok
+  end
+
+  describe "extract/1" do
+    test "returns the key when key is assigned in the Conn" do
+      conn = %Conn{assigns: %{key: %Key{access_key: "1234"}}}
+      assert Originator.extract(conn.assigns) == %Key{access_key: "1234"}
+    end
+
+    test "returns the admin_user when admin_user is assigned in the Conn" do
+      conn = %Conn{assigns: %{admin_user: %User{is_admin: true}}}
+      assert Originator.extract(conn.assigns) == %User{is_admin: true}
+    end
+
+    test "returns the end_user when end_user is assigned in the Conn" do
+      conn = %Conn{assigns: %{end_user: %User{is_admin: false}}}
+      assert Originator.extract(conn.assigns) == %User{is_admin: false}
+    end
+  end
+
+  describe "set_in_attrs/3" do
+    test "puts the originator into the given attributes" do
+      conn = %Conn{assigns: %{key: %Key{access_key: "1234"}}}
+      attrs = %{title: "some_title"}
+      attrs = Originator.set_in_attrs(attrs, conn.assigns)
+
+      assert attrs["originator"] == %Key{access_key: "1234"}
+    end
+  end
+
+  describe "get_initial_originator/1" do
+    test "returns the originator that inserted the record" do
+      insert_user = insert(:user)
+
+      {:ok, inserted} =
+        :account
+        |> params_for(originator: insert_user)
+        |> Account.insert()
+
+      {:ok, updated} =
+        Account.update(inserted, %{
+          name: "updated_name",
+          originator: insert(:user)
+        })
+
+      assert Originator.get_initial_originator(updated) == insert_user
+    end
+  end
+end


### PR DESCRIPTION
Issue/Task Number: #611 
Closes #611

# Overview

This PR adds missing test for ActivityLogger

# Changes

Add tests for the following modules:

- ActivityLogger
- ActivityLogger.ActivityLogging
- ActivityLogger.ActivityRepo
- EWallet.Web.Originator

# Implementation Details

N/A

# Usage

`mix test`

# Impact

No changes to DB schema or API specs