### PR TITLE
Exclude soft-deleted API keys from /api_key.all

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/api_key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/api_key_controller.ex
@@ -21,12 +21,12 @@ defmodule AdminAPI.V1.APIKeyController do
   alias EWalletDB.APIKey
 
   @doc """
-  Retrieves a list of API keys including soft-deleted.
+  Retrieves a list of API keys.
   """
   @spec all(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def all(conn, attrs) do
     with :ok <- permit(:all, conn.assigns, nil) do
-      APIKey
+      APIKey.query_all()
       |> Orchestrator.query(APIKeyOverlay, attrs)
       |> respond_multiple(conn)
     else

--- a/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/key_controller.ex
@@ -21,7 +21,7 @@ defmodule AdminAPI.V1.KeyController do
   alias EWalletDB.Key
 
   @doc """
-  Retrieves a list of keys including soft-deleted.
+  Retrieves a list of keys.
   """
   @spec all(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def all(conn, attrs) do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
@@ -23,12 +23,12 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
       [api_key1, api_key2] = APIKey |> ensure_num_records(2) |> Preloader.preload(:account)
 
       response = admin_user_request("/api_key.all")
-      records = response["data"]["data"]
+      api_keys = response["data"]["data"]
 
-      assert response["pagination"]["count"] == 2
-      assert Enum.count(records) == 2
-      assert Enum.any?(records, fn r -> r.id == api_key1.id end)
-      assert Enum.any?(records, fn r -> r.id == api_key2.id end)
+      assert response["data"]["pagination"]["count"] == 2
+      assert Enum.count(api_keys) == 2
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key1.id end)
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key2.id end)
     end
 
     test "responds with a list of api keys when given params" do
@@ -50,13 +50,13 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
       }
 
       response = admin_user_request("/api_key.all", attrs)
-      records = response["data"]["data"]
+      api_keys = response["data"]["data"]
 
       # Returning 1 due to `per_page: 1`
-      assert response["pagination"]["count"] == 1
-      assert Enum.count(records) == 1
-      refute Enum.any?(records, fn r -> r.id == api_key1.id end)
-      assert Enum.any?(records, fn r -> r.id == api_key2.id end)
+      assert response["data"]["pagination"]["count"] == 1
+      assert Enum.count(api_keys) == 1
+      refute Enum.any?(api_keys, fn a -> a["id"] == api_key1.id end)
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key2.id end)
     end
 
     test "responds with a list of api keys excluding the soft-deleted ones" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
@@ -113,6 +113,20 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
                }
     end
 
+    test "responds with a list of api keys excluding the soft-deleted ones" do
+      originator = insert(:user)
+      [api_key1, api_key2, api_key3] = ensure_num_records(APIKey, 3)
+      {:ok, _} = APIKey.delete(api_key2, originator)
+
+      response = admin_user_request("/api_key.all")
+      api_keys = response["data"]["data"]
+
+      assert Enum.count(api_keys) == 2
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key1.id end)
+      refute Enum.any?(api_keys, fn a -> a["id"] == api_key2.id end)
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key3.id end)
+    end
+
     test_supports_match_any("/api_key.all", :admin_auth, :api_key, :key)
     test_supports_match_all("/api_key.all", :admin_auth, :api_key, :key)
   end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/api_key_controller_test.exs
@@ -22,52 +22,19 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
     test "responds with a list of api keys when no params are given" do
       [api_key1, api_key2] = APIKey |> ensure_num_records(2) |> Preloader.preload(:account)
 
