### PR TITLE
Fix json validation for configuration

### DIFF
--- a/apps/admin_panel/assets/src/omg-page-configuration/index.js
+++ b/apps/admin_panel/assets/src/omg-page-configuration/index.js
@@ -290,7 +290,7 @@ class ConfigurationPage extends Component {
                 name={'GCS Credential JSON'}
                 description={configurations.gcs_credentials.description}
                 value={this.state.gcsCredentials}
-                placeholder={'ie. {"type": "service_account", "project_id": "your-porject-id" ...'}
+                placeholder={'ie. {"type": "service_account", "project_id": "your-project-id" ...'}
                 border={this.state.emailAdapter !== 'gcs'}
                 onChange={this.onChangeInput('gcsCredentials')}
                 inputErrorMessage='Invalid json credential'

--- a/apps/admin_panel/assets/src/omg-page-configuration/index.js
+++ b/apps/admin_panel/assets/src/omg-page-configuration/index.js
@@ -142,10 +142,8 @@ class ConfigurationPage extends Component {
     return (
       Object.keys(this.props.configurations).reduce((prev, curr) => {
         return (
-          (prev &&
-            String(this.props.configurations[curr].value) ===
-              String(this.state[_.camelCase(curr)])) ||
-          (_.isNil(this.state[_.camelCase(curr)]) && _.isNil(this.props.configurations[curr].value))
+          prev &&
+          String(this.props.configurations[curr].value) === String(this.state[_.camelCase(curr)])
         )
       }, true) ||
       Number(this.state.maxPerPage) < 1 ||
@@ -292,13 +290,15 @@ class ConfigurationPage extends Component {
                 name={'GCS Credential JSON'}
                 description={configurations.gcs_credentials.description}
                 value={this.state.gcsCredentials}
-                placeholder={'ie. AIzaSyD0g8OombPqMBoIhit8ESNj0TueP_OVx2w'}
+                placeholder={'ie. {"type": "service_account", "project_id": "your-porject-id" ...'}
                 border={this.state.emailAdapter !== 'gcs'}
                 onChange={this.onChangeInput('gcsCredentials')}
                 inputErrorMessage='Invalid json credential'
                 inputValidator={value => {
                   try {
-                    JSON.parse(value)
+                    if (value.length === 0) return true
+                    // INCASE OF THE GCS KEY HAS NEW LINE IN PEM
+                    JSON.parse(value.replace(/\n|\r/g, ''))
                     return true
                   } catch (error) {
                     return false


### PR DESCRIPTION
Issue/Task Number: -

# Overview
Sometimes when saving gcs key you would insterted a newline `\r \n` and that will breaks the json validation. This PR fixes it.

# Changes

- Fix configuration json validation.
- Remove some cases that disable the save config button.

# Usage

Try to update gcs with json key and save it.

# Impact

Deploy as usual.
