### PR TITLE
Fix regressed bin/ewallet command due to -* matching

### DIFF
--- a/rel/commands/config.sh
+++ b/rel/commands/config.sh
@@ -35,9 +35,8 @@ eval set -- "$ARGS"
 
 while true; do
     case "$1" in
-        -- ) shift; break;;
         -h ) print_usage; exit 2;;
-        -* ) print_usage; exit 1;;
+        -- ) shift; break;;
         *  ) break;;
     esac
 done

--- a/rel/commands/initdb.sh
+++ b/rel/commands/initdb.sh
@@ -26,7 +26,6 @@ eval set -- "$ARGS"
 while true; do
     case "$1" in
         -h ) print_usage; exit 2;;
-        -* ) print_usage; exit 1;;
         *  ) break;;
     esac
 done

--- a/rel/commands/seed.sh
+++ b/rel/commands/seed.sh
@@ -35,7 +35,6 @@ while true; do
         -e | --e2e )    SEED_SPEC=seed_e2e; shift;;
         -s | --sample ) SEED_SPEC=seed_sample; shift;;
         -h ) print_usage; exit 2;;
-        -* ) print_usage; exit 1;;
         *  ) break;;
     esac
 done


### PR DESCRIPTION
The `-* )` matching added in previous commit to (re-)handle argument error is now causing all commands to fail due to how we use `getopt` always result in having `--` for a positional argument, which happens to match `-*` and fail.