-      assert admin_user_request("/api_key.all") ==
-               %{
-                 "version" => "1",
-                 "success" => true,
-                 "data" => %{
-                   "object" => "list",
-                   "data" => [
-                     %{
-                       "object" => "api_key",
-                       "id" => api_key1.id,
-                       "key" => api_key1.key,
-                       "account_id" => api_key1.account.id,
-                       "owner_app" => api_key1.owner_app,
-                       "expired" => false,
-                       "enabled" => true,
-                       "created_at" => DateFormatter.to_iso8601(api_key1.inserted_at),
-                       "updated_at" => DateFormatter.to_iso8601(api_key1.updated_at),
-                       "deleted_at" => DateFormatter.to_iso8601(api_key1.deleted_at)
-                     },
-                     %{
-                       "object" => "api_key",
-                       "id" => api_key2.id,
-                       "key" => api_key2.key,
-                       "account_id" => api_key2.account.id,
-                       "owner_app" => api_key2.owner_app,
-                       "expired" => false,
-                       "enabled" => true,
-                       "created_at" => DateFormatter.to_iso8601(api_key2.inserted_at),
-                       "updated_at" => DateFormatter.to_iso8601(api_key2.updated_at),
-                       "deleted_at" => DateFormatter.to_iso8601(api_key2.deleted_at)
-                     }
-                   ],
-                   "pagination" => %{
-                     "current_page" => 1,
-                     "per_page" => 10,
-                     "is_first_page" => true,
-                     "is_last_page" => true,
-                     "count" => 2
-                   }
-                 }
-               }
+      response = admin_user_request("/api_key.all")
+      records = response["data"]["data"]
+
+      assert response["pagination"]["count"] == 2
+      assert Enum.count(records) == 2
+      assert Enum.any?(records, fn r -> r.id == api_key1.id end)
+      assert Enum.any?(records, fn r -> r.id == api_key2.id end)
     end
 
     test "responds with a list of api keys when given params" do
-      [_, api_key] = insert_list(2, :api_key, owner_app: "test_admin_auth_api_key_all")
+      [api_key1, api_key2] = insert_list(2, :api_key, owner_app: "test_admin_auth_api_key_all")
 
+      # Note that per_page is set to only a single record
       attrs = %{
         match_all: [
           %{
@@ -82,35 +49,14 @@ defmodule AdminAPI.V1.AdminAuth.APIKeyControllerTest do
         sort_dir: "desc"
       }
 
-      assert admin_user_request("/api_key.all", attrs) ==
-               %{
-                 "version" => "1",
-                 "success" => true,
-                 "data" => %{
-                   "object" => "list",
-                   "data" => [
-                     %{
-                       "object" => "api_key",
-                       "id" => api_key.id,
-                       "key" => api_key.key,
-                       "account_id" => api_key.account.id,
-                       "owner_app" => api_key.owner_app,
-                       "expired" => false,
-                       "enabled" => true,
-                       "created_at" => DateFormatter.to_iso8601(api_key.inserted_at),
-                       "updated_at" => DateFormatter.to_iso8601(api_key.updated_at),
-                       "deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)
-                     }
-                   ],
-                   "pagination" => %{
-                     "current_page" => 1,
-                     "per_page" => 1,
-                     "is_first_page" => true,
-                     "is_last_page" => false,
-                     "count" => 1
-                   }
-                 }
-               }
+      response = admin_user_request("/api_key.all", attrs)
+      records = response["data"]["data"]
+
+      # Returning 1 due to `per_page: 1`
+      assert response["pagination"]["count"] == 1
+      assert Enum.count(records) == 1
+      refute Enum.any?(records, fn r -> r.id == api_key1.id end)
+      assert Enum.any?(records, fn r -> r.id == api_key2.id end)
     end
 
     test "responds with a list of api keys excluding the soft-deleted ones" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/key_controller_test.exs
@@ -38,6 +38,20 @@ defmodule AdminAPI.V1.AdminAuth.KeyControllerTest do
              end)
     end
 
+    test "responds with a list of keys excluding the soft-deleted ones" do
+      originator = insert(:user)
+      [key1, key2, key3] = ensure_num_records(Key, 3)
+      {:ok, _} = Key.delete(key2, originator)
+
+      response = admin_user_request("/access_key.all")
+      keys = response["data"]["data"]
+
+      assert Enum.count(keys) == 2
+      assert Enum.any?(keys, fn a -> a["id"] == key1.id end)
+      refute Enum.any?(keys, fn a -> a["id"] == key2.id end)
+      assert Enum.any?(keys, fn a -> a["id"] == key3.id end)
+    end
+
     test_supports_match_any("/access_key.all", :admin_auth, :key, :access_key)
     test_supports_match_all("/access_key.all", :admin_auth, :key, :access_key)
   end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
@@ -23,12 +23,12 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
       [api_key1, api_key2] = APIKey |> ensure_num_records(2) |> Preloader.preload(:account)
 
       response = provider_request("/api_key.all")
-      records = response["data"]["data"]
+      api_keys = response["data"]["data"]
 
-      assert response["pagination"]["count"] == 2
-      assert Enum.count(records) == 2
-      assert Enum.any?(records, fn r -> r.id == api_key1.id end)
-      assert Enum.any?(records, fn r -> r.id == api_key2.id end)
+      assert response["data"]["pagination"]["count"] == 2
+      assert Enum.count(api_keys) == 2
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key1.id end)
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key2.id end)
     end
 
     test "responds with a list of api keys when given pagination params" do
