### PR TITLE
Fix settings

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/account_wallet_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_wallet_controller.ex
@@ -20,7 +20,7 @@ defmodule AdminAPI.V1.AccountWalletController do
   import AdminAPI.V1.ErrorHandler
   alias EWallet.WalletPolicy
   alias EWallet.Web.{Orchestrator, BalanceLoader, Paginator, V1.WalletOverlay}
-  alias EWalletDB.{Account, User, Wallet}
+  alias EWalletDB.{Account, Wallet}
 
   def all_for_account_and_users(conn, attrs) do
     do_all(attrs, :accounts_and_users, conn)

--- a/apps/ewallet_config/lib/ewallet_config/setting.ex
+++ b/apps/ewallet_config/lib/ewallet_config/setting.ex
@@ -325,9 +325,7 @@ defmodule EWalletConfig.Setting do
     Map.put(attrs, :data, %{value: value})
   end
 
-  defp cast_value(attrs, _) do
-    Map.put(attrs, :data, %{value: nil})
-  end
+  defp cast_value(attrs, _), do: attrs
 
   defp cast_value(%{secret: true, value: value} = attrs) do
     Map.put(attrs, :encrypted_data, %{value: value})

--- a/apps/ewallet_config/priv/repo/seeds_settings/00_setting.exs
+++ b/apps/ewallet_config/priv/repo/seeds_settings/00_setting.exs
@@ -94,7 +94,7 @@ defmodule EWalletDB.Repo.Seeds.SettingSeed do
   end
 
   defp sync_position(key, %{position: old_pos}, %{position: new_pos}) when is_integer(old_pos) and is_integer(new_pos) and old_pos != new_pos do
-    case Setting.update(key, %{position: new_pos}) do
+    case Setting.update(key, %{position: new_pos, originator: %EWalletDB.Seeder{}}) do
       {:ok, _} -> {:ok, old_pos, new_pos}
       {:error, changeset} -> {:error, changeset}
     end

--- a/apps/ewallet_config/test/ewallet_config/setting_test.exs
+++ b/apps/ewallet_config/test/ewallet_config/setting_test.exs
@@ -330,6 +330,38 @@ defmodule EWalletConfig.SettingTest do
       assert setting.value == "xyz"
     end
 
+    test "updates only the position and leave the value unchanged" do
+      {:ok, _} =
+        Setting.insert(%{
+          key: "my_key",
+          value: "abc",
+          type: "string",
+          position: 1,
+          originator: %System{}
+        })
+
+      {res, setting} = Setting.update("my_key", %{position: 2, originator: %System{}})
+
+      assert res == :ok
+      assert setting.value == "abc"
+      assert setting.position == 2
+    end
+
+    test "can update a value to nil" do
+      {:ok, _} =
+        Setting.insert(%{
+          key: "my_key",
+          value: "abc",
+          type: "string",
+          originator: %System{}
+        })
+
+      {res, setting} = Setting.update("my_key", %{value: nil, originator: %System{}})
+
+      assert res == :ok
+      assert setting.value == nil
+    end
+
     test "fails to update a select setting when the value is invalid" do
       {:ok, _} =
         Setting.insert(%{

--- a/apps/local_ledger/lib/local_ledger/application.ex
+++ b/apps/local_ledger/lib/local_ledger/application.ex
@@ -22,8 +22,8 @@ defmodule LocalLedger.Application do
     import Supervisor.Spec
     DeferredConfig.populate(:local_ledger)
 
-    settings = Application.get_env(:ewallet, :settings)
-    Config.register_and_load(:ewallet, settings)
+    settings = Application.get_env(:local_ledger, :settings)
+    Config.register_and_load(:local_ledger, settings)
 
     children =
       case Application.get_env(:local_ledger, LocalLedger.Scheduler) do


### PR DESCRIPTION
Issue/Task Number: 727
Closes #727 

# Overview

There was some small issues with the settings, this PR fixes them.

# Changes

- Add missing originator when the seed is updating the position
- Fix a bug where the value was lost when the position changes
- Fix a crash when changing the position of a setting with a secret value
- Set the correct application to `local_ledger` when loading the settings for the local ledger

# Implementation Details

The `cast_value(attrs, _)` function in the `Setting` module now returns the given unchanged attributes when there is no `value` provided in the attributes instead of setting the value to `nil`.

# Usage

Running `mix seed` with updated setting position will now work.

# Impact

N/A