### PR TITLE
Move InvalidDateFormatError from EWallet.Errors to Utils.Errors

### DIFF
--- a/apps/utils/lib/errors/invalid_date_format_error.ex
+++ b/apps/utils/lib/errors/invalid_date_format_error.ex
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule EWallet.Errors.InvalidDateFormatError do
+defmodule Utils.Errors.InvalidDateFormatError do
   defexception message: "Invalid date format error, supports only NaiveDateTime and DateTime"
 end

--- a/apps/utils/lib/helpers/date_formatter.ex
+++ b/apps/utils/lib/helpers/date_formatter.ex
@@ -17,7 +17,7 @@ defmodule Utils.Helpers.DateFormatter do
   This module allows formatting of a date (naive or date time) into an iso8601 string.
   """
 
-  alias EWallet.Errors.InvalidDateFormatError
+  alias Utils.Errors.InvalidDateFormatError
 
   @doc """
   Parses the given date time to an iso8601 string.

--- a/apps/utils/test/utils/helpers/date_formatter_test.exs
+++ b/apps/utils/test/utils/helpers/date_formatter_test.exs
@@ -14,7 +14,7 @@
 
 defmodule Utils.Helpers.DateFormatterTest do
   use ExUnit.Case
-  alias EWallet.Errors.InvalidDateFormatError
+  alias Utils.Errors.InvalidDateFormatError
   alias Utils.Helpers.DateFormatter
 
   describe "to_iso8601/1" do


### PR DESCRIPTION
Issue/Task Number: #634
Closes #634 

# Overview

This PR moves `EWallet.Errors.InvalidDateFormatError` to `Utils.Errors.InvalidDateFormatError`

# Changes

- Move `EWallet.Errors.InvalidDateFormatError` to `Utils.Errors.InvalidDateFormatError`
- Update `Utils.Helpers.DateFormatter` accordingly

# Implementation Details

As most of the logic using `InvalidDateFormatError` has been moved to a more generic/decoupled `Utils` subapp, it makes sense to move the generic `InvalidDateFormatError` there as well.

# Usage

Future references to `InvalidDateFormatError` should be `Utils.Errors.InvalidDateFormatError`.

# Impact

No changes to the DB schema or API specs