### PR TITLE
Refactor config command to prevent double-argv parsing

### DIFF
--- a/apps/ewallet/lib/ewallet/release_tasks.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks.ex
@@ -114,7 +114,7 @@ defmodule EWallet.ReleaseTasks do
   @config_apps [:activity_logger, :ewallet_config]
 
   def config_base64 do
-    case :init.get_plain_arguments do
+    case :init.get_plain_arguments() do
       [key, value] ->
         config_base64(key, value)
 

--- a/docker-gen.sh
+++ b/docker-gen.sh
@@ -1,15 +1,20 @@
 #!/bin/sh
 
-OPTS=hdi:n:p:k:K:f:
-ARGS=$(getopt $OPTS "$*" 2>/dev/null)
-
 print_usage() {
-    printf "Usage: %s [-%s]\\n" "$0" "$OPTS"
+    printf "Usage: %s [CONFIG..] [OPTS]\\n" "$0"
     printf "\\n"
-    printf "     -h         Print this help.\\n"
-    printf "     -d         Generate a development override.\\n"
+    printf "Generates a Docker-Compose configuration overrides for various\\n"
+    printf "purposes. This script will output to STDOUT, it is expected that\\n"
+    printf "a user will pipe its output into a file. For example:\\n"
     printf "\\n"
-    printf "Config:\\n"
+    printf "     %s > docker-compose.override.yml\\n" "$0"
+    printf "\\n"
+    printf "OPTS:\\n"
+    printf "\\n"
+    printf "     -h         Prints this help.\\n"
+    printf "     -d         Generates a development override.\\n"
+    printf "\\n"
+    printf "CONFIG:\\n"
     printf "\\n"
     printf "     -i image   Specify an alternative eWallet image name.\\n"
     printf "     -n network Specify an external network.\\n"
@@ -20,14 +25,15 @@ print_usage() {
     printf "\\n"
 }
 
+ARGS=$(getopt -s sh hdi:n:p:k:K:f: "$@" 2>/dev/null)
+
 # shellcheck disable=SC2181
 if [ $? != 0 ]; then
     print_usage
     exit 1
 fi
 
-# shellcheck disable=SC2086
-set -- $ARGS
+eval set -- "$ARGS"
 
 IMAGE_NAME=""
 POSTGRES_PASSWORD=""

--- a/rel/commands/config.sh
+++ b/rel/commands/config.sh
@@ -1,4 +1,49 @@
 #!/bin/sh
 
-# shellcheck disable=SC2068
-"$RELEASE_ROOT_DIR/bin/ewallet" command Elixir.EWallet.ReleaseTasks config $@
+print_usage() {
+    printf "Usage: bin/ewallet config [OPTS] KEY VALUE\\n"
+    printf "\\n"
+    printf "Update the eWallet configuration in the database.\\n"
+    printf "\\n"
+    printf "This command uses POSIX sh shell escaping to handle argument\\n"
+    printf "splitting, this means you MUST escape quotes if it was intended\\n"
+    printf "as part of a configuration value. For example:\\n"
+    printf "\\n"
+    printf "     bin/ewallet config example \"{\\\"key\\\": \\\"value\\\"}\"\\n"
+    printf "\\n"
+    printf "Alternatively, use a single quote:\\n"
+    printf "\\n"
+    printf "     bin/ewallet config example '{\"key\": \"value\"}'\\n"
+    printf "\\n"
+    printf "OPTS:\\n"
+    printf "\\n"
+    printf "     -h          Prints this help.\\n"
+    printf "\\n"
+}
+
+ARGS=$(getopt -s sh h "$@" 2>/dev/null)
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    print_usage
+    exit 1
+fi
+
+eval set -- "$ARGS"
+
+while true; do
+    case "$1" in
+        -h ) print_usage; exit 2;;
+        -- ) shift; break;;
+        *  ) break;;
+    esac
+done
+
+# We don't want to deal with argument parsing again in Elixir. No, just no.
+# Let's sidestep all issues by passing the already-parsed value as Base64
+# and let the release task decode it.
+
+KEY="$(printf "%s" "$1" | base64)"; shift
+VALUE="$(printf "%s" "$1" | base64)"; shift
+
+exec "$RELEASE_ROOT_DIR/bin/ewallet" command Elixir.EWallet.ReleaseTasks config_base64 "$KEY" "$VALUE"

--- a/rel/commands/initdb.sh
+++ b/rel/commands/initdb.sh
@@ -1,3 +1,31 @@
 #!/bin/sh
 
-"$RELEASE_ROOT_DIR/bin/ewallet" command Elixir.EWallet.ReleaseTasks initdb
+print_usage() {
+    printf "Usage: bin/ewallet initdb [OPTS]\\n"
+    printf "\\n"
+    printf "Create and upgrade the database.\\n"
+    printf "\\n"
+    printf "OPTS:\\n"
+    printf "\\n"
+    printf "     -h          Prints this help.\\n"
+    printf "\\n"
+}
+
+ARGS=$(getopt -s sh h "$@" 2>/dev/null)
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    print_usage
+    exit 1
+fi
+
+eval set -- "$ARGS"
+
+while true; do
+    case "$1" in
+        -h ) print_usage; exit 2;;
+        *  ) break;;
+    esac
+done
+
+exec "$RELEASE_ROOT_DIR/bin/ewallet" command Elixir.EWallet.ReleaseTasks initdb

