### PR TITLE
Add Dialyzer in build steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,24 @@ jobs:
             make check-credo
           environment:
             MIX_ENV: test
+
+  dialyze:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Determining runtime versions
+          command: |
+            set -xe
+            mkdir -p ~/var
+            elixir --version > ~/var/elixir-version
+      - restore_cache:
+          name: Restoring runtime PLT from cache
+          keys:
+            - v1-ewallet-plt-{{ checksum "~/var/elixir-version" }}
+      - attach_workspace: &ewallet_workspace
+          name: Attaching workspace
+          at: ~/
       - run:
           name: Checking dialyzer
           command: |
@@ -77,6 +95,11 @@ jobs:
             make check-dialyzer
           environment:
             MIX_ENV: test
+      - save_cache:
+          name: Caching runtime PLT
+          key: v1-ewallet-plt-{{ checksum "~/var/elixir-version" }}
+          paths:
+            - ~/.mix/*.plt
 
   test:
     <<: *defaults
@@ -256,6 +279,9 @@ workflows:
           requires:
             - build_test
       - test:
+          requires:
+            - build_test
+      - dialyze:
           requires:
             - build_test
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,6 @@ workflows:
             branches:
               only:
                 - master
-                - 633-dialyxir
             tags:
               only: /^v.*/
       - test_e2e:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          name: Restoring eWallet dependencies from cache
+          name: Restoring eWallet artifacts from cache
           keys:
-            - v1-ewallet-deps-{{ checksum "mix.lock" }}
-            - v1-ewallet-deps-
-      - restore_cache:
-          name: Restoring eWallet test artifacts from cache
-          keys:
-            - v1-ewallet-test-build-{{ checksum "mix.exs" }}
-            - v1-ewallet-test-build-
+            - v1-ewallet-{{ checksum "mix.lock" }}-{{ checksum "mix.exs" }}-{{ checksum "apps/admin_panel/assets/yarn.lock" }}
+            - v1-ewallet-{{ checksum "mix.lock" }}-{{ checksum "mix.exs" }}-
+            - v1-ewallet-{{ checksum "mix.lock" }}-
+            - v1-ewallet-
       - run:
           name: Building eWallet in test environment
           command: |
@@ -34,30 +31,17 @@ jobs:
             #   See also admin_api/config/config.exs
             mix deps.clean bcrypt_elixir mime --build
             make build-test
-      - save_cache:
-          name: Caching eWallet dependencies
-          key: v1-ewallet-deps-{{ checksum "mix.lock" }}
-          paths:
-            - deps
-      - save_cache:
-          name: Caching eWallet test artifacts
-          key: v1-ewallet-test-build-{{ checksum "mix.exs" }}
-          paths:
-            - _build/test
-      - restore_cache:
-          name: Restoring eWallet assets dependencies from cache
-          keys:
-            - v1-ewallet-assets-deps-{{ checksum "apps/admin_panel/assets/yarn.lock" }}
-            - v1-ewallet-assets-deps-
       - run:
           name: Building eWallet assets
           command: |
             set -xe
             make deps-assets
       - save_cache:
-          name: Caching eWallet assets dependencies
-          key: v1-ewallet-assets-deps-{{ checksum "apps/admin_panel/assets/yarn.lock" }}
+          name: Caching eWallet artifacts
+          key: v1-ewallet-{{ checksum "mix.lock" }}-{{ checksum "mix.exs" }}-{{ checksum "apps/admin_panel/assets/yarn.lock" }}
           paths:
+            - deps
+            - _build/test
             - apps/admin_panel/assets/node_modules
       -  persist_to_workspace:
           name: Persisting workspace
@@ -120,28 +104,16 @@ jobs:
       - restore_cache:
           name: Restoring eWallet production artifacts from cache
           keys:
-            - v1-ewallet-prod-build-{{ checksum "mix.exs" }}
-            - v1-ewallet-prod-build-
+            - v1-ewallet-prod-{{ checksum "mix.exs" }}-{{ checksum "Dockerfile" }}
+            - v1-ewallet-prod-{{ checksum "mix.exs" }}-
+            - v1-ewallet-prod-
       - run:
           name: Building eWallet in production environment
           command: |
             set -xe
             make build-prod
-      - save_cache:
-          name: Caching eWallet artifacts
-          key: v1-ewallet-prod-build-{{ checksum "mix.exs" }}
-          paths:
-            - _build/prod/.mix
-            - _build/prod/consolidated
-            - _build/prod/lib
-      - restore_cache:
-          name: Restoring Docker image artifacts from cache
-          keys:
-            - v1-docker-image-{{ checksum "Dockerfile" }}-{{ checksum "mix.exs" }}
-            - v1-docker-image-{{ checksum "Dockerfile" }}
-            - v1-docker-image-
       - run:
-          name: Building Docker image
+          name: Building eWallet Docker image
           command: |
             set -xe
             docker load -i ~/caches/docker-layers.tar || true
@@ -149,10 +121,13 @@ jobs:
             mkdir -p ~/caches
             docker save -o ~/caches/docker-layers.tar "$IMAGE_NAME"
       - save_cache:
-          name: Saving Docker image layer cache
+          name: Caching eWallet production artifacts
+          key: v1-ewallet-prod-{{ checksum "mix.exs" }}-{{ checksum "Dockerfile" }}
           paths:
+            - _build/prod/.mix
+            - _build/prod/consolidated
+            - _build/prod/lib
             - ~/caches/docker-layers.tar
-          key: v1-docker-image-{{ checksum "Dockerfile" }}-{{ checksum "mix.exs" }}
       - persist_to_workspace:
           name: Persisting workspace
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,9 @@ jobs:
       - restore_cache:
           name: Restoring runtime PLT from cache
           keys:
-            - v1-ewallet-plt-{{ checksum "~/var/elixir-version" }}
+            - v1-ewallet-plt-{{ checksum "~/var/elixir-version" }}-{{ checksum "mix.lock" }}
+            - v1-ewallet-plt-{{ checksum "~/var/elixir-version" }}-
+            - v1-ewallet-plt-
       - attach_workspace: &ewallet_workspace
           name: Attaching workspace
           at: ~/
@@ -92,14 +94,16 @@ jobs:
           name: Checking dialyzer
           command: |
             set -xe
+            export PLT_CORE_PATH=$HOME/var/dialyzer
+            mkdir -p $PLT_CORE_PATH
             make check-dialyzer
           environment:
             MIX_ENV: test
       - save_cache:
           name: Caching runtime PLT
-          key: v1-ewallet-plt-{{ checksum "~/var/elixir-version" }}
+          key: v1-ewallet-plt-{{ checksum "~/var/elixir-version" }}-{{ checksum "mix.lock" }}
           paths:
-            - ~/.mix/*.plt
+            - ~/var/dialyzer
           when: always
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
           key: v1-ewallet-plt-{{ checksum "~/var/elixir-version" }}
           paths:
             - ~/.mix/*.plt
+          when: always
 
   test:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2
 
+
 presets:
   defaults: &defaults
     working_directory: ~/src
@@ -60,11 +61,11 @@ jobs:
             - apps/admin_panel/assets/node_modules
       -  persist_to_workspace:
           name: Persisting workspace
-          root: ~/src
+          root: ~/
           paths:
-            - deps
-            - _build
-            - apps/admin_panel/assets/node_modules
+            - src/deps
+            - src/_build
+            - src/apps/admin_panel/assets/node_modules
 
   lint:
     <<: *defaults
@@ -72,7 +73,7 @@ jobs:
       - checkout
       - attach_workspace: &ewallet_workspace
           name: Attaching workspace
-          at: ~/src
+          at: ~/
       - run:
           name: Checking code formattings
           command: |
@@ -136,6 +137,7 @@ jobs:
       - restore_cache:
           name: Restoring Docker image artifacts from cache
           keys:
+            - v1-docker-image-{{ checksum "Dockerfile" }}-{{ checksum "mix.exs" }}
             - v1-docker-image-{{ checksum "Dockerfile" }}
             - v1-docker-image-
       - run:
@@ -144,19 +146,18 @@ jobs:
             set -xe
             docker load -i ~/caches/docker-layers.tar || true
             make docker-build IMAGE_NAME=$IMAGE_NAME
-            mkdir -p ~/caches /tmp/workspace
+            mkdir -p ~/caches
             docker save -o ~/caches/docker-layers.tar "$IMAGE_NAME"
-            docker save -o /tmp/workspace/docker-image.tar "$IMAGE_NAME"
       - save_cache:
           name: Saving Docker image layer cache
           paths:
             - ~/caches/docker-layers.tar
-          key: v1-docker-image-{{ checksum "Dockerfile" }}
+          key: v1-docker-image-{{ checksum "Dockerfile" }}-{{ checksum "mix.exs" }}
       - persist_to_workspace:
           name: Persisting workspace
-          root: /tmp/workspace
+          root: ~/
           paths:
-            - docker-image.tar
+            - caches/docker-layers.tar
 
   test_e2e:
     <<: *defaults
@@ -165,7 +166,7 @@ jobs:
       - checkout
       - attach_workspace: &ewallet_docker_workspace
           name: Attaching workspace
-          at: /tmp/workspace
+          at: ~/
       - run:
           name: Preparing E2E environments
           command: |
@@ -182,7 +183,7 @@ jobs:
             E2E_TEST_USER_PASSWORD=$(openssl rand -base64 24 | tr '+/' '-_')
             EOF
 
-            docker load -i /tmp/workspace/docker-image.tar
+            docker load -i ~/caches/docker-layers.tar
             docker network create net0
 
             sh docker-gen.sh -i "$IMAGE_NAME" -n net0 -f .env > docker-compose.override.yml
@@ -228,7 +229,7 @@ jobs:
           name: Publishing Docker image
           command: |
             set -xe
-            docker load -i /tmp/workspace/docker-image.tar
+            docker load -i ~/caches/docker-layers.tar
 
             IMAGE_TAG=""
             if [ -n "$CIRCLE_TAG" ]; then
@@ -269,15 +270,12 @@ workflows:
   test_build:
     jobs:
       - build_test
-
       - lint:
           requires:
             - build_test
-
       - test:
           requires:
             - build_test
-
       - build:
           requires:
             - lint
@@ -289,12 +287,10 @@ workflows:
                 - 633-dialyxir
             tags:
               only: /^v.*/
