### PR TITLE
Increase test coverage for helpers, fetchers, views, serializers, etc.

### DIFF
--- a/apps/admin_api/test/admin_api/v1/helpers/account_helper_test.exs
+++ b/apps/admin_api/test/admin_api/v1/helpers/account_helper_test.exs
@@ -1,0 +1,109 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule AdminAPI.V1.AccountHelperTest do
+  use AdminAPI.ConnCase, async: true
+  import EWalletDB.Factory
+  alias AdminAPI.V1.AccountHelper
+  alias Plug.Conn
+
+  describe "get_current_account/1" do
+    test "returns the user's auth_token account when exist" do
+      admin = insert(:admin)
+      account = insert(:account)
+      auth_token = insert(:auth_token, user: admin, account: account, owner_app: "admin_api")
+
+      conn = %Conn{
+        assigns: %{admin_user: admin},
+        private: %{auth_auth_token: auth_token.token}
+      }
+
+      assert AccountHelper.get_current_account(conn).uuid == account.uuid
+    end
+
+    test "returns the user's account when the auth_token is not associated with an account" do
+      admin = insert(:admin)
+      account = insert(:account)
+      _ = insert(:membership, user: admin, account: account)
+      auth_token = insert(:auth_token, user: admin, account: nil, owner_app: "admin_api")
+
+      conn = %Conn{
+        assigns: %{admin_user: admin},
+        private: %{auth_auth_token: auth_token.token}
+      }
+
+      assert AccountHelper.get_current_account(conn).uuid == account.uuid
+    end
+
+    test "returns the key's account when the conn is authenticated using a key" do
+      account = insert(:account)
+      key = insert(:key, account: account)
+
+      conn = %Conn{
+        assigns: %{
+          key: key
+        }
+      }
+
+      assert AccountHelper.get_current_account(conn).uuid == account.uuid
+    end
+  end
+
+  describe "get_accessible_account_uuids/1" do
+    setup do
+      account_1 = insert(:account)
+      account_2 = insert(:account, parent: account_1)
+      account_3 = insert(:account, parent: account_2)
+
+      %{
+        account_1: account_1,
+        account_2: account_2,
+        account_3: account_3
+      }
+    end
+
+    test "returns all accessible account uuids when given an admin user", context do
+      admin = insert(:admin)
+      _ = insert(:membership, user: admin, account: context.account_2)
+
+      conn = %Conn{
+        assigns: %{admin_user: admin}
+      }
+
+      uuids = AccountHelper.get_accessible_account_uuids(conn.assigns)
+
+      assert Enum.count(uuids) == 2
+      refute Enum.member?(uuids, context.account_1.uuid)
+      assert Enum.member?(uuids, context.account_2.uuid)
+      assert Enum.member?(uuids, context.account_3.uuid)
+    end
+
+    test "returns all accessible account uuids when given a key", context do
+      key = insert(:key, account: context.account_2)
+
+      conn = %Conn{
+        assigns: %{
+          key: key
+        }
+      }
+
+      uuids = AccountHelper.get_accessible_account_uuids(conn.assigns)
+
+      assert Enum.count(uuids) == 2
+      refute Enum.member?(uuids, context.account_1.uuid)
+      assert Enum.member?(uuids, context.account_2.uuid)
+      assert Enum.member?(uuids, context.account_3.uuid)
+    end
+  end
+end

--- a/apps/admin_api/test/admin_api/v1/views/mint_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/mint_view_test.exs
@@ -1,0 +1,57 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule AdminAPI.V1.MintViewTest do
+  use AdminAPI.ViewCase, :v1
+  alias AdminAPI.V1.MintView
+  alias EWallet.Web.Paginator
+  alias EWallet.Web.V1.MintSerializer
+
+  describe "render/2" do
+    test "renders mint.json with the given mint" do
+      mint = insert(:mint)
+
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: MintSerializer.serialize(mint)
+      }
+
+      assert MintView.render("mint.json", %{mint: mint}) == expected
+    end
+
+    test "renders mints.json with the given mints" do
+      mint_1 = insert(:mint)
+      mint_2 = insert(:mint)
+
+      paginator = %Paginator{
+        data: [mint_1, mint_2],
+        pagination: %{
+          per_page: 10,
+          current_page: 1,
+          is_first_page: true,
+          is_last_page: false
+        }
+      }
+
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: MintSerializer.serialize(paginator)
+      }
+
+      assert MintView.render("mints.json", %{mints: paginator}) == expected
+    end
+  end
+end

--- a/apps/admin_api/test/admin_api/v1/views/reset_password_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/reset_password_view_test.exs
@@ -1,0 +1,40 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule AdminAPI.V1.ResetPasswordViewTest do
+  use AdminAPI.ViewCase, :v1
+  alias AdminAPI.V1.ResetPasswordView
+
+  describe "render/2" do
+    test "renders empty.json with the success: true" do
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: %{}
+      }
+
+      assert ResetPasswordView.render("empty.json", %{success: true}) == expected
+    end
+
+    test "renders empty.json with the success: false" do
+      expected = %{
+        version: @expected_version,
+        success: false,
+        data: %{}
+      }
+
+      assert ResetPasswordView.render("empty.json", %{success: false}) == expected
+    end
+  end
+end

--- a/apps/admin_api/test/admin_api/v1/views/transaction_consumption_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/transaction_consumption_view_test.exs
@@ -1,0 +1,72 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule AdminAPI.V1.TransactionConsumptionViewTest do
+  use AdminAPI.ViewCase, :v1
+  alias AdminAPI.V1.TransactionConsumptionView
+  alias EWallet.Web.Paginator
+  alias EWallet.Web.V1.TransactionConsumptionSerializer
+  alias EWalletDB.Helpers.Preloader
+
+  describe "render/2" do
+    test "renders transaction_consumption.json with the given transaction_consumption" do
+      consumption =
+        :transaction_consumption
+        |> insert()
+        |> Preloader.preload([:token, :transaction_request])
+
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: TransactionConsumptionSerializer.serialize(consumption)
+      }
+
+      assert TransactionConsumptionView.render("transaction_consumption.json", %{
+               transaction_consumption: consumption
+             }) == expected
+    end
+
+    test "renders transaction_consumptions.json with the given transaction_consumptions" do
+      consumption_1 =
+        :transaction_consumption
+        |> insert()
+        |> Preloader.preload([:token, :transaction_request])
+
+      consumption_2 =
+        :transaction_consumption
+        |> insert()
+        |> Preloader.preload([:token, :transaction_request])
+
+      paginator = %Paginator{
+        data: [consumption_1, consumption_2],
+        pagination: %{
+          per_page: 10,
+          current_page: 1,
+          is_first_page: true,
+          is_last_page: false
+        }
+      }
+
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: TransactionConsumptionSerializer.serialize(paginator)
+      }
+
+      assert TransactionConsumptionView.render("transaction_consumptions.json", %{
+               transaction_consumptions: paginator
+             }) == expected
+    end
+  end
+end

--- a/apps/admin_api/test/admin_api/v1/views/user_auth_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/user_auth_view_test.exs
@@ -1,0 +1,43 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule AdminAPI.V1.UserAuthViewTest do
+  use AdminAPI.ViewCase, :v1
+  alias AdminAPI.V1.UserAuthView
+  alias EWallet.Web.V1.UserAuthTokenSerializer
+
+  describe "render/2" do
+    test "renders auth_token.json with the given mint" do
+      auth_token = insert(:auth_token)
+
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: UserAuthTokenSerializer.serialize(auth_token)
+      }
+
+      assert UserAuthView.render("auth_token.json", %{auth_token: auth_token}) == expected
+    end
+
+    test "renders empty_response.json" do
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: %{}
+      }
+
+      assert UserAuthView.render("empty_response.json", %{success: true}) == expected
+    end
+  end
+end

--- a/apps/admin_api/test/admin_api/v1/views/wallet_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/wallet_view_test.exs
@@ -15,6 +15,7 @@
 defmodule AdminAPI.V1.WalletViewTest do
   use AdminAPI.ViewCase, :v1
   alias AdminAPI.V1.WalletView
+  alias EWallet.BalanceFetcher
   alias EWallet.Web.Paginator
   alias EWallet.Web.V1.WalletSerializer
   alias Ecto.Adapters.SQL.Sandbox
@@ -28,6 +29,8 @@ defmodule AdminAPI.V1.WalletViewTest do
     test "renders wallet.json with the given wallet" do
       wallet = insert(:wallet)
 
