### PR TITLE
Bump version to v1.1.0-pre.2

### DIFF
--- a/apps/activity_logger/mix.exs
+++ b/apps/activity_logger/mix.exs
@@ -4,7 +4,7 @@ defmodule ActivityLogger.MixProject do
   def project do
     [
       app: :activity_logger,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/admin_api/mix.exs
+++ b/apps/admin_api/mix.exs
@@ -4,7 +4,7 @@ defmodule AdminAPI.Mixfile do
   def project do
     [
       app: :admin_api,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/admin_panel/mix.exs
+++ b/apps/admin_panel/mix.exs
@@ -4,7 +4,7 @@ defmodule AdminPanel.Mixfile do
   def project do
     [
       app: :admin_panel,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ewallet/config/config.exs
+++ b/apps/ewallet/config/config.exs
@@ -4,7 +4,7 @@ use Mix.Config
 
 config :ewallet,
   ecto_repos: [],
-  version: "1.1.0-pre.0",
+  version: "1.1.0-pre.2",
   settings: [
     :base_url,
     :sender_email,

--- a/apps/ewallet/mix.exs
+++ b/apps/ewallet/mix.exs
@@ -4,7 +4,7 @@ defmodule EWallet.Mixfile do
   def project do
     [
       app: :ewallet,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ewallet_api/mix.exs
+++ b/apps/ewallet_api/mix.exs
@@ -4,7 +4,7 @@ defmodule EWalletAPI.Mixfile do
   def project do
     [
       app: :ewallet_api,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ewallet_config/mix.exs
+++ b/apps/ewallet_config/mix.exs
@@ -4,7 +4,7 @@ defmodule EWalletConfig.MixProject do
   def project do
     [
       app: :ewallet_config,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ewallet_db/mix.exs
+++ b/apps/ewallet_db/mix.exs
@@ -4,7 +4,7 @@ defmodule EWalletDB.Mixfile do
   def project do
     [
       app: :ewallet_db,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/load_tester/mix.exs
+++ b/apps/load_tester/mix.exs
@@ -4,7 +4,7 @@ defmodule LoadTester.MixProject do
   def project do
     [
       app: :load_tester,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/local_ledger/mix.exs
+++ b/apps/local_ledger/mix.exs
@@ -4,7 +4,7 @@ defmodule LocalLedger.Mixfile do
   def project do
     [
       app: :local_ledger,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/local_ledger_db/mix.exs
+++ b/apps/local_ledger_db/mix.exs
@@ -4,7 +4,7 @@ defmodule LocalLedgerDB.Mixfile do
   def project do
     [
       app: :local_ledger_db,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/url_dispatcher/mix.exs
+++ b/apps/url_dispatcher/mix.exs
@@ -4,7 +4,7 @@ defmodule UrlDispatcher.Mixfile do
   def project do
     [
       app: :url_dispatcher,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/utils/mix.exs
+++ b/apps/utils/mix.exs
@@ -4,7 +4,7 @@ defmodule Utils.MixProject do
   def project do
     [
       app: :utils,
-      version: "1.1.0-pre.0",
+      version: "1.1.0-pre.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
Issue/Task Number: #740 
Closes #740 

# Overview

This PR bumps up the version to `pre.2` (which I didn't do for `pre.1` 🙏).

# Changes

- Update all Mixfile's version to `1.1.0-pre.2`

# Implementation Details

N/A

# Usage

N/A

# Impact

None
