### PR TITLE
Fix tags building on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,16 +381,24 @@ jobs:
 workflows:
   test_build:
     jobs:
-      - build_test
+      - build_test:
+          filters: &all_branches
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - lint:
           requires:
             - build_test
+          filters: *all_branches
       - test:
           requires:
             - build_test
+          filters: *all_branches
       - dialyze:
           requires:
             - build_test
+          filters: *all_branches
 
       # Non-mainline branches only
       - report:


### PR DESCRIPTION
Closes #742 

Currently tags are not getting built due to tags filter wasn’t being included in the branch filter for non-tag specific steps. This commit fixes that by make sure all tags are matched in non-tag specific steps.