+      {:ok, wallet} = BalanceFetcher.all(%{"wallet" => wallet})
+
       expected = %{
         version: @expected_version,
         success: true,
@@ -40,6 +43,9 @@ defmodule AdminAPI.V1.WalletViewTest do
     test "renders wallets.json with the given wallets" do
       wallet_1 = insert(:wallet)
       wallet_2 = insert(:wallet)
+
+      {:ok, wallet_1} = BalanceFetcher.all(%{"wallet" => wallet_1})
+      {:ok, wallet_2} = BalanceFetcher.all(%{"wallet" => wallet_2})
 
       paginator = %Paginator{
         data: [wallet_1, wallet_2],

--- a/apps/admin_api/test/admin_api/v1/views/wallet_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/wallet_view_test.exs
@@ -1,0 +1,63 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule AdminAPI.V1.WalletViewTest do
+  use AdminAPI.ViewCase, :v1
+  alias AdminAPI.V1.WalletView
+  alias EWallet.Web.Paginator
+  alias EWallet.Web.V1.WalletSerializer
+  alias Ecto.Adapters.SQL.Sandbox
+  alias LocalLedgerDB.Repo, as: LocalLedgerDBRepo
+
+  setup do
+    :ok = Sandbox.checkout(LocalLedgerDBRepo)
+  end
+
+  describe "render/2" do
+    test "renders wallet.json with the given wallet" do
+      wallet = insert(:wallet)
+
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: WalletSerializer.serialize(wallet)
+      }
+
+      assert WalletView.render("wallet.json", %{wallet: wallet}) == expected
+    end
+
+    test "renders wallets.json with the given wallets" do
+      wallet_1 = insert(:wallet)
+      wallet_2 = insert(:wallet)
+
+      paginator = %Paginator{
+        data: [wallet_1, wallet_2],
+        pagination: %{
+          per_page: 10,
+          current_page: 1,
+          is_first_page: true,
+          is_last_page: false
+        }
+      }
+
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: WalletSerializer.serialize(paginator)
+      }
+
+      assert WalletView.render("wallets.json", %{wallets: paginator}) == expected
+    end
+  end
+end

--- a/apps/ewallet/lib/ewallet/fetchers/exchange_account_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/exchange_account_fetcher.ex
@@ -58,11 +58,11 @@ defmodule EWallet.ExchangeAccountFetcher do
       when not is_nil(exchange_wallet_address) do
     with {:ok, exchange_wallet} <- WalletFetcher.get(nil, exchange_wallet_address),
          exchange_wallet <- Repo.preload(exchange_wallet, [:account]),
-         %Account{} = _exchange_account <-
+         %Account{} <-
            exchange_wallet.account || {:error, :exchange_address_not_account} do
       {:ok, exchange_wallet}
     else
-      {:error, :account_wallet_not_found} ->
+      {:error, :wallet_not_found} ->
         {:error, :exchange_account_wallet_not_found}
 
       error ->

--- a/apps/ewallet/lib/ewallet/fetchers/exchange_account_fetcher.ex
+++ b/apps/ewallet/lib/ewallet/fetchers/exchange_account_fetcher.ex
@@ -58,8 +58,7 @@ defmodule EWallet.ExchangeAccountFetcher do
       when not is_nil(exchange_wallet_address) do
     with {:ok, exchange_wallet} <- WalletFetcher.get(nil, exchange_wallet_address),
          exchange_wallet <- Repo.preload(exchange_wallet, [:account]),
-         %Account{} <-
-           exchange_wallet.account || {:error, :exchange_address_not_account} do
+         %Account{} <- exchange_wallet.account || {:error, :exchange_address_not_account} do
       {:ok, exchange_wallet}
     else
       {:error, :wallet_not_found} ->

--- a/apps/ewallet/lib/ewallet/gates/genesis_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/genesis_gate.ex
@@ -20,6 +20,11 @@ defmodule EWallet.GenesisGate do
   alias EWalletDB.{Account, Mint, Transaction, Wallet}
   alias LocalLedger.Transaction, as: LedgerTransaction
 
+  @doc """
+  Get the genesis transaction by the idempotency_token, or create a new transaction
+  if the idempotency_token could not be found.
+  """
+  @spec create(map()) :: {:ok, %Transaction{}} | {:error, Ecto.Changeset.t()}
   def create(%{
         idempotency_token: idempotency_token,
         account: account,
@@ -44,6 +49,19 @@ defmodule EWallet.GenesisGate do
     })
   end
 
+  @doc """
+  Processes the genesis transaction with the mint.
+
+  If the `transaction`'s status is pending, it inserts a corresponding `LocalLedgerDB.Transaction`,
+  and, on success, returns an `EWalletDB.Transaction` with a confirmed status along with
+  a confirmed `EWalletDB.Mint`.
+
+  If the `transaction`'s status is already confirmed, it returns the transaction untouched, while
+  still attempting to confirm the given `mint`.
+
+  If the `transaction`'s status is already failed, it returns the transaction's error code and
+  error description. It does not attempt to confirm the given `mint`.
+  """
   @spec process_with_transaction(%Transaction{}, %Mint{}) ::
           {:ok, %Mint{}, %Transaction{}} | {:error, atom(), String.t(), %Mint{}}
 

--- a/apps/ewallet/lib/ewallet/web/websocket.ex
+++ b/apps/ewallet/lib/ewallet/web/websocket.ex
@@ -94,7 +94,7 @@ defmodule EWallet.Web.WebSocket do
     invalid_version(conn, accept, error_handler)
   end
 
-  def invalid_version(conn, accept, error_handler) do
+  defp invalid_version(conn, accept, error_handler) do
     conn =
       conn
       |> assign(:accept, inspect(accept))
@@ -103,7 +103,7 @@ defmodule EWallet.Web.WebSocket do
     {:error, conn}
   end
 
-  def get_accept_version(accept, app) do
+  defp get_accept_version(accept, app) do
     app
     |> Application.get_env(:api_versions)
     |> Map.fetch(accept)

--- a/apps/ewallet/mix.exs
+++ b/apps/ewallet/mix.exs
@@ -39,6 +39,7 @@ defmodule EWallet.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:appsignal, "~> 1.0"},
       {:bamboo, "~> 0.8"},
       {:bamboo_smtp, "~> 1.4.0"},
       {:bodyguard, "~> 2.2"},
@@ -54,7 +55,7 @@ defmodule EWallet.Mixfile do
       {:phoenix_html, "~> 2.11.0"},
       {:quantum, "~> 2.2.6"},
       {:sentry, "~> 6.4"},
-      {:timex, "~> 3.0"},
+      {:timex, "~> 3.0"}
     ]
   end
 end

--- a/apps/ewallet/test/ewallet/exchange/calculation_test.exs
+++ b/apps/ewallet/test/ewallet/exchange/calculation_test.exs
@@ -14,4 +14,6 @@
 
 defmodule EWallet.Exchange.CalculationTest do
   use ExUnit.Case
+
+  # No tests for a purely struct module
 end

--- a/apps/ewallet/test/ewallet/fetchers/address_record_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/address_record_fetcher_test.exs
@@ -1,0 +1,93 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.AddressRecordFetcherTest do
+  use EWallet.DBCase, async: true
+  import EWalletDB.Factory
+  alias EWallet.AddressRecordFetcher
+  alias Utils.Types.WalletAddress
+  alias Utils.Types.ExternalID
+
+  describe "fetch/3" do
+    setup do
+      wallet_1 = insert(:wallet)
+      wallet_2 = insert(:wallet)
+      token = insert(:token)
+
+      %{
+        wallet_1: wallet_1,
+        wallet_2: wallet_2,
+        token: token
+      }
+    end
+
+    test "returns from_wallet, to_wallet, and token", context do
+      attrs = %{
+        "from_address" => context.wallet_1.address,
+        "to_address" => context.wallet_2.address,
+        "token_id" => context.token.id
+      }
+
+      {res, from_wallet, to_wallet, token} = AddressRecordFetcher.fetch(attrs)
+
+      assert res == :ok
+      assert from_wallet.uuid == context.wallet_1.uuid
+      assert to_wallet.uuid == context.wallet_2.uuid
+      assert token.uuid == context.token.uuid
+    end
+
+    test "returns :from_address_not_found when from_address is invalid", context do
+      {:ok, fake_address} = WalletAddress.generate()
+
+      attrs = %{
+        "from_address" => fake_address,
+        "to_address" => context.wallet_2.address,
+        "token_id" => context.token.id
+      }
+
+      {res, reason} = AddressRecordFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :from_address_not_found
+    end
+
+    test "returns :to_address_not_found when to_address is invalid", context do
+      {:ok, fake_address} = WalletAddress.generate()
+
+      attrs = %{
+        "from_address" => context.wallet_1.address,
+        "to_address" => fake_address,
+        "token_id" => context.token.id
+      }
+
+      {res, reason} = AddressRecordFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :to_address_not_found
+    end
+
+    test "returns :token_not_found when token_id is invalid", context do
+      attrs = %{
+        "from_address" => context.wallet_1.address,
+        "to_address" => context.wallet_2.address,
+        "token_id" => ExternalID.generate("tok_")
+      }
+
+      {res, reason} = AddressRecordFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :token_not_found
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/fetchers/address_record_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/address_record_fetcher_test.exs
@@ -16,10 +16,10 @@ defmodule EWallet.AddressRecordFetcherTest do
   use EWallet.DBCase, async: true
   import EWalletDB.Factory
   alias EWallet.AddressRecordFetcher
