### PR TITLE
Fix documentation downloading scripts with the wrong file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ The quickest way to get OmiseGO eWallet Server running on macOS and Linux is to 
 2. Download OmiseGO eWallet Server's [docker-compose.yml](https://raw.githubusercontent.com/omisego/ewallet/master/docker-compose.yml):
 
     ```shell
-    curl -o -sSL https://raw.githubusercontent.com/omisego/ewallet/master/docker-compose.yml
+    curl -O -sSL https://raw.githubusercontent.com/omisego/ewallet/master/docker-compose.yml
     ```
 
 3. Create `docker-compose.override.yml` either [manually](https://docs.docker.com/compose/extends/) or use auto-configuration script:
 
     ```
-    curl -o -sSL https://raw.githubusercontent.com/omisego/ewallet/master/docker-gen.sh
+    curl -O -sSL https://raw.githubusercontent.com/omisego/ewallet/master/docker-gen.sh
     chmod +x docker-gen.sh
     ./docker-gen.sh > docker-compose.override.yml
     ```


### PR DESCRIPTION
Issue/Task Number: #744 
Closes #744

# Overview

This fixes the curl commands in the `README.md` downloading files and saving with the name `-sSL`.

# Changes

- Update curl commands in the `README.md` from `-o` to `-O`

# Implementation Details

N/A

# Usage

Try the commands in the `README.md` again.

# Impact

No changes to the API specs or DB schema.