--- a/rel/commands/seed.sh
+++ b/rel/commands/seed.sh
@@ -1,10 +1,40 @@
 #!/bin/sh
 
-seed_spec=seed
+print_usage() {
+    printf "Usage: bin/ewallet seed [OPTS]\\n"
+    printf "\\n"
+    printf "Seeds the database with initial data for production, testing\\n"
+    printf "and evaluation purpose. This command does not attempt to\\n"
+    printf "detect whether the database has already been seeded or not and\\n"
+    printf "is expected to be run only once after running initdb.\\n"
+    printf "\\n"
+    printf "OPTS:\\n"
+    printf "\\n"
+    printf "     -h          Prints this help.\\n"
+    printf "     -e --e2e    Seeds the end-to-end testing data.\\n"
+    printf "     -s --sample Seeds the sample data.\\n"
+    printf "\\n"
+}
 
-while [ "$#" -gt 0 ]; do case $1 in
-    -e|--e2e) seed_spec=seed_e2e;;
-    *) echo "$0: illegal option -- $1"; exit 1;;
-esac; shift; done
+ARGS=$(getopt -s sh -l e2e -l sample hes "$@" 2>/dev/null)
 
-"$RELEASE_ROOT_DIR/bin/ewallet" command Elixir.EWallet.ReleaseTasks "${seed_spec}"
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+    print_usage
+    exit 1
+fi
+
+eval set -- "$ARGS"
+
+SEED_SPEC=seed
+
+while true; do
+    case "$1" in
+        -e | --e2e )    SEED_SPEC=seed_e2e; shift;;
+        -s | --sample ) SEED_SPEC=seed_sample; shift;;
+        -h ) print_usage; exit 2;;
+        *  ) break;;
+    esac
+done
+
+exec "$RELEASE_ROOT_DIR/bin/ewallet" command Elixir.EWallet.ReleaseTasks "$SEED_SPEC"

--- a/rootfs/entrypoint
+++ b/rootfs/entrypoint
@@ -66,6 +66,7 @@ s6-env REPLACE_OS_VARS=yes
 ##
 ifelse { test $1 == "initdb" } { /app/bin/ewallet $@ }
 ifelse { test $1 == "seed" } { /app/bin/ewallet $@ }
+ifelse { test $1 == "config" } { /app/bin/ewallet $@ }
 
 ifelse { test $1 == "foreground" } {
   importas -D true SERVE_ENDPOINTS SERVE_ENDPOINTS

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
+
 BASE_DIR=$(cd "$(dirname "$0")" || exit; pwd -P)
 FILE_LIST="/tmp/update_version_files"
 
 if [ -z "$1" ]; then
-    printf "Usage: %s NEW_VERSION\\n\\n" "$0"
+    printf "Usage: %s NEW_VERSION\\n" "$0"
+    printf "\\n"
     printf "Update version string in mix.exs and config.exs with NEW_VERSION\\n"
     printf "by scanning lines with version: string. This script will try its\\n"
     printf "best to retain the indention of the original string.\\n"


### PR DESCRIPTION
Issue/Task Number: #664 

# Overview

Refactor `bin/ewallet config` command to accept shell quoting so that we could pass key and value with space in it (for example, Google Cloud JSON configuration). Note that this require proper shell quoting/escaping:

```
$ bin/ewallet config key "foo bar baz"
```

Will save `foo bar baz` to `key`. If explicit quote string is needed, you will need to use either:

```
$ bin/ewallet config key "\"foo bar baz\""
$ bin/ewallet config key '"foo bar baz"'
```

Which will save `"foo bar baz"` (with quote) to the `key`. Additionally, having space in key is supported in the same way as value although we do not have (or should have) any configuration key with space in it:

```
$ bin/ewallet config "just because you can" "doesn't mean you should"
```

Will save `doesn't mean you should` as `just because you can`.

# Changes

- Refactor the whole shell script involved to have consistent argument parsing.
- Refactor config.sh to properly handle argument splitting and pass it to command as base64.
- Refactor `ReleaseTasks.config` to always accept base64.

# Implementation Details

1. Use `getopt -s sh` to properly parse argument and quote them using sh.
2. Base64 the argument to avoid parsing arguments on Elixir side.
3. Pass it into the new `config_base64` release task.
4. Decode base64 (again, to avoid parsing arguments on Elixir side) and save it to database.

# Bonus stage

* The command now `exec` into release task instead of spawning a subprocess.
* Argument handling is done mostly on the shell script side which means error on Elixir side is now mostly a `give_up` which tell the user to file a bug report (invalid values shouldn't get passed to Elixir side in theory, but theory is theory).
* `bin/ewallet seed` now accepts `--sample` (or use `-s` as a short args) and `bin/ewallet seed`, `bin/ewallet initdb`, `bin/ewallet config` and `./docker-gen.sh` now accepts `-h` which will print a hopefully helpful message. (Surprise, `update-versions.sh` already has it for some reason).
* Wow. Thanks for reading. 