-  alias Utils.Types.WalletAddress
   alias Utils.Types.ExternalID
+  alias Utils.Types.WalletAddress
 
-  describe "fetch/3" do
+  describe "fetch/1" do
     setup do
       wallet_1 = insert(:wallet)
       wallet_2 = insert(:wallet)

--- a/apps/ewallet/test/ewallet/fetchers/exchange_account_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/exchange_account_fetcher_test.exs
@@ -1,0 +1,155 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.ExchangeAccountFetcherTest do
+  use EWallet.DBCase, async: true
+  import EWalletDB.Factory
+  alias EWallet.ExchangeAccountFetcher
+  alias Utils.Types.ExternalID
+  alias Utils.Types.WalletAddress
+
+  setup do
+    account = insert(:account)
+    wallet = insert(:wallet, account: account, user: nil)
+
+    %{
+      account: account,
+      wallet: wallet
+    }
+  end
+
+  describe "fetch/1 with both exchange_account_id and exchange_wallet_address provided" do
+    test "returns the wallet if the wallet address matches the account id", context do
+      attrs = %{
+        "exchange_account_id" => context.account.id,
+        "exchange_wallet_address" => context.wallet.address
+      }
+
+      {res, exchange_wallet} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :ok
+      assert exchange_wallet.uuid == context.wallet.uuid
+      assert exchange_wallet.account_uuid == context.account.uuid
+    end
+
+    test "returns :exchange_account_id_not_found if account id is invalid", context do
+      attrs = %{
+        "exchange_account_id" => ExternalID.generate("acc_"),
+        "exchange_wallet_address" => context.wallet.address
+      }
+
+      {res, reason} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :exchange_account_id_not_found
+    end
+
+    test "returns :exchange_account_wallet_not_found if wallet address id is invalid", context do
+      {:ok, fake_address} = WalletAddress.generate()
+
+      attrs = %{
+        "exchange_account_id" => context.account.id,
+        "exchange_wallet_address" => fake_address
+      }
+
+      {res, reason} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :exchange_account_wallet_not_found
+    end
+
+    test "returns :exchange_account_wallet_mismatch if the wallet does not belong to the account", context do
+      attrs = %{
+        "exchange_account_id" => context.account.id,
+        "exchange_wallet_address" => insert(:wallet).address
+      }
+
+      {res, reason} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :exchange_account_wallet_mismatch
+    end
+  end
+
+  describe "fetch/1 with only exchange_account_id provided" do
+    test "returns the exchange account's wallet if only the account id is provided", context do
+      attrs = %{
+        "exchange_account_id" => context.account.id
+      }
+
+      {res, exchange_wallet} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :ok
+      assert exchange_wallet.uuid == context.wallet.uuid
+      assert exchange_wallet.account_uuid == context.account.uuid
+    end
+
+    test "returns :exchange_account_id_not_found if account id is invalid", _context do
+      attrs = %{
+        "exchange_account_id" => ExternalID.generate("acc_")
+      }
+
+      {res, reason} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :exchange_account_id_not_found
+    end
+  end
+
+  describe "fetch/1 with only exchange_wallet_address" do
+    test "returns the exchange wallet if only the wallet address is provided", context do
+      attrs = %{
+        "exchange_wallet_address" => context.wallet.address
+      }
+
+      {res, exchange_wallet} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :ok
+      assert exchange_wallet.uuid == context.wallet.uuid
+      assert exchange_wallet.account_uuid == context.account.uuid
+    end
+
+    test "returns :exchange_address_not_account if wallet address is owned by a user", _context do
+      wallet = insert(:wallet, user: insert(:user), account: nil)
+
+      attrs = %{
+        "exchange_wallet_address" => wallet.address
+      }
+
+      {res, reason} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :exchange_address_not_account
+    end
+
+    test "returns :exchange_account_wallet_not_found if wallet address is invalid", _context do
+      {:ok, fake_address} = WalletAddress.generate()
+
+      attrs = %{
+        "exchange_wallet_address" => fake_address
+      }
+
+      {res, reason} = ExchangeAccountFetcher.fetch(attrs)
+
+      assert res == :error
+      assert reason == :exchange_account_wallet_not_found
+    end
+  end
+
+  describe "fetch/1 with no related attributes" do
+    test "returns a successful nil" do
+      assert ExchangeAccountFetcher.fetch(%{foo: "bar"}) == {:ok, nil}
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/fetchers/exchange_account_fetcher_test.exs
+++ b/apps/ewallet/test/ewallet/fetchers/exchange_account_fetcher_test.exs
@@ -69,7 +69,8 @@ defmodule EWallet.ExchangeAccountFetcherTest do
       assert reason == :exchange_account_wallet_not_found
     end
 