@@ -50,13 +50,13 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
       }
 
       response = provider_request("/api_key.all", attrs)
-      records = response["data"]["data"]
+      api_keys = response["data"]["data"]
 
       # Returning 1 due to `per_page: 1`
-      assert response["pagination"]["count"] == 1
-      assert Enum.count(records) == 1
-      refute Enum.any?(records, fn r -> r.id == api_key1.id end)
-      assert Enum.any?(records, fn r -> r.id == api_key2.id end)
+      assert response["data"]["pagination"]["count"] == 1
+      assert Enum.count(api_keys) == 1
+      refute Enum.any?(api_keys, fn a -> a["id"] == api_key1.id end)
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key2.id end)
     end
 
     test "responds with a list of api keys excluding the soft-deleted ones" do
@@ -68,9 +68,9 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
       api_keys = response["data"]["data"]
 
       assert Enum.count(api_keys) == 2
-      assert Enum.any?(api_keys, fn a -> a.id == api_key1.id end)
-      refute Enum.any?(api_keys, fn a -> a.id == api_key2.id end)
-      assert Enum.any?(api_keys, fn a -> a.id == api_key3.id end)
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key1.id end)
+      refute Enum.any?(api_keys, fn a -> a["id"] == api_key2.id end)
+      assert Enum.any?(api_keys, fn a -> a["id"] == api_key3.id end)
     end
 
     test_supports_match_any("/api_key.all", :provider_auth, :api_key, :key)

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
@@ -114,6 +114,19 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
                }
     end
 
+    test "responds with a list of api keys excluding the soft-deleted ones" do
+      [api_key1, api_key2, api_key3] = ensure_num_records(APIKey, 3)
+      {:ok, soft_deleted} = APIKey.delete(api_key2)
+
+      response = provider_request("/api_key.all")
+      api_keys = response["data"]["data"]
+
+      assert Enum.count(api_keys) == 2
+      assert Enum.any?(api_keys, fn a -> a.id == api_key1.id end)
+      refute Enum.any?(api_keys, fn a -> a.id == api_key2.id end)
+      assert Enum.any?(api_keys, fn a -> a.id == api_key3.id end)
+    end
+
     test_supports_match_any("/api_key.all", :provider_auth, :api_key, :key)
     test_supports_match_all("/api_key.all", :provider_auth, :api_key, :key)
   end

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/api_key_controller_test.exs
@@ -22,51 +22,17 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
     test "responds with a list of api keys when no params are given" do
       [api_key1, api_key2] = APIKey |> ensure_num_records(2) |> Preloader.preload(:account)
 