-
       - test_e2e:
           requires:
             - build
           filters: *mainline_branches
-
       - publish:
           requires:
             - test_e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,13 @@ jobs:
             make check-credo
           environment:
             MIX_ENV: test
+      - run:
+          name: Checking dialyzer
+          command: |
+            set -xe
+            make check-dialyzer
+          environment:
+            MIX_ENV: test
 
   test:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,47 +14,65 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: &ewallet_deps
+      - restore_cache:
           name: Restoring eWallet dependencies from cache
           keys:
             - v1-ewallet-deps-{{ checksum "mix.lock" }}
             - v1-ewallet-deps-
-      - restore_cache: &ewallet_test_build
+      - restore_cache:
           name: Restoring eWallet test artifacts from cache
           keys:
             - v1-ewallet-test-build-{{ checksum "mix.exs" }}
             - v1-ewallet-test-build-
       - run:
-          name: Retrieving eWallet dependencies
+          name: Building eWallet in test environment
           command: |
             set -xe
-            # Force rebuilding bcrypt_elixir otherwise it's gonna fail loading NIFs
-            find deps/ -name bcrypt_elixir -print0 | xargs -0 rm -rf || true
-            make deps-ewallet
+            # * Clean bcrypt_elixir to avoid NIF issue due to broken cache.
+            # * Clean mime in order to make the new type recognized by mime app.
+            #   See also admin_api/config/config.exs
+            mix deps.clean bcrypt_elixir mime --build
+            make build-test
       - save_cache:
           name: Caching eWallet dependencies
           key: v1-ewallet-deps-{{ checksum "mix.lock" }}
           paths:
             - deps
-      - run:
-          name: Building eWallet in test environment
-          command: |
-            set -xe
-            # Force rebuilding bcrypt_elixir otherwise it's gonna fail loading NIFs
-            find _build/ -name bcrypt_elixir -print0 | xargs -0 rm -rf || true
-            make build-test
       - save_cache:
           name: Caching eWallet test artifacts
           key: v1-ewallet-test-build-{{ checksum "mix.exs" }}
           paths:
             - _build/test
+      - restore_cache:
+          name: Restoring eWallet assets dependencies from cache
+          keys:
+            - v1-ewallet-assets-deps-{{ checksum "apps/admin_panel/assets/yarn.lock" }}
+            - v1-ewallet-assets-deps-
+      - run:
+          name: Building eWallet assets
+          command: |
+            set -xe
+            make deps-assets
+      - save_cache:
+          name: Caching eWallet assets dependencies
+          key: v1-ewallet-assets-deps-{{ checksum "apps/admin_panel/assets/yarn.lock" }}
+          paths:
+            - apps/admin_panel/assets/node_modules
+      -  persist_to_workspace:
+          name: Persisting workspace
+          root: ~/src
+          paths:
+            - deps
+            - _build
+            - apps/admin_panel/assets/node_modules
 
   lint:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: *ewallet_deps
-      - restore_cache: *ewallet_test_build
+      - attach_workspace: &ewallet_workspace
+          name: Attaching workspace
+          at: ~/src
       - run:
           name: Checking code formattings
           command: |
@@ -64,10 +82,6 @@ jobs:
           name: Checking credo
           command: |
             set -xe
-            # Force rebuilding bcrypt_elixir otherwise it's gonna fail loading NIFs
-            find deps/ -name bcrypt_elixir -print0 | xargs -0 rm -rf || true
-            find _build/ -name bcrypt_elixir -print0 | xargs -0 rm -rf || true
-            make deps-ewallet
             make check-credo
           environment:
             MIX_ENV: test
@@ -79,20 +93,11 @@ jobs:
       - image: postgres:9.6-alpine
     steps:
       - checkout
