### PR TITLE
Fix test factory inserting roles with conflicting priorities

### DIFF
--- a/apps/ewallet_db/test/support/factory.ex
+++ b/apps/ewallet_db/test/support/factory.ex
@@ -200,7 +200,8 @@ defmodule EWalletDB.Factory do
     %Role{
       name: sequence("role"),
       display_name: "Role display name",
-      priority: sequence(""),
+      # Add a prefix temporarily so ExMachina.sequence/2 plays along nicely
+      priority: "priority" |> sequence() |> String.replace_leading("priority", ""),
       originator: %System{}
     }
   end


### PR DESCRIPTION
Issue/Task Number: #653
Closes #653

# Overview

This PR fixes the random test failure about conflicting role priorities.

# Changes

- Instead of using `sequence("")` in `EWalletDB.Factory.role_factory/0`, use `sequence("priority")` instead and trim the string out later.

# Implementation Details

Looks like `ExMachina.sequence/1` is generating duplicate values, even though it should be incrementing the counter each time. This PR lets the function generate the function with a usual string first then trims the string out later so that `ExMachina.sequence/1` can function properly.

# Usage

`mix test`

# Impact

No changes to DB schema or API specs.