-      assert provider_request("/api_key.all") ==
-               %{
-                 "version" => "1",
-                 "success" => true,
-                 "data" => %{
-                   "object" => "list",
-                   "data" => [
-                     %{
-                       "object" => "api_key",
-                       "id" => api_key1.id,
-                       "key" => api_key1.key,
-                       "account_id" => api_key1.account.id,
-                       "owner_app" => api_key1.owner_app,
-                       "expired" => false,
-                       "enabled" => true,
-                       "created_at" => DateFormatter.to_iso8601(api_key1.inserted_at),
-                       "updated_at" => DateFormatter.to_iso8601(api_key1.updated_at),
-                       "deleted_at" => DateFormatter.to_iso8601(api_key1.deleted_at)
-                     },
-                     %{
-                       "object" => "api_key",
-                       "id" => api_key2.id,
-                       "key" => api_key2.key,
-                       "account_id" => api_key2.account.id,
-                       "owner_app" => api_key2.owner_app,
-                       "expired" => false,
-                       "enabled" => true,
-                       "created_at" => DateFormatter.to_iso8601(api_key2.inserted_at),
-                       "updated_at" => DateFormatter.to_iso8601(api_key2.updated_at),
-                       "deleted_at" => DateFormatter.to_iso8601(api_key2.deleted_at)
-                     }
-                   ],
-                   "pagination" => %{
-                     "current_page" => 1,
-                     "per_page" => 10,
-                     "is_first_page" => true,
-                     "is_last_page" => true,
-                     "count" => 2
-                   }
-                 }
-               }
+      response = provider_request("/api_key.all")
+      records = response["data"]["data"]
+
+      assert response["pagination"]["count"] == 2
+      assert Enum.count(records) == 2
+      assert Enum.any?(records, fn r -> r.id == api_key1.id end)
+      assert Enum.any?(records, fn r -> r.id == api_key2.id end)
     end
 
     test "responds with a list of api keys when given pagination params" do
-      [_, api_key] = insert_list(2, :api_key, owner_app: "test_provider_auth_api_key_all")
+      [api_key1, api_key2] = insert_list(2, :api_key, owner_app: "test_provider_auth_api_key_all")
 
       # Note that per_page is set to only a single record
       attrs = %{
@@ -83,40 +49,20 @@ defmodule AdminAPI.V1.ProviderAuth.APIKeyControllerTest do
         sort_dir: "desc"
       }
 
-      assert provider_request("/api_key.all", attrs) ==
-               %{
-                 "version" => "1",
-                 "success" => true,
-                 "data" => %{
-                   "object" => "list",
-                   "data" => [
-                     %{
-                       "object" => "api_key",
-                       "id" => api_key.id,
-                       "key" => api_key.key,
-                       "account_id" => api_key.account.id,
-                       "owner_app" => api_key.owner_app,
-                       "expired" => false,
-                       "enabled" => true,
-                       "created_at" => DateFormatter.to_iso8601(api_key.inserted_at),
-                       "updated_at" => DateFormatter.to_iso8601(api_key.updated_at),
-                       "deleted_at" => DateFormatter.to_iso8601(api_key.deleted_at)
-                     }
-                   ],
-                   "pagination" => %{
-                     "current_page" => 1,
-                     "per_page" => 1,
-                     "is_first_page" => true,
-                     "is_last_page" => false,
-                     "count" => 1
-                   }
-                 }
-               }
+      response = provider_request("/api_key.all", attrs)
+      records = response["data"]["data"]
+
+      # Returning 1 due to `per_page: 1`
+      assert response["pagination"]["count"] == 1
+      assert Enum.count(records) == 1
+      refute Enum.any?(records, fn r -> r.id == api_key1.id end)
+      assert Enum.any?(records, fn r -> r.id == api_key2.id end)
     end
 
     test "responds with a list of api keys excluding the soft-deleted ones" do
+      originator = insert(:user)
       [api_key1, api_key2, api_key3] = ensure_num_records(APIKey, 3)
-      {:ok, soft_deleted} = APIKey.delete(api_key2)
+      {:ok, _} = APIKey.delete(api_key2, originator)
 
       response = provider_request("/api_key.all")
       api_keys = response["data"]["data"]

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/key_controller_test.exs
@@ -38,6 +38,20 @@ defmodule AdminAPI.V1.ProviderAuth.KeyControllerTest do
              end)
     end
 
