### PR TITLE
Fix Docker image push failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ jobs:
                 fi
             elif [ "$CIRCLE_BRANCH" = "master" ]; then
                 IMAGE_TAG="dev"
-                IMAGE_TAG="dev-$(git rev-parse --short HEAD) $IMAGE_TAG"
+                IMAGE_TAG="dev-$(echo "$CIRCLE_SHA1" | head -c 8) $IMAGE_TAG"
             fi
 
             for tag in $IMAGE_TAG; do


### PR DESCRIPTION
Issue/Task Number:

# Overview

Fixes failure during Docker image push.

# Changes

Use `CIRCLE_SHA1` instead of `git rev-parse`. 