### PR TITLE
Add missing `redirect_url` param for `me.update_email` doc endpoint

### DIFF
--- a/apps/admin_api/priv/spec.json
+++ b/apps/admin_api/priv/spec.json
@@ -19382,10 +19382,14 @@
                 "properties": {
                   "email": {
                     "type": "string"
+                  },
+                  "redirect_url": {
+                    "type": "string"
                   }
                 },
                 "example": {
-                  "email": "new.email@example.com"
+                  "email": "new.email@example.com",
+                  "redirect_url": "https://example.com"
                 }
               }
             }

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -3184,8 +3184,11 @@ paths:
               properties:
                 email:
                   type: string
+                redirect_url:
+                  type: string
               example:
                 email: new.email@example.com
+                redirect_url: 'https://example.com'
       responses:
         '200': *ref_34
         '500': *ref_2

--- a/apps/admin_api/priv/swagger/admin/request_bodies.yaml
+++ b/apps/admin_api/priv/swagger/admin/request_bodies.yaml
@@ -165,8 +165,11 @@ AdminUpdateEmailBody:
         properties:
           email:
             type: string
+          redirect_url:
+            type: string
         example:
           email: new.email@example.com
+          redirect_url: https://example.com
 
 AdminUploadBody:
   description: The parameters to use for uploading an admin's avatar. Only supports .jpg, .jpeg, .gif and .png.


### PR DESCRIPTION
Issue/Task Number: 635
Closes #635 

# Overview

This PR adds the missing `redirect_url` param to the `me.update_email` open api endpoint.
