### PR TITLE
Fix file noent

### DIFF
--- a/apps/ewallet_config/test/ewallet_config/storage/local_test.exs
+++ b/apps/ewallet_config/test/ewallet_config/storage/local_test.exs
@@ -23,6 +23,13 @@ defmodule EWalletConfig.Storage.LocalTest do
     def storage_dir(_, _), do: "private/temp_test_files/"
   end
 
+  setup do
+    # Create the directory to store the temporary test files
+    :ok = File.mkdir_p!(test_file_path())
+
+    :ok
+  end
+
   describe "get_path/2" do
     test "returns the path with the root dir prepended" do
       root_dir = Application.get_env(:ewallet, :root)
@@ -130,5 +137,11 @@ defmodule EWalletConfig.Storage.LocalTest do
       # Invoke & assert
       assert Local.delete(MockDefinition, "v1", {file, nil}) == :ok
     end
+  end
+
+  defp test_file_path do
+    :ewallet
+    |> Application.get_env(:root)
+    |> Path.join(@temp_test_file_dir)
   end
 end

--- a/apps/ewallet_config/test/ewallet_config/storage/local_test.exs
+++ b/apps/ewallet_config/test/ewallet_config/storage/local_test.exs
@@ -18,6 +18,8 @@ defmodule EWalletConfig.Storage.LocalTest do
   alias EWalletConfig.Config
   alias EWalletConfig.Storage.Local
 
+  @temp_test_file_dir "private/temp_test_files"
+
   defmodule MockDefinition do
     use Arc.Definition
     def storage_dir(_, _), do: "private/temp_test_files/"
@@ -140,8 +142,8 @@ defmodule EWalletConfig.Storage.LocalTest do
   end
 
   defp test_file_path do
-    :ewallet
-    |> Application.get_env(:root)
+    "../../"
+    |> Path.absname()
     |> Path.join(@temp_test_file_dir)
   end
 end


### PR DESCRIPTION
Issue/Task Number: #640 
Closes #640 

# Overview

This PR fixes the `{:error, :noent}` error that's happening on `EWalletConfig.Storage.LocalTest`.

# Changes

- Ensure that the required directory exists before performing the tests with file storage.

# Implementation Details

Since `EWalletConfig.Storage.LocalTest` is testing for file writing, the file needed to go somewhere. So this PR ensures that the directory exists.

A caveat is that this test belongs to the `EWalletConfig` app and does not have knowledge of `Application.get_env(:ewallet, :root)`. So a hard coded `Path.absname("../../")` is used instead to obtain the root directory.

# Usage

Running `mix test` should pass successfully.

# Impact

No changes to DB schema or API specs.
