### PR TITLE
Pin v1.1.x to ewallet-builder:v1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   builder:
     docker:
-      - image: omisegoimages/ewallet-builder:stable
+      - image: omisegoimages/ewallet-builder:v1.1
     working_directory: ~/src
     environment:
       IMAGE_NAME: "omisego/ewallet"


### PR DESCRIPTION
Issue/Task Number: #489
Required by #489

# Overview

This PR pins the `v1.1` branch to `omisegoimages/ewallet-builder:v1.1` so that `master` branch can continue with `omisegoimages/ewallet-builder:stable` with an upgraded version of Elixir and etc.

# Changes

- Pin `.circleci/config.yml` to `omisegoimages/ewallet-builder:v1.1`

# Usage

None.

# Impact

CircleCI-related only. And CircleCI should pick up this change automatically.
