### PR TITLE
Fix error reporting in commands.

### DIFF
--- a/rel/commands/config.sh
+++ b/rel/commands/config.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set +e
+
 print_usage() {
     printf "Usage: bin/ewallet config [OPTS] KEY VALUE\\n"
     printf "\\n"
@@ -33,8 +35,9 @@ eval set -- "$ARGS"
 
 while true; do
     case "$1" in
-        -h ) print_usage; exit 2;;
         -- ) shift; break;;
+        -h ) print_usage; exit 2;;
+        -* ) print_usage; exit 1;;
         *  ) break;;
     esac
 done

--- a/rel/commands/initdb.sh
+++ b/rel/commands/initdb.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set +e
+
 print_usage() {
     printf "Usage: bin/ewallet initdb [OPTS]\\n"
     printf "\\n"
@@ -24,6 +26,7 @@ eval set -- "$ARGS"
 while true; do
     case "$1" in
         -h ) print_usage; exit 2;;
+        -* ) print_usage; exit 1;;
         *  ) break;;
     esac
 done

--- a/rel/commands/seed.sh
+++ b/rel/commands/seed.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set +e
+
 print_usage() {
     printf "Usage: bin/ewallet seed [OPTS]\\n"
     printf "\\n"
@@ -33,6 +35,7 @@ while true; do
         -e | --e2e )    SEED_SPEC=seed_e2e; shift;;
         -s | --sample ) SEED_SPEC=seed_sample; shift;;
         -h ) print_usage; exit 2;;
+        -* ) print_usage; exit 1;;
         *  ) break;;
     esac
 done


### PR DESCRIPTION
Fix error reporting in `bin/ewallet` maintenance commands due to `bin/ewallet` script setting `set -e` which make `getopt` exit immediately when given an invalid argument (because we use inredirect checks via `$? != 0` to print help). 