-    test "returns :exchange_account_wallet_mismatch if the wallet does not belong to the account", context do
+    test "returns :exchange_account_wallet_mismatch if the wallet does not belong to the account",
+         context do
       attrs = %{
         "exchange_account_id" => context.account.id,
         "exchange_wallet_address" => insert(:wallet).address

--- a/apps/ewallet/test/ewallet/gates/genesis_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/genesis_gate_test.exs
@@ -1,0 +1,172 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.GenesisGateTest do
+  use EWallet.DBCase, async: true
+  import EWalletDB.Factory
+  alias Ecto.UUID
+  alias EWallet.GenesisGate
+  alias EWalletDB.{Account, Transaction}
+  alias LocalLedgerDB.Transaction, as: LedgerTransaction
+
+  setup do
+    {:ok, account} = :account |> params_for() |> Account.insert()
+
+    attrs = %{
+      idempotency_token: UUID.generate(),
+      account: account,
+      token: insert(:token),
+      amount: 1_000_000,
+      attrs: %{
+        "metadata" => %{"foo" => "bar"},
+        "encrypted_metadata" => nil
+      },
+      originator: insert(:user)
+    }
+
+    %{
+      attrs: attrs
+    }
+  end
+
+  describe "create/1" do
+    test "returns a genesis transaction", context do
+      {res, transaction} = GenesisGate.create(context.attrs)
+
+      assert res == :ok
+      assert %Transaction{} = transaction
+      assert transaction.idempotency_token == context.attrs.idempotency_token
+    end
+
+    test "defaults the metadata to an empty map", context do
+      {res, transaction} =
+        context.attrs
+        |> Map.put(:attrs, %{"metadata" => nil})
+        |> GenesisGate.create()
+
+      assert res == :ok
+      assert transaction.metadata == %{}
+    end
+
+    test "defaults the encrypted_metadata to an empty map", context do
+      {res, transaction} =
+        context.attrs
+        |> Map.put(:attrs, %{"encrypted_metadata" => nil})
+        |> GenesisGate.create()
+
+      assert res == :ok
+      assert transaction.encrypted_metadata == %{}
+    end
+
+    test "does not save the orignator to the payload", context do
+      {res, transaction} =
+        context.attrs
+        |> Map.put(:attrs, %{"foo" => "bar"})
+        |> GenesisGate.create()
+
+      assert res == :ok
+      assert transaction.payload["foo"] == "bar"
+      refute Map.has_key?(transaction.payload, "originator")
+    end
+  end
+
+  describe "process_with_transaction/2 with a pending transaction" do
+    test "returns the mint and the confirmed transaction", context do
+      {:ok, transaction} = GenesisGate.create(context.attrs)
+
+      mint =
+        insert(:mint, token_uuid: context.attrs.token.uuid, transaction_uuid: transaction.uuid)
+
+      assert transaction.status == Transaction.pending()
+      refute mint.confirmed
+
+      {res, processed_mint, processed_transaction} =
+        GenesisGate.process_with_transaction(transaction, mint)
+
+      assert res == :ok
+      assert processed_mint.uuid == mint.uuid
+      assert processed_mint.confirmed
+      assert processed_transaction.uuid == processed_transaction.uuid
+      assert processed_transaction.status == Transaction.confirmed()
+    end
+
+    test "inserts a corresponding local ledger transaction", context do
+      {:ok, transaction} = GenesisGate.create(context.attrs)
+
+      mint =
+        insert(:mint, token_uuid: context.attrs.token.uuid, transaction_uuid: transaction.uuid)
+
+      assert transaction.status == Transaction.pending()
+      refute mint.confirmed
+
+      {res, _, _} = GenesisGate.process_with_transaction(transaction, mint)
+      ledger_txn = LedgerTransaction.get_by_idempotency_token(context.attrs.idempotency_token)
+
+      assert res == :ok
+      assert %LedgerTransaction{} = ledger_txn
+      assert ledger_txn.idempotency_token == context.attrs.idempotency_token
+    end
+  end
+
+  describe "process_with_transaction/2 with a confirmed transaction" do
+    test "returns the mint and the confirmed transaction", context do
+      {:ok, transaction} = GenesisGate.create(context.attrs)
+
+      mint =
+        insert(:mint, token_uuid: context.attrs.token.uuid, transaction_uuid: transaction.uuid)
+
+      {:ok, mint, transaction} = GenesisGate.process_with_transaction(transaction, mint)
+
+      assert transaction.status == Transaction.confirmed()
+      assert mint.confirmed
+
+      {res, processed_mint, processed_transaction} =
+        GenesisGate.process_with_transaction(transaction, mint)
+
+      assert res == :ok
+      assert processed_mint.uuid == mint.uuid
+      assert processed_mint.confirmed
+      assert processed_transaction.uuid == processed_transaction.uuid
+      assert processed_transaction.status == Transaction.confirmed()
+    end
+  end
+
+  describe "process_with_transaction/2 with a failed transaction" do
+    test "returns the mint and the confirmed transaction", context do
+      {:ok, transaction} = GenesisGate.create(context.attrs)
+
+      mint =
+        insert(:mint, token_uuid: context.attrs.token.uuid, transaction_uuid: transaction.uuid)
+
+      transaction =
+        Map.merge(transaction, %{
+          status: Transaction.failed(),
+          error_code: :some_error_code,
+          error_description: "some error description"
+        })
+
+      assert transaction.status == Transaction.failed()
+      refute mint.confirmed
+
+      {res, code, description, returned_mint} =
+        GenesisGate.process_with_transaction(transaction, mint)
+
+      assert res == :error
+      assert code == :some_error_code
+      assert description == "some error description"
+      assert returned_mint.uuid == mint.uuid
+      refute returned_mint.confirmed
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/v1/serializers/api_key_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/api_key_serializer_test.exs
@@ -1,0 +1,103 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.V1.APIKeySerializerTest do
+  use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Association.NotLoaded
+  alias EWallet.Web.Paginator
+  alias EWallet.Web.V1.APIKeySerializer
+  alias Utils.Helpers.DateFormatter
+
+  describe "serialize/1" do
+    test "serializes a api_key into the correct response format" do
+      api_key = :api_key |> insert() |> Repo.preload(:account)
+
+      expected = %{
+        object: "api_key",
+        id: api_key.id,
+        key: api_key.key,
+        account_id: api_key.account.id,
+        owner_app: api_key.owner_app,
+        expired: !api_key.enabled,
+        enabled: api_key.enabled,
+        created_at: DateFormatter.to_iso8601(api_key.inserted_at),
+        updated_at: DateFormatter.to_iso8601(api_key.updated_at),
+        deleted_at: DateFormatter.to_iso8601(api_key.deleted_at)
+      }
+
+      assert APIKeySerializer.serialize(api_key) == expected
+    end
+
+    test "serializes to nil if the api_key is not loaded" do
+      assert APIKeySerializer.serialize(%NotLoaded{}) == nil
+    end
+
+    test "serializes nil to nil " do
+      assert APIKeySerializer.serialize(nil) == nil
+    end
+
+    test "serializes a api_key paginator into a list object" do
+      api_key_1 = :api_key |> insert() |> Repo.preload(:account)
+      api_key_2 = :api_key |> insert() |> Repo.preload(:account)
+
+      paginator = %Paginator{
+        data: [api_key_1, api_key_2],
+        pagination: %{
+          current_page: 1,
+          per_page: 10,
+          is_first_page: true,
+          is_last_page: true
+        }
+      }
+
+      expected = %{
+        object: "list",
+        data: [
+          %{
+            object: "api_key",
+            id: api_key_1.id,
+            key: api_key_1.key,
+            account_id: api_key_1.account.id,
+            owner_app: api_key_1.owner_app,
+            expired: !api_key_1.enabled,
+            enabled: api_key_1.enabled,
+            created_at: DateFormatter.to_iso8601(api_key_1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(api_key_1.updated_at),
+            deleted_at: DateFormatter.to_iso8601(api_key_1.deleted_at)
+          },
+          %{
+            object: "api_key",
+            id: api_key_2.id,
+            key: api_key_2.key,
+            account_id: api_key_2.account.id,
+            owner_app: api_key_2.owner_app,
+            expired: !api_key_2.enabled,
+            enabled: api_key_2.enabled,
+            created_at: DateFormatter.to_iso8601(api_key_2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(api_key_2.updated_at),
+            deleted_at: DateFormatter.to_iso8601(api_key_2.deleted_at)
+          }
+        ],
+        pagination: %{
+          current_page: 1,
+          per_page: 10,
+          is_first_page: true,
+          is_last_page: true
+        }
+      }
+
+      assert APIKeySerializer.serialize(paginator) == expected
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/v1/serializers/balance_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/balance_serializer_test.exs
@@ -1,0 +1,44 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.V1.BalanceSerializerTest do
+  use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Association.NotLoaded
+  alias EWallet.Web.V1.{BalanceSerializer, TokenSerializer}
+
+  describe "serialize/1" do
+    test "serializes a balance into the correct response format" do
+      balance = %{
+        token: insert(:token),
+        amount: 1_000_000
+      }
+
+      expected = %{
+        object: "balance",
+        token: TokenSerializer.serialize(balance.token),
+        amount: balance.amount
+      }
+
+      assert BalanceSerializer.serialize(balance) == expected
+    end
+
+    test "serializes to nil if the balance is not loaded" do
+      assert BalanceSerializer.serialize(%NotLoaded{}) == nil
+    end
+
+    test "serializes nil to nil " do
+      assert BalanceSerializer.serialize(nil) == nil
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/v1/serializers/list_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/list_serializer_test.exs
@@ -1,0 +1,31 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.V1.ListSerializerTest do
+  use EWallet.Web.SerializerCase, :v1
+  alias EWallet.Web.V1.ListSerializer
+
+  describe "serialize/1" do
+    test "serializes into a list object" do
+      list = ["any", "kind", "of", "list", 1, 2, 3]
+
+      expected = %{
+        object: "list",
+        data: list
+      }
+
+      assert ListSerializer.serialize(list) == expected
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/v1/serializers/mint_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/mint_serializer_test.exs
@@ -1,0 +1,154 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.V1.MintSerializerTest do
+  use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Association.NotLoaded
+  alias EWallet.Web.Paginator
+  alias EWallet.Web.V1.{AccountSerializer, MintSerializer, TokenSerializer, TransactionSerializer}
+  alias Utils.Helpers.{Assoc, DateFormatter}
+
+  describe "serialize/1" do
+    test "serializes a mint into V1 response format" do
+      mint = insert(:mint)
+
+      expected = %{
+        object: "mint",
+        id: mint.id,
+        description: mint.description,
+        amount: mint.amount,
+        confirmed: mint.confirmed,
+        token_id: Assoc.get(mint, [:token, :id]),
+        token: TokenSerializer.serialize(mint.token),
+        account_id: Assoc.get(mint, [:account, :id]),
+        account: AccountSerializer.serialize(mint.account),
+        transaction_id: Assoc.get(mint, [:transaction, :id]),
+        transaction: TransactionSerializer.serialize(mint.transaction),
+        created_at: DateFormatter.to_iso8601(mint.inserted_at),
+        updated_at: DateFormatter.to_iso8601(mint.updated_at)
+      }
+
+      assert MintSerializer.serialize(mint) == expected
+    end
+
+    test "serializes a mint list into a list object" do
+      mint_1 = insert(:mint)
+      mint_2 = insert(:mint)
+
+      mint_list = [mint_1, mint_2]
+
+      expected = [
+        %{
+          object: "mint",
+          id: mint_1.id,
+          description: mint_1.description,
+          amount: mint_1.amount,
+          confirmed: mint_1.confirmed,
+          token_id: Assoc.get(mint_1, [:token, :id]),
+          token: TokenSerializer.serialize(mint_1.token),
+          account_id: Assoc.get(mint_1, [:account, :id]),
+          account: AccountSerializer.serialize(mint_1.account),
+          transaction_id: Assoc.get(mint_1, [:transaction, :id]),
+          transaction: TransactionSerializer.serialize(mint_1.transaction),
+          created_at: DateFormatter.to_iso8601(mint_1.inserted_at),
+          updated_at: DateFormatter.to_iso8601(mint_1.updated_at)
+        },
+        %{
+          object: "mint",
+          id: mint_2.id,
+          description: mint_2.description,
+          amount: mint_2.amount,
+          confirmed: mint_2.confirmed,
+          token_id: Assoc.get(mint_2, [:token, :id]),
+          token: TokenSerializer.serialize(mint_2.token),
+          account_id: Assoc.get(mint_2, [:account, :id]),
+          account: AccountSerializer.serialize(mint_2.account),
+          transaction_id: Assoc.get(mint_2, [:transaction, :id]),
+          transaction: TransactionSerializer.serialize(mint_2.transaction),
+          created_at: DateFormatter.to_iso8601(mint_2.inserted_at),
+          updated_at: DateFormatter.to_iso8601(mint_2.updated_at)
+        }
+      ]
+
+      assert MintSerializer.serialize(mint_list) == expected
+    end
+
+    test "serializes a mint paginator into a paginated list object" do
+      mint_1 = insert(:mint)
+      mint_2 = insert(:mint)
+
+      paginator = %Paginator{
+        data: [mint_1, mint_2],
+        pagination: %{
+          current_page: 9,
+          per_page: 7,
+          is_first_page: false,
+          is_last_page: true
+        }
+      }
+
+      expected = %{
+        object: "list",
+        data: [
+          %{
+            object: "mint",
+            id: mint_1.id,
+            description: mint_1.description,
+            amount: mint_1.amount,
+            confirmed: mint_1.confirmed,
+            token_id: Assoc.get(mint_1, [:token, :id]),
+            token: TokenSerializer.serialize(mint_1.token),
+            account_id: Assoc.get(mint_1, [:account, :id]),
+            account: AccountSerializer.serialize(mint_1.account),
+            transaction_id: Assoc.get(mint_1, [:transaction, :id]),
+            transaction: TransactionSerializer.serialize(mint_1.transaction),
+            created_at: DateFormatter.to_iso8601(mint_1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(mint_1.updated_at)
+          },
+          %{
+            object: "mint",
+            id: mint_2.id,
+            description: mint_2.description,
+            amount: mint_2.amount,
+            confirmed: mint_2.confirmed,
+            token_id: Assoc.get(mint_2, [:token, :id]),
+            token: TokenSerializer.serialize(mint_2.token),
+            account_id: Assoc.get(mint_2, [:account, :id]),
+            account: AccountSerializer.serialize(mint_2.account),
+            transaction_id: Assoc.get(mint_2, [:transaction, :id]),
+            transaction: TransactionSerializer.serialize(mint_2.transaction),
+            created_at: DateFormatter.to_iso8601(mint_2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(mint_2.updated_at)
+          }
+        ],
+        pagination: %{
+          current_page: 9,
+          per_page: 7,
+          is_first_page: false,
+          is_last_page: true
+        }
+      }
+
+      assert MintSerializer.serialize(paginator) == expected
+    end
+
+    test "serializes to nil if the mint is nil" do
+      assert MintSerializer.serialize(nil) == nil
+    end
+
+    test "serializes to nil if the mint is not loaded" do
+      assert MintSerializer.serialize(%NotLoaded{}) == nil
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/v1/serializers/token_stats_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/token_stats_serializer_test.exs
@@ -1,0 +1,40 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.V1.TokenStatsSerializerTest do
+  use EWallet.Web.SerializerCase, :v1
+  alias EWallet.Web.V1.{TokenSerializer, TokenStatsSerializer}
+
+  describe "serialize/1" do
+    test "serializes into a token_stats object" do
+      stats = %{
+        token: insert(:token),
+        total_supply: 1_234_567
+      }
+
+      expected = %{
+        object: "token_stats",
+        token_id: stats.token.id,
+        token: TokenSerializer.serialize(stats.token),
+        total_supply: stats.total_supply
+      }
+
+      assert TokenStatsSerializer.serialize(stats) == expected
+    end
+
+    test "serializes nil to nil" do
+      assert TokenStatsSerializer.serialize(nil) == nil
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/v1/serializers/wallet_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/wallet_serializer_test.exs
@@ -1,0 +1,207 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.V1.WalletSerializerTest do
+  use EWallet.Web.SerializerCase, :v1
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Ecto.Association.NotLoaded
+  alias EWallet.BalanceFetcher
+  alias EWallet.Web.Paginator
+  alias EWallet.Web.V1.{AccountSerializer, BalanceSerializer, WalletSerializer, UserSerializer}
+  alias EWalletDB.Helpers.Preloader
+  alias LocalLedgerDB.Repo, as: LocalLedgerDBRepo
+  alias Utils.Helpers.{Assoc, DateFormatter}
+
+  setup do
+    :ok = Sandbox.checkout(LocalLedgerDBRepo)
+  end
+
+  describe "serialize/1" do
+    test "serializes a wallet into a wallet object" do
+      wallet = insert(:wallet)
+      {:ok, wallet} = BalanceFetcher.all(%{"wallet" => wallet})
+
+      expected = %{
+        object: "wallet",
+        socket_topic: "wallet:#{wallet.address}",
+        address: wallet.address,
+        name: wallet.name,
+        identifier: wallet.identifier,
+        metadata: wallet.metadata,
+        encrypted_metadata: wallet.encrypted_metadata,
+        user_id: Assoc.get(wallet, [:user, :id]),
+        user: UserSerializer.serialize(wallet.user),
+        account_id: Assoc.get(wallet, [:account, :id]),
+        account: AccountSerializer.serialize(wallet.account),
+        balances: Enum.map(wallet.balances, &BalanceSerializer.serialize/1),
+        enabled: wallet.enabled,
+        created_at: DateFormatter.to_iso8601(wallet.inserted_at),
+        updated_at: DateFormatter.to_iso8601(wallet.updated_at)
+      }
+
+      assert WalletSerializer.serialize(wallet) == expected
+    end
+
+    test "serializes a wallet paginator into a paginated list object" do
+      wallet_1 = insert(:wallet)
+      wallet_2 = insert(:wallet)
+      {:ok, wallet_1} = BalanceFetcher.all(%{"wallet" => wallet_1})
+      {:ok, wallet_2} = BalanceFetcher.all(%{"wallet" => wallet_2})
+
+      paginator = %Paginator{
+        data: [wallet_1, wallet_2],
+        pagination: %{
+          current_page: 9,
+          per_page: 7,
+          is_first_page: false,
+          is_last_page: true
+        }
+      }
+
+      expected = %{
+        object: "list",
+        data: [
+          %{
+            object: "wallet",
+            socket_topic: "wallet:#{wallet_1.address}",
+            address: wallet_1.address,
+            name: wallet_1.name,
+            identifier: wallet_1.identifier,
+            metadata: wallet_1.metadata,
+            encrypted_metadata: wallet_1.encrypted_metadata,
+            user_id: Assoc.get(wallet_1, [:user, :id]),
+            user: UserSerializer.serialize(wallet_1.user),
+            account_id: Assoc.get(wallet_1, [:account, :id]),
+            account: AccountSerializer.serialize(wallet_1.account),
+            balances: Enum.map(wallet_1.balances, &BalanceSerializer.serialize/1),
+            enabled: wallet_1.enabled,
+            created_at: DateFormatter.to_iso8601(wallet_1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(wallet_1.updated_at)
+          },
+          %{
+            object: "wallet",
+            socket_topic: "wallet:#{wallet_2.address}",
+            address: wallet_2.address,
+            name: wallet_2.name,
+            identifier: wallet_2.identifier,
+            metadata: wallet_2.metadata,
+            encrypted_metadata: wallet_2.encrypted_metadata,
+            user_id: Assoc.get(wallet_2, [:user, :id]),
+            user: UserSerializer.serialize(wallet_2.user),
+            account_id: Assoc.get(wallet_2, [:account, :id]),
+            account: AccountSerializer.serialize(wallet_2.account),
+            balances: Enum.map(wallet_2.balances, &BalanceSerializer.serialize/1),
+            enabled: wallet_2.enabled,
+            created_at: DateFormatter.to_iso8601(wallet_2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(wallet_2.updated_at)
+          }
+        ],
+        pagination: %{
+          current_page: 9,
+          per_page: 7,
+          is_first_page: false,
+          is_last_page: true
+        }
+      }
+
+      assert WalletSerializer.serialize(paginator) == expected
+    end
+
+    test "serializes a wallet list into a list object" do
+      wallet_1 = insert(:wallet)
+      wallet_2 = insert(:wallet)
+      {:ok, wallet_1} = BalanceFetcher.all(%{"wallet" => wallet_1})
+      {:ok, wallet_2} = BalanceFetcher.all(%{"wallet" => wallet_2})
+
+      wallet_list = [wallet_1, wallet_2]
+
+      expected = %{
+        object: "list",
+        data: [
+          %{
+            object: "wallet",
+            socket_topic: "wallet:#{wallet_1.address}",
+            address: wallet_1.address,
+            name: wallet_1.name,
+            identifier: wallet_1.identifier,
+            metadata: wallet_1.metadata,
+            encrypted_metadata: wallet_1.encrypted_metadata,
+            user_id: Assoc.get(wallet_1, [:user, :id]),
+            user: UserSerializer.serialize(wallet_1.user),
+            account_id: Assoc.get(wallet_1, [:account, :id]),
+            account: AccountSerializer.serialize(wallet_1.account),
+            balances: Enum.map(wallet_1.balances, &BalanceSerializer.serialize/1),
+            enabled: wallet_1.enabled,
+            created_at: DateFormatter.to_iso8601(wallet_1.inserted_at),
+            updated_at: DateFormatter.to_iso8601(wallet_1.updated_at)
+          },
+          %{
+            object: "wallet",
+            socket_topic: "wallet:#{wallet_2.address}",
+            address: wallet_2.address,
+            name: wallet_2.name,
+            identifier: wallet_2.identifier,
+            metadata: wallet_2.metadata,
+            encrypted_metadata: wallet_2.encrypted_metadata,
+            user_id: Assoc.get(wallet_2, [:user, :id]),
+            user: UserSerializer.serialize(wallet_2.user),
+            account_id: Assoc.get(wallet_2, [:account, :id]),
+            account: AccountSerializer.serialize(wallet_2.account),
+            balances: Enum.map(wallet_2.balances, &BalanceSerializer.serialize/1),
+            enabled: wallet_2.enabled,
+            created_at: DateFormatter.to_iso8601(wallet_2.inserted_at),
+            updated_at: DateFormatter.to_iso8601(wallet_2.updated_at)
+          }
+        ]
+      }
+
+      assert WalletSerializer.serialize(wallet_list) == expected
+    end
+
+    test "serializes to nil if the wallet is nil" do
+      assert WalletSerializer.serialize(nil) == nil
+    end
+
+    test "serializes to nil if the wallet is not loaded" do
+      assert WalletSerializer.serialize(%NotLoaded{}) == nil
+    end
+  end
+
+  describe "serialize_without_balances/1" do
+    test "serializes a wallet into a wallet object with `balances: nil`" do
+      wallet = insert(:wallet)
+      wallet = Preloader.preload(wallet, [:user, :account])
+
+      expected = %{
+        object: "wallet",
+        socket_topic: "wallet:#{wallet.address}",
+        address: wallet.address,
+        name: wallet.name,
+        identifier: wallet.identifier,
+        metadata: wallet.metadata,
+        encrypted_metadata: wallet.encrypted_metadata,
+        user_id: Assoc.get(wallet, [:user, :id]),
+        user: UserSerializer.serialize(wallet.user),
+        account_id: Assoc.get(wallet, [:account, :id]),
+        account: AccountSerializer.serialize(wallet.account),
+        balances: nil,
+        enabled: wallet.enabled,
+        created_at: DateFormatter.to_iso8601(wallet.inserted_at),
+        updated_at: DateFormatter.to_iso8601(wallet.updated_at)
+      }
+
+      assert WalletSerializer.serialize_without_balances(wallet) == expected
+    end
+  end
+end

--- a/apps/ewallet/test/ewallet/web/websocket_test.exs
+++ b/apps/ewallet/test/ewallet/web/websocket_test.exs
@@ -1,0 +1,116 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.WebSocketTest do
+  use EWallet.DBCase, async: true
+  alias EWallet.Web.WebSocket
+  alias Plug.Conn
+
+  defmodule MockEndpoint do
+  end
+
+  defmodule MockSerializer do
+  end
+
+  defmodule MockErrorHandler do
+    def handle_error(conn, :invalid_version) do
+      Conn.halt(conn)
+    end
+  end
+
+  describe "default_config/0" do
+    test "returns an array of default config" do
+      config = WebSocket.default_config()
+
+      assert Keyword.get(config, :timeout) == 60_000
+      assert Keyword.get(config, :transport_log) === false
+    end
+  end
+
+  describe "get_endpoint/4" do
+    setup do
+      app = :ewallet_test
+      accept_header = "some_accept_header"
+
+      :ok =
+        Application.put_env(app, :api_versions, %{
+          accept_header => %{
+            endpoint: MockEndpoint,
+            websocket_serializer: MockSerializer
+          }
+        })
+
+      on_exit(fn ->
+        :ok = Application.delete_env(app, :api_versions)
+      end)
+    end
+
+    test "returns the endpoint and serializer" do
+      {res, endpoint, serializer} =
+        WebSocket.get_endpoint(
+          %Conn{},
+          "some_accept_header",
+          :ewallet_test,
+          &MockErrorHandler.handle_error/2
+        )
+
+      assert res == :ok
+      assert endpoint == MockEndpoint
+      assert serializer == MockSerializer
+    end
+
+    test "returns the handled error when the accept header cannot be matched" do
+      {res, conn} =
+        WebSocket.get_endpoint(
+          %Conn{},
+          "different_header",
+          :ewallet_test,
+          &MockErrorHandler.handle_error/2
+        )
+
+      assert res == :error
+      assert conn.halted
+    end
+  end
+
+  describe "get_endpoint/3" do
+    test "returns the handled error" do
+      {res, conn} =
+        WebSocket.get_endpoint(%Conn{}, "different_header", &MockErrorHandler.handle_error/2)
+
+      assert res == :error
+      assert conn.halted
+    end
+  end
+
+  describe "update_headers/1" do
+    test "returns the params with header keys downcased" do
+      conn = %Plug.Conn{params: %{"headers" => %{"Foo" => "bar"}}}
+      refute Map.has_key?(conn.params["headers"], "foo")
+
+      params = WebSocket.update_headers(conn)
+
+      assert Map.get(params["headers"], "foo") == "bar"
+    end
+
+    test "returns the params with vsn header removed" do
+      conn = %Plug.Conn{params: %{"vsn" => "1"}}
+      assert Map.has_key?(conn.params, "vsn")
+
+      params = WebSocket.update_headers(conn)
+
+      refute Map.has_key?(params, "vsn")
+    end
+  end
+end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/wallet_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/wallet_view_test.exs
@@ -1,0 +1,51 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWalletAPI.V1.WalletViewTest do
+  use EWalletAPI.ViewCase, :v1
+  alias EWalletAPI.V1.WalletView
+  alias EWallet.Web.Paginator
+  alias EWallet.Web.V1.WalletSerializer
+  alias Ecto.Adapters.SQL.Sandbox
+  alias LocalLedgerDB.Repo, as: LocalLedgerDBRepo
+
+  setup do
+    :ok = Sandbox.checkout(LocalLedgerDBRepo)
+  end
+
+  describe "render/2" do
+    test "renders wallets.json with the given wallets" do
+      wallet_1 = insert(:wallet)
+      wallet_2 = insert(:wallet)
+
+      paginator = %Paginator{
+        data: [wallet_1, wallet_2],
+        pagination: %{
+          per_page: 10,
+          current_page: 1,
+          is_first_page: true,
+          is_last_page: false
+        }
+      }
+
+      expected = %{
+        version: @expected_version,
+        success: true,
+        data: WalletSerializer.serialize(paginator)
+      }
+
+      assert WalletView.render("wallets.json", %{wallets: paginator}) == expected
+    end
+  end
+end

--- a/apps/ewallet_api/test/ewallet_api/v1/views/wallet_view_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/views/wallet_view_test.exs
@@ -15,6 +15,7 @@
 defmodule EWalletAPI.V1.WalletViewTest do
   use EWalletAPI.ViewCase, :v1
   alias EWalletAPI.V1.WalletView
+  alias EWallet.BalanceFetcher
   alias EWallet.Web.Paginator
   alias EWallet.Web.V1.WalletSerializer
   alias Ecto.Adapters.SQL.Sandbox
@@ -28,6 +29,9 @@ defmodule EWalletAPI.V1.WalletViewTest do
     test "renders wallets.json with the given wallets" do
       wallet_1 = insert(:wallet)
       wallet_2 = insert(:wallet)
+
+      {:ok, wallet_1} = BalanceFetcher.all(%{"wallet" => wallet_1})
+      {:ok, wallet_2} = BalanceFetcher.all(%{"wallet" => wallet_2})
 
       paginator = %Paginator{
         data: [wallet_1, wallet_2],

--- a/apps/ewallet_config/test/ewallet_config/file_storage_supervisor_test.exs
+++ b/apps/ewallet_config/test/ewallet_config/file_storage_supervisor_test.exs
@@ -55,7 +55,8 @@ defmodule EWalletConfig.FileStorageSupervisorTest do
 
   describe "start_link/0" do
     test "stops and starts a new Supervisor" do
-      :ok = FileStorageSupervisor.stop()
+      :ok = Supervisor.terminate_child(EWalletConfig.Supervisor, FileStorageSupervisor)
+
       {:ok, pid} = FileStorageSupervisor.start_link()
 
       assert pid != nil

--- a/apps/ewallet_config/test/ewallet_config/file_storage_supervisor_test.exs
+++ b/apps/ewallet_config/test/ewallet_config/file_storage_supervisor_test.exs
@@ -55,11 +55,17 @@ defmodule EWalletConfig.FileStorageSupervisorTest do
 
   describe "start_link/0" do
     test "stops and starts a new Supervisor" do
+      # Stops the exising GenServer via the Supervisor so the supervisor doesn't try
+      # to restart it during this test.
       :ok = Supervisor.terminate_child(EWalletConfig.Supervisor, FileStorageSupervisor)
 
       {:ok, pid} = FileStorageSupervisor.start_link()
 
       assert pid != nil
+
+      # Stops the GenServer started during this test and restart the one from the supervisor.
+      :ok = FileStorageSupervisor.stop()
+      {:ok, _} = Supervisor.restart_child(EWalletConfig.Supervisor, FileStorageSupervisor)
     end
   end
 

--- a/apps/ewallet_db/lib/ewallet_db/membership_checker.ex
+++ b/apps/ewallet_db/lib/ewallet_db/membership_checker.ex
@@ -15,10 +15,19 @@
 defmodule EWalletDB.MembershipChecker do
   @moduledoc """
   Module responsible for checking if a user can be added to an account.
-  Tested through Membership.assign/3 function since it's only used there for now.
   """
   alias EWalletDB.{Account, Membership}
 
+  @doc """
+  Checks whether the given originator can add the user to the given account.
+
+  Note that this function **does not check for the permission** to add a membership.
+  Its purpose is to inform whether there is a conflicting membership with the given
+  arguments or not.
+
+  Returns `true` if the user can be added to the account
+  without a conflicting existing membership.
+  """
   def allowed?(user, account, role, originator) do
     memberships = Membership.all_by_user(user, [:role, :account])
     membership_accounts_uuids = load_uuids(memberships, :account_uuid)
@@ -94,9 +103,9 @@ defmodule EWalletDB.MembershipChecker do
 
   defp init_descendants_search_or_return(allowed?, _, _, _, _, _, _), do: allowed?
 
-  def search_descendants([]), do: true
+  defp search_descendants([], _, _, _, _), do: true
 
-  def search_descendants(uuids_intersect, user, role, memberships, originator) do
+  defp search_descendants(uuids_intersect, user, role, memberships, originator) do
     Enum.each(uuids_intersect, fn matching_descendant_uuid ->
       membership =
         Enum.find(memberships, fn membership ->

--- a/apps/ewallet_db/lib/ewallet_db/role.ex
+++ b/apps/ewallet_db/lib/ewallet_db/role.ex
@@ -55,6 +55,7 @@ defmodule EWalletDB.Role do
     )
     |> validate_required([:name, :priority])
     |> unique_constraint(:name)
+    |> unique_constraint(:priority)
   end
 
   @doc """

--- a/apps/ewallet_db/test/ewallet_db/account_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/account_test.exs
@@ -354,17 +354,17 @@ defmodule EWalletDB.AccountTest do
       account_2 = insert(:account, parent: account)
       account_3 = insert(:account, parent: account_1)
 
+      expected =
+        [account, account_1, account_2, account_3]
+        |> Enum.map(fn a -> {a.uuid, Account.get_depth(a)} end)
+        |> Enum.sort_by(fn {_, depth} -> depth end)
+
       descendants =
         Enum.map(Account.get_all_descendants(account), fn descendant ->
           {descendant.uuid, descendant.depth}
         end)
 
-      assert descendants == [
-               {account.uuid, 0},
-               {account_1.uuid, 1},
-               {account_2.uuid, 1},
-               {account_3.uuid, 2}
-             ]
+      assert descendants == expected
     end
 
     test "gets only the given account for the lower child" do

--- a/apps/ewallet_db/test/ewallet_db/helpers/preloader_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/helpers/preloader_test.exs
@@ -1,0 +1,60 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWalletDB.Helpers.PreloaderTest do
+  use EWalletDB.SchemaCase, async: true
+  import EWalletDB.Factory
+  alias Ecto.Association.NotLoaded
+  alias EWalletDB.Helpers.Preloader
+  alias EWalletDB.{Account, Membership, Role, User, Repo}
+
+  setup do
+    membership = insert(:membership)
+    membership = Repo.get(Membership, membership.uuid)
+
+    assert %NotLoaded{} = membership.user
+    assert %NotLoaded{} = membership.role
+    assert %NotLoaded{} = membership.account
+
+    %{membership: membership}
+  end
+
+  describe "preload_option/2" do
+    test "preloads only the fields specified in the :preload option", context do
+      membership = Preloader.preload_option(context.membership, preload: [:role])
+
+      assert %NotLoaded{} = membership.user
+      assert %Role{} = membership.role
+      assert %NotLoaded{} = membership.account
+    end
+
+    test "does nothing when :preload option is not given", context do
+      membership = Preloader.preload_option(context.membership, [])
+
+      assert %NotLoaded{} = membership.user
+      assert %NotLoaded{} = membership.role
+      assert %NotLoaded{} = membership.account
+    end
+  end
+
+  describe "preload/2" do
+    test "preloads the given associations", context do
+      membership = Preloader.preload(context.membership, [:user, :account])
+
+      assert %User{} = membership.user
+      assert %NotLoaded{} = membership.role
+      assert %Account{} = membership.account
+    end
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/membership_checker_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/membership_checker_test.exs
@@ -27,7 +27,7 @@ defmodule EWalletDB.MembershipCheckerTest do
 
     # Lower number = higher priority
     role_high = insert(:role, priority: 99)
-    role_low = insert(:role, priority: 99999)
+    role_low = insert(:role, priority: 99_999)
 
     %{
       user: user,

--- a/apps/ewallet_db/test/ewallet_db/membership_checker_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/membership_checker_test.exs
@@ -1,0 +1,191 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWalletDB.MembershipCheckerTest do
+  use EWalletDB.SchemaCase, async: true
+  import EWalletDB.Factory
+  alias EWalletDB.MembershipChecker
+  alias EWalletDB.{Membership, Repo}
+
+  setup do
+    user = insert(:user)
+
+    account_1 = insert(:account)
+    account_2 = insert(:account, parent: account_1)
+    account_3 = insert(:account, parent: account_2)
+
+    # Lower number = higher priority
+    role_high = insert(:role, priority: 99)
+    role_low = insert(:role, priority: 99999)
+
+    %{
+      user: user,
+      account_1: account_1,
+      account_2: account_2,
+      account_3: account_3,
+      role_high: role_high,
+      role_low: role_low,
+      originator: user
+    }
+  end
+
+  describe "allowed?/4" do
+    # Test for existing memberships with the direct account
+
+    test "returns true when the user is not a member of the given account", ctx do
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_high, ctx.originator)
+    end
+
+    test "returns true when the user has a lower role in the given account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_1, role: ctx.role_low)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_high, ctx.originator)
+    end
+
+    test "returns false when the user has a higher role in the given account", ctx do
+      _ = insert(:membership, user: ctx.user, account: ctx.account_1, role: ctx.role_high)
+      refute MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_low, ctx.originator)
+    end
+
+    test "returns true when the user has the same role in the given account", ctx do
+      _ = insert(:membership, user: ctx.user, account: ctx.account_1, role: ctx.role_high)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_high, ctx.originator)
+    end
+
+    # Test for existing memberships with a parent account
+
+    test "returns true when the user has a lower role in a direct parent account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_1, role: ctx.role_low)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_high, ctx.originator)
+    end
+
+    test "returns false when the user has a higher role in a direct parent account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_1, role: ctx.role_high)
+      refute MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_low, ctx.originator)
+    end
+
+    test "returns true when the user has the same role in a direct parent account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_1, role: ctx.role_high)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_high, ctx.originator)
+    end
+
+    # Test for existing memberships with an ancestor account
+
+    test "returns true when the user has a lower role in an ancestor account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_1, role: ctx.role_low)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_3, ctx.role_high, ctx.originator)
+    end
+
+    test "returns false when the user has a higher role in an ancestor account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_1, role: ctx.role_high)
+      refute MembershipChecker.allowed?(ctx.user, ctx.account_3, ctx.role_low, ctx.originator)
+    end
+
+    test "returns true when the user has the same role in an ancestor account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_1, role: ctx.role_high)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_3, ctx.role_high, ctx.originator)
+    end
+
+    # Test for existing memberships with a child account
+
+    test "returns true when the user has a lower role in a child account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_low)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_high, ctx.originator)
+    end
+
+    test "returns true when the user has a higher role in a child account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_high)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_low, ctx.originator)
+    end
+
+    test "returns true when the user has the same role in a child account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_high)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_high, ctx.originator)
+    end
+
+    # Test for redundant membership pruning on a child account
+
+    test "deletes a lower priority membership in a child account", ctx do
+      membership =
+        insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_low)
+
+      assert Repo.get(Membership, membership.uuid)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_high, ctx.originator)
+      refute Repo.get(Membership, membership.uuid)
+    end
+
+    test "keeps the higher priority membership in a child account", ctx do
+      membership =
+        insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_high)
+
+      assert Repo.get(Membership, membership.uuid)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_low, ctx.originator)
+      assert Repo.get(Membership, membership.uuid)
+    end
+
+    test "deletes the same priority membership in a child account", ctx do
+      membership =
+        insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_high)
+
+      assert Repo.get(Membership, membership.uuid)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_2, ctx.role_high, ctx.originator)
+      refute Repo.get(Membership, membership.uuid)
+    end
+
+    # Test for existing memberships with a descendant account
+
+    test "returns true when the user has a lower role in a descendant account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_low)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_high, ctx.originator)
+    end
+
+    test "returns true when the user has a higher role in a descendant account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_high)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_low, ctx.originator)
+    end
+
+    test "returns true when the user has the same role in a descendant account", ctx do
+      _ = insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_high)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_high, ctx.originator)
+    end
+
+    # Test for redundant membership pruning on a descendant account
+
+    test "deletes a lower priority membership in a descendant account", ctx do
+      membership =
+        insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_low)
+
+      assert Repo.get(Membership, membership.uuid)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_high, ctx.originator)
+      refute Repo.get(Membership, membership.uuid)
+    end
+
+    test "keeps the higher priority membership in a descendant account", ctx do
+      membership =
+        insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_high)
+
+      assert Repo.get(Membership, membership.uuid)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_low, ctx.originator)
+      assert Repo.get(Membership, membership.uuid)
+    end
+
+    test "deletes the same priority membership in a descendant account", ctx do
+      membership =
+        insert(:membership, user: ctx.originator, account: ctx.account_3, role: ctx.role_high)
+
+      assert Repo.get(Membership, membership.uuid)
+      assert MembershipChecker.allowed?(ctx.user, ctx.account_1, ctx.role_high, ctx.originator)
+      refute Repo.get(Membership, membership.uuid)
+    end
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/uploaders/avatar_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/uploaders/avatar_test.exs
@@ -1,0 +1,88 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWalletDB.Uploaders.AvatarTest do
+  use ExUnit.Case, async: true
+  alias Arc.File
+  alias EWalletDB.Account
+  alias EWalletDB.Uploaders.Avatar
+
+  describe "validate/1" do
+    test "returns true if the file name ends with .jpg" do
+      assert Avatar.validate({%File{file_name: "some_file.jpg"}, nil})
+    end
+
+    test "returns true if the file name ends with .jpeg" do
+      assert Avatar.validate({%File{file_name: "some_file.jpeg"}, nil})
+    end
+
+    test "returns true if the file name ends with .gif" do
+      assert Avatar.validate({%File{file_name: "some_file.gif"}, nil})
+    end
+
+    test "returns true if the file name ends with .png" do
+      assert Avatar.validate({%File{file_name: "some_file.png"}, nil})
+    end
+
+    test "returns false if the file name ends with an unsupported extension" do
+      refute Avatar.validate({%File{file_name: "some_file.zip"}, nil})
+      refute Avatar.validate({%File{file_name: "some_file.exe"}, nil})
+      refute Avatar.validate({%File{file_name: "some_file.txt"}, nil})
+      refute Avatar.validate({%File{file_name: "some_file.csv"}, nil})
+    end
+  end
+
+  describe "transform/2" do
+    test "returns the png conversion argument command for :large" do
+      {operation, args, type} = Avatar.transform(:large, {%File{}, nil})
+
+      assert operation == :convert
+      assert String.contains?(args, " -extent 400x400")
+      assert String.contains?(args, " -format png")
+      assert type == :png
+    end
+
+    test "returns the png conversion argument command for :small" do
+      {operation, args, type} = Avatar.transform(:small, {%File{}, nil})
+
+      assert operation == :convert
+      assert String.contains?(args, " -extent 150x150")
+      assert String.contains?(args, " -format png")
+      assert type == :png
+    end
+
+    test "returns the png conversion argument command for :thumb" do
+      {operation, args, type} = Avatar.transform(:thumb, {%File{}, nil})
+
+      assert operation == :convert
+      assert String.contains?(args, " -extent 50x50")
+      assert String.contains?(args, " -format png")
+      assert type == :png
+    end
+  end
+
+  describe "filename/2" do
+    test "returns the given version" do
+      assert Avatar.filename("v1", {%File{}, nil}) == "v1"
+    end
+  end
+
+  describe "storage_dir/2" do
+    test "returns a public path categorized by the schema" do
+      path = Avatar.storage_dir("some_version", {%File{}, %Account{id: "some_account_id"}})
+
+      assert ["public", "uploads", _, "account", "avatars", "some_account_id"] = Path.split(path)
+    end
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/uploaders/file_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/uploaders/file_test.exs
@@ -19,14 +19,14 @@ defmodule EWalletDB.Uploaders.FileTest do
 
   describe "validate/1" do
     test "returns true if the file name ends with .csv" do
-      assert File.validate({%Arc.File{file_name: "some_file.csv"}, nil})
+      assert File.validate({%File{file_name: "some_file.csv"}, nil})
     end
 
     test "returns false if the file name does not end with .csv" do
-      refute File.validate({%Arc.File{file_name: "some_file.zip"}, nil})
-      refute File.validate({%Arc.File{file_name: "some_file.exe"}, nil})
-      refute File.validate({%Arc.File{file_name: "some_file.txt"}, nil})
-      refute File.validate({%Arc.File{file_name: "some_file.jpg"}, nil})
+      refute File.validate({%File{file_name: "some_file.zip"}, nil})
+      refute File.validate({%File{file_name: "some_file.exe"}, nil})
+      refute File.validate({%File{file_name: "some_file.txt"}, nil})
+      refute File.validate({%File{file_name: "some_file.jpg"}, nil})
     end
   end
 

--- a/apps/ewallet_db/test/ewallet_db/uploaders/file_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/uploaders/file_test.exs
@@ -14,19 +14,19 @@
 
 defmodule EWalletDB.Uploaders.FileTest do
   use ExUnit.Case, async: true
-  alias Arc.File
+  alias Arc.File, as: ArcFile
   alias EWalletDB.Uploaders.File
 
   describe "validate/1" do
     test "returns true if the file name ends with .csv" do
-      assert File.validate({%File{file_name: "some_file.csv"}, nil})
+      assert File.validate({%ArcFile{file_name: "some_file.csv"}, nil})
     end
 
     test "returns false if the file name does not end with .csv" do
-      refute File.validate({%File{file_name: "some_file.zip"}, nil})
-      refute File.validate({%File{file_name: "some_file.exe"}, nil})
-      refute File.validate({%File{file_name: "some_file.txt"}, nil})
-      refute File.validate({%File{file_name: "some_file.jpg"}, nil})
+      refute File.validate({%ArcFile{file_name: "some_file.zip"}, nil})
+      refute File.validate({%ArcFile{file_name: "some_file.exe"}, nil})
+      refute File.validate({%ArcFile{file_name: "some_file.txt"}, nil})
+      refute File.validate({%ArcFile{file_name: "some_file.jpg"}, nil})
     end
   end
 

--- a/apps/ewallet_db/test/ewallet_db/uploaders/file_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/uploaders/file_test.exs
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 defmodule EWalletDB.Uploaders.FileTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Arc.File
   alias EWalletDB.Uploaders.File
 

--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -103,6 +103,7 @@ defmodule EWalletDB.Factory do
       address: address,
       name: sequence("Wallet name"),
       identifier: Wallet.primary(),
+      account: nil,
       user: insert(:user),
       enabled: true,
       metadata: %{},


### PR DESCRIPTION
Issue/Task Number: #615 
Closes #615

# Overview

This PR adds more tests to cover the helpers, fetchers, views, serializers, etc. in all subapps.

# Changes

The impacted implementations are:

- `EWallet.Web.WebSocket.invalid_version/3` and `EWallet.Web.WebSocket.get_accept_version/2`
- `EWalletDB.MembershipChecker.search_descendants/1` and `EWalletDB.MembershipChecker.search_descendants/5`
- `EWalletDB.Role.changeset/2`
- `EWallet.ExchangeAccountFetcher.fetch/1`

Tests added for the following modules:

- AdminAPI.V1.AccountHelper
- EWallet.AddressRecordFetcher
- EWallet.ExchangeAccountFetcher
- EWallet.GenesisGate
- EWallet.Exchange.Calculation
- EWallet.Web.WebSocket
- EWalletDB.Helpers.Preloader
- EWalletDB.MembershipChecker
- EWalletDB.Uploaders.Avatar

Views:

- AdminAPI.V1.MintView
- AdminAPI.V1.ResetPasswordView
- AdminAPI.V1.TransactionConsumptionView
- AdminAPI.V1.UserAuthView
- AdminAPI.V1.WalletView

Serializers:

- EWallet.Web.V1.APIKeySerializer
- EWallet.Web.V1.BalanceSerializer
- EWallet.Web.V1.ListSerializer
- EWallet.Web.V1.MintSerializer
- EWallet.Web.V1.TokenStatsSerializer
- EWallet.Web.V1.WalletSerializer

# Implementation Details

Went through all files and folders manually and compare between the `lib/` and `test/` folder, listed and out implemented tests for them. I might not have covered all but this should already cover quite a bit.

Reasons for updated implementations:

- `EWallet.Web.WebSocket`'s `invalid_version/3` and `get_accept_version/2` were changed to private functions since no other modules depend on them and are not part of the `Phoenix.Socket.Transport` behavior that the module implements.
- `EWalletDB.MembershipChecker`'s `search_descendants/1` and `search_descendants/5` were changed to private functions since no other modules depend on them
- `EWalletDB.Role.changeset/2` had `unique_constraint(:priority)` added, otherwise Ecto was returning that the constraint is not known.
- `EWallet.ExchangeAccountFetcher.fetch/1`'s with clause is changed from `{:error, :account_wallet_not_found}` to `{:error, :wallet_not_found}` since `:wallet_not_found` is actually what can be returned from `WalletFetcher.get(nil, _)`.

# Usage

Run `mix test` should pass successfully.

# Impact

No changes to DB schema or API specs.