+    test "responds with a list of keys excluding the soft-deleted ones" do
+      originator = insert(:user)
+      [key1, key2, key3] = ensure_num_records(Key, 3)
+      {:ok, _} = Key.delete(key2, originator)
+
+      response = provider_request("/access_key.all")
+      keys = response["data"]["data"]
+
+      assert Enum.count(keys) == 2
+      assert Enum.any?(keys, fn a -> a["id"] == key1.id end)
+      refute Enum.any?(keys, fn a -> a["id"] == key2.id end)
+      assert Enum.any?(keys, fn a -> a["id"] == key3.id end)
+    end
+
     test_supports_match_any("/access_key.all", :provider_auth, :key, :access_key)
     test_supports_match_all("/access_key.all", :provider_auth, :key, :access_key)
   end

--- a/apps/ewallet_db/lib/ewallet_db/api_key.ex
+++ b/apps/ewallet_db/lib/ewallet_db/api_key.ex
@@ -88,6 +88,13 @@ defmodule EWalletDB.APIKey do
   end
 
   @doc """
+  Build the query for all APIKeys excluding the soft-deleted ones.
+  """
+  def query_all do
+    exclude_deleted(APIKey)
+  end
+
+  @doc """
   Get API key by id, exclude soft-deleted.
   """
   @spec get(String.t()) :: %APIKey{} | nil

--- a/apps/ewallet_db/lib/ewallet_db/key.ex
+++ b/apps/ewallet_db/lib/ewallet_db/key.ex
@@ -86,7 +86,9 @@ defmodule EWalletDB.Key do
   end
 
   def query_all_for_account_uuids(query, account_uuids) do
-    where(query, [a], a.account_uuid in ^account_uuids)
+    query
+    |> exclude_deleted()
+    |> where([a], a.account_uuid in ^account_uuids)
   end
 
   @doc """

--- a/apps/ewallet_db/test/ewallet_db/api_key_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/api_key_test.exs
@@ -16,13 +16,33 @@ defmodule EWalletDB.APIKeyTest do
   use EWalletDB.SchemaCase, async: true
   import EWalletDB.Factory
   alias Ecto.UUID
-  alias EWalletDB.APIKey
+  alias EWalletDB.{APIKey, Repo}
   alias ActivityLogger.System
 
   @owner_app :some_app
 
   describe "APIKey factory" do
     test_has_valid_factory(APIKey)
+  end
+
+  describe "query_all/0" do
+    test "returns a query for all API keys excluding the soft-deleted ones" do
+      originator = insert(:user)
+
+      api_key_1 = insert(:api_key)
+      api_key_2 = insert(:api_key)
+      api_key_3 = insert(:api_key)
+
+      {:ok, _} = APIKey.delete(api_key_2, originator)
+
+      query = APIKey.query_all()
+      records = Repo.all(query)
+
+      assert Enum.count(records) == 2
+      assert Enum.any?(records, fn r -> r.id == api_key_1.id end)
+      refute Enum.any?(records, fn r -> r.id == api_key_2.id end)
+      assert Enum.any?(records, fn r -> r.id == api_key_3.id end)
+    end
   end
 
   describe "get/1" do


### PR DESCRIPTION
Issue/Task Number: #655 
Closes #655

# Overview

This PR excludes soft-deleted API keys from `/api_key.all`

# Changes

- Add `APIKey.query_all/0` for generating a default APIKey query with soft delete excluded.
- Update APIKeyController to use the new `APIKey.query_all/0` instead of `APIKey` directly.
- Bonus: Add tests for /access_key.all

# Implementation Details

I created a new `APIKey.query_all/0` instead of adding `exclude_deleted/0` to the controller so that we don't need to add `exclude_deleted/0` all over the codebase.

# Usage

Make a request to `/api_key.all` should return only API keys that have not been soft deleted.

# Impact

No changes to the DB schema or API specs.