-      - restore_cache: *ewallet_deps
-      - restore_cache: *ewallet_test_build
-      - restore_cache: &ewallet_deps_assets
-          name: Restoring eWallet assets dependencies from cache
-          keys:
-            - v1-ewallet-assets-deps-{{ checksum "apps/admin_panel/assets/yarn.lock" }}
-            - v1-ewallet-assets-deps-
+      - attach_workspace: *ewallet_workspace
       - run:
           name: Running eWallet tests
           command: |
             set -xe
-            # Force rebuilding bcrypt_elixir otherwise it's gonna fail loading NIFs
-            find deps/ -name bcrypt_elixir -print0 | xargs -0 rm -rf || true
-            find _build/ -name bcrypt_elixir -print0 | xargs -0 rm -rf || true
             make test-ewallet
           environment:
             DATABASE_URL: postgresql://postgres:@localhost:5432/ewallet
@@ -103,33 +108,23 @@ jobs:
           name: Running eWallet assets tests
           command: |
             set -xe
-            make deps-assets
             make test-assets
-      - save_cache:
-          name: Caching eWallet test dependencies
-          key: v1-ewallet-assets-deps-{{ checksum "apps/admin_panel/assets/yarn.lock" }}
-          paths:
-            - apps/admin_panel/assets/node_modules
 
   build:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: *ewallet_deps
-      - restore_cache: *ewallet_deps_assets
+      - setup_remote_docker
+      - attach_workspace: *ewallet_workspace
       - restore_cache:
           name: Restoring eWallet production artifacts from cache
           keys:
             - v1-ewallet-prod-build-{{ checksum "mix.exs" }}
             - v1-ewallet-prod-build-
-      - setup_remote_docker
       - run:
           name: Building eWallet in production environment
           command: |
             set -xe
-            # Force rebuilding bcrypt_elixir otherwise it's gonna fail loading NIFs
-            find deps/ -name bcrypt_elixir -print0 | xargs -0 rm -rf || true
-            find _build/ -name bcrypt_elixir -print0 | xargs -0 rm -rf || true
             make build-prod
       - save_cache:
           name: Caching eWallet artifacts
@@ -168,7 +163,7 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
-      - attach_workspace: &attach_workspace
+      - attach_workspace: &ewallet_docker_workspace
           name: Attaching workspace
           at: /tmp/workspace
       - run:
@@ -224,7 +219,7 @@ jobs:
     <<: *defaults
     steps:
       - setup_remote_docker
-      - attach_workspace: *attach_workspace
+      - attach_workspace: *ewallet_docker_workspace
       - run:
           name: Logging into Docker Hub
           command: |
@@ -291,6 +286,7 @@ workflows:
             branches:
               only:
                 - master
+                - 633-dialyxir
             tags:
               only: /^v.*/
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ check-credo:
 	mix credo
 
 check-dialyzer:
-	mix dialyzer
+	mix dialyzer --halt-exit-status
 
 .PHONY: format check-format check-credo
 

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ check-format:
 check-credo:
 	mix credo
 
+check-dialyzer:
+	mix dialyzer
+
 .PHONY: format check-format check-credo
 
 #

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,11 @@ build-assets: deps-assets
 # If we call mix phx.digest without mix compile, mix release will silently fail
 # for some reason. Always make sure to run mix compile first.
 build-prod: deps-ewallet build-assets
-	env MIX_ENV=prod mix deps.clean mime --build
 	env MIX_ENV=prod mix compile
 	env MIX_ENV=prod mix phx.digest
 	env MIX_ENV=prod mix release
 
 build-test: deps-ewallet
-	env MIX_ENV=test mix deps.clean mime --build
 	env MIX_ENV=test mix compile
 
 .PHONY: build-assets build-prod build-test

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,7 @@ defmodule EWallet.Umbrella.Mixfile do
       dialyzer: [
         flags: [:underspecs, :unknown, :unmatched_returns],
         plt_add_apps: [:iex, :mix],
+        plt_core_path: System.get_env("PLT_CORE_PATH"),
         ignore_warnings: ".dialyzer_ignore.exs",
         flags: ~w(-Wunmatched_returns -Werror_handling -Wunderspecs)
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule EWallet.Umbrella.Mixfile do
   defp deps do
     [
       {:credo, "0.10.0", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev, :test], runtime: false},
       {:distillery, "~> 1.5", runtime: false},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:excoveralls, "~> 0.8", only: :test, runtime: false},


### PR DESCRIPTION
Issue/Task Number: #663

# Overview

Run Dialyzer as part of the build process in order to ensure code are properly written.

# Changes

- Cleanup build steps to use a shared workspace instead of cache
- Add Dialyzer step

# Impact

You will probably see `dialyze` step failing in all PRs until everything is fixed.