### PR TITLE
Fix error 500 when updating an email with an invalid email format

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/error_handler.ex
+++ b/apps/admin_api/lib/admin_api/v1/error_handler.ex
@@ -18,6 +18,7 @@ defmodule AdminAPI.V1.ErrorHandler do
   """
   import Phoenix.Controller, only: [json: 2]
   import Plug.Conn, only: [halt: 1]
+  alias Ecto.Changeset
   alias EWallet.Web.V1.ErrorHandler, as: EWalletErrorHandler
   alias EWallet.Web.V1.ResponseSerializer
 
@@ -133,6 +134,10 @@ defmodule AdminAPI.V1.ErrorHandler do
     code
     |> EWalletErrorHandler.build_error(attrs, errors())
     |> respond(conn)
+  end
+
+  def handle_error(conn, %Changeset{} = changeset) do
+    handle_error(conn, :invalid_parameter, changeset)
   end
 
   def handle_error(conn, code) do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/self_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/self_controller_test.exs
@@ -298,7 +298,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
     test "returns success and updates the user's email" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       # Make sure the email is not the same
       assert admin.email != new_email
@@ -319,7 +319,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
     test "returns an email_already_exists error when the email is used by another user" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       # Meanwhile, another admin has also been created with the new email.
       _ = insert(:admin, email: new_email)
@@ -340,7 +340,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
     test "returns a token_not_found error when the email is invalid" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       response =
         unauthenticated_request("/admin.verify_email_update", %{
@@ -358,7 +358,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
     test "returns a token_not_found error when the token is invalid" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      _request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, _request} = UpdateEmailRequest.generate(admin, new_email)
 
       response =
         unauthenticated_request("/admin.verify_email_update", %{
@@ -376,7 +376,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
     test "returns an invalid parameter error when the email is not given" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       response =
         unauthenticated_request("/admin.verify_email_update", %{
@@ -391,7 +391,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
     test "returns an invalid parameter error when the token is not given" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       response =
         unauthenticated_request("/admin.verify_email_update", %{
@@ -406,7 +406,7 @@ defmodule AdminAPI.V1.AdminAuth.SelfControllerTest do
     test "generates an activity log" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       timestamp = DateTime.utc_now()
 

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/update_email_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/update_email_controller_test.exs
@@ -69,7 +69,21 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
                "The given `redirect_url` is not allowed. Got: '#{redirect_url}'."
     end
 
-    test "returns an error when sending email = nil" do
+    test "returns client:invalid_parameter error when the given email is not in an email format" do
+      response =
+        admin_user_request("/me.update_email", %{
+          "email" => "not an email",
+          "redirect_url" => @redirect_url
+        })
+
+      assert response["success"] == false
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. `email` must be a valid email address format."
+    end
+
+    test "returns client:invalid_parameter error when the given email = nil" do
       response =
         admin_user_request("/me.update_email", %{
           "email" => nil,
@@ -78,9 +92,10 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
 
       assert response["success"] == false
       assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
-    test "returns an error if the email is not supplied" do
+    test "returns client:invalid_parameter error if the email is not supplied" do
       response =
         admin_user_request("/me.update_email", %{
           "redirect_url" => @redirect_url
@@ -88,9 +103,10 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
 
       assert response["success"] == false
       assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
-    test "returns an error if the redirect_url is not supplied" do
+    test "returns client:invalid_parameter error if the redirect_url is not supplied" do
       response =
         admin_user_request("/me.update_email", %{
           "email" => "test_update_email@example.com"
@@ -98,9 +114,10 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
 
       assert response["success"] == false
       assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
-    test "returns an error if there is already a user with the associated email" do
+    test "returns user:email_already_exists error if there is already a user with the associated email" do
       another_admin = insert(:admin)
 
       response =
@@ -150,7 +167,7 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
     test "returns success and updates the user's email" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       # Make sure the email is not the same
       assert admin.email != new_email
@@ -171,7 +188,7 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
     test "returns an email_already_exists error when the email is used by another user" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       # Meanwhile, another admin has also been created with the new email.
       _ = insert(:admin, email: new_email)
@@ -192,7 +209,7 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
     test "returns a token_not_found error when the email is invalid" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       response =
         unauthenticated_request("/admin.verify_email_update", %{
@@ -210,7 +227,7 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
     test "returns a token_not_found error when the token is invalid" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      _request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, _request} = UpdateEmailRequest.generate(admin, new_email)
 
       response =
         unauthenticated_request("/admin.verify_email_update", %{
@@ -228,7 +245,7 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
     test "returns an invalid parameter error when the email is not given" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       response =
         unauthenticated_request("/admin.verify_email_update", %{
@@ -243,7 +260,7 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
     test "returns an invalid parameter error when the token is not given" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       response =
         unauthenticated_request("/admin.verify_email_update", %{
@@ -258,7 +275,7 @@ defmodule AdminAPI.V1.AdminAuth.UpdateEmailControllerTest do
     test "generates activity logs" do
       admin = get_test_admin()
       new_email = "test_email_update@example.com"
-      request = UpdateEmailRequest.generate(admin, new_email)
+      {:ok, request} = UpdateEmailRequest.generate(admin, new_email)
 
       timestamp = DateTime.utc_now()
 

--- a/apps/ewallet/lib/ewallet/gates/update_email_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/update_email_gate.ex
@@ -21,7 +21,7 @@ defmodule EWallet.UpdateEmailGate do
   def update(user, email_address) do
     with {:ok, email_address} <- validate_email_unused(email_address),
          {_, _} <- UpdateEmailRequest.disable_all_for(user),
-         %UpdateEmailRequest{} = request <- UpdateEmailRequest.generate(user, email_address) do
+         {:ok, request} <- UpdateEmailRequest.generate(user, email_address) do
       {:ok, request}
     else
       error -> error

--- a/apps/ewallet_db/lib/ewallet_db/update_email_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/update_email_request.ex
@@ -59,6 +59,7 @@ defmodule EWalletDB.UpdateEmailRequest do
   @doc """
   Retrieves all active requests.
   """
+  @spec all_active() :: [%__MODULE__{}]
   def all_active do
     UpdateEmailRequest
     |> where([c], c.enabled == true)
@@ -95,6 +96,7 @@ defmodule EWalletDB.UpdateEmailRequest do
   @doc """
   Deletes all the current requests for a user.
   """
+  @spec disable_all_for(%User{}) :: {integer(), nil | [term()]} | no_return()
   def disable_all_for(user) do
     UpdateEmailRequest
     |> where([f], f.user_uuid == ^user.uuid)
@@ -104,19 +106,15 @@ defmodule EWalletDB.UpdateEmailRequest do
   @doc """
   Generates a change email request for the given user.
   """
-  @spec generate(%User{}, String.t()) :: %UpdateEmailRequest{} | {:error, Changeset.t()}
+  @spec generate(%User{}, String.t()) ::
+          {:ok, %UpdateEmailRequest{}} | {:error, Ecto.Changeset.t()}
   def generate(user, email) do
-    token = Crypto.generate_base64_key(@token_length)
-
-    {:ok, _} =
-      insert(%{
-        token: token,
-        email: email,
-        user_uuid: user.uuid,
-        originator: user
-      })
-
-    UpdateEmailRequest.get(email, token)
+    insert(%{
+      token: Crypto.generate_base64_key(@token_length),
+      email: email,
+      user_uuid: user.uuid,
+      originator: user
+    })
   end
 
   defp insert(attrs) do

--- a/apps/ewallet_db/test/ewallet_db/update_email_request_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/update_email_request_test.exs
@@ -111,12 +111,27 @@ defmodule EWalletDB.UpdateEmailRequestTest do
       user = insert(:admin)
       new_email = "new.email@example.com"
 
-      request = UpdateEmailRequest.generate(user, new_email)
+      {res, request} = UpdateEmailRequest.generate(user, new_email)
 
+      assert res == :ok
       assert %UpdateEmailRequest{} = request
       assert request.email == new_email
       assert request.user_uuid == user.uuid
       assert String.length(request.token) == 43
+    end
+
+    test "returns an invalid changeset if the email format is invalid" do
+      user = insert(:admin)
+      {res, changeset} = UpdateEmailRequest.generate(user, "not an email")
+
+      assert res == :error
+      refute changeset.valid?
+
+      assert changeset.errors == [
+               email:
+                 {"must be a valid email address format",
+                  [validation: :valid_email_address_format]}
+             ]
     end
   end
 end


### PR DESCRIPTION
Issue/Task Number: #636 
Closes #636 

# Overview

This PR fixes the error 500 when providing the email update endpoint with an invalid format email.

# Changes

- Updated `EWalletDB.UpdateEmailRequest.generate/2`
- Added a test to cover this fix to `EWalletDB.UpdateEmailRequest` and `AdminAPI.V1.SelfController`

# Implementation Details

The fix is done by changing `EWalletDB.UpdateEmailRequest.generate/2` to consistently return either `{:ok, %EWalletDB.UpdateEmailRequest{}}` or `{:error, %Ecto.Changeset{}}`, instead of hard-pattern matching to `{:ok, _}`.

# Usage

The following command should return a proper error response:

```sh
curl 10.5.10.10:4000/api/admin/me.update_email \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGAdmin <redacted>" \
-H "Content-Type: application/json" \
-d '{
  "email": "not an email",
  "redirect_url": "http://localhost:4000/update_email?email={email}&token={token}"
}' \
-v -w "\n" | jq
```

# Impact

No changes to the DB schema or API specs (except for fixing the error 500 to return the proper error response).