### PR TITLE
Fix various `/*.get` endpoints returning error 500 when not provided with `id`

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_controller.ex
@@ -72,6 +72,8 @@ defmodule AdminAPI.V1.AccountController do
     end
   end
 
+  def get(conn, _), do: handle_error(conn, :missing_id)
+
   @doc """
   Creates a new account.
 

--- a/apps/admin_api/lib/admin_api/v1/controllers/account_wallet_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_wallet_controller.ex
@@ -45,6 +45,8 @@ defmodule AdminAPI.V1.AccountWalletController do
     end
   end
 
+  defp do_all(_, _, conn), do: handle_error(conn, :missing_id)
+
   defp prepare_account_uuids(account, true = _owned) do
     [account.uuid]
   end

--- a/apps/admin_api/lib/admin_api/v1/controllers/admin_user_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/admin_user_controller.ex
@@ -50,6 +50,8 @@ defmodule AdminAPI.V1.AdminUserController do
     end
   end
 
+  def get(conn, _), do: handle_error(conn, :missing_id)
+
   @doc """
   Enable or disable a user.
   """

--- a/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/category_controller.ex
@@ -54,6 +54,8 @@ defmodule AdminAPI.V1.CategoryController do
     end
   end
 
+  def get(conn, _), do: handle_error(conn, :missing_id)
+
   @doc """
   Creates a new category.
   """

--- a/apps/admin_api/lib/admin_api/v1/controllers/exchange_pair_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/exchange_pair_controller.ex
@@ -54,6 +54,8 @@ defmodule AdminAPI.V1.ExchangePairController do
     end
   end
 
+  def get(conn, _), do: handle_error(conn, :missing_id)
+
   @doc """
   Creates a new exchange pair.
   """

--- a/apps/admin_api/lib/admin_api/v1/controllers/role_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/role_controller.ex
@@ -54,6 +54,8 @@ defmodule AdminAPI.V1.RoleController do
     end
   end
 
+  def get(conn, _), do: handle_error(conn, :missing_id)
+
   @doc """
   Creates a new role.
   """

--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -148,8 +148,9 @@ defmodule AdminAPI.V1.TokenController do
     end
   end
 
-  def update(conn, _),
-    do: handle_error(conn, :invalid_parameter, "Invalid parameter provided. `id` is required.")
+  def update(conn, _) do
+    handle_error(conn, :invalid_parameter, "Invalid parameter provided. `id` is required.")
+  end
 
   @doc """
   Enable or disable a token.

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_consumption_controller.ex
@@ -143,6 +143,8 @@ defmodule AdminAPI.V1.TransactionConsumptionController do
     end
   end
 
+  def get(conn, _), do: handle_error(conn, :missing_id)
+
   def consume(conn, %{"idempotency_token" => idempotency_token} = attrs)
       when idempotency_token != nil do
     with attrs <- Originator.set_in_attrs(attrs, conn.assigns),

--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_request_controller.ex
@@ -87,6 +87,14 @@ defmodule AdminAPI.V1.TransactionRequestController do
     end
   end
 
+  def get(conn, _),
+    do:
+      handle_error(
+        conn,
+        :invalid_parameter,
+        "Invalid parameter provided. `formatted_id` is required."
+      )
+
   @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def create(conn, attrs) do
     attrs

--- a/apps/admin_api/lib/admin_api/v1/controllers/user_auth_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/user_auth_controller.ex
@@ -51,4 +51,12 @@ defmodule AdminAPI.V1.UserAuthController do
 
     render(conn, :empty_response, %{})
   end
+
+  def logout(conn, _),
+    do:
+      handle_error(
+        conn,
+        :invalid_parameter,
+        "Invalid parameter provided. `auth_token` is required."
+      )
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_controller_test.exs
@@ -112,6 +112,15 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
       assert Enum.count(accounts) == 1
       assert Enum.at(accounts, 0)["name"] == "Account 5"
     end
+
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/account.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
   end
 
   describe "/account.get_descendants" do
@@ -614,6 +623,15 @@ defmodule AdminAPI.V1.AdminAuth.AccountControllerTest do
 
       account = Account.get(account.id)
       assert account.avatar == nil
+    end
+
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/account.upload_avatar", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns 'unauthorized' if the given account ID was not found" do

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/account_wallet_controller_test.exs
@@ -163,6 +163,15 @@ defmodule AdminAPI.V1.AdminAuth.AccountWalletControllerTest do
       assert Enum.member?(wallets, {account_3.id, "secondary_3"})
       assert Enum.member?(wallets, {account_3.id, "secondary_4"})
     end
+
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/account.get_wallets_and_user_wallets", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
   end
 
   describe "/account.get_wallets" do
@@ -304,6 +313,15 @@ defmodule AdminAPI.V1.AdminAuth.AccountWalletControllerTest do
       assert Enum.member?(wallets, {account_2.id, "secondary_2"})
       assert Enum.member?(wallets, {account_3.id, "secondary_3"})
       assert Enum.member?(wallets, {account_3.id, "secondary_4"})
+    end
+
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/account.get_wallets", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
     end
   end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/admin_user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/admin_user_controller_test.exs
@@ -156,6 +156,15 @@ defmodule AdminAPI.V1.AdminAuth.AdminUserControllerTest do
       assert response["data"]["email"] == admin.email
     end
 
+    test "returns 'client:invalid_parameter' error when id is not given" do
+      response = admin_user_request("/account.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns 'user:id_not_found' if the given ID is not an admin" do
       {:ok, user} = :user |> params_for() |> User.insert()
       response = admin_user_request("/admin.get", %{"id" => user.id})

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/category_controller_test.exs
@@ -76,6 +76,15 @@ defmodule AdminAPI.V1.AdminAuth.CategoryControllerTest do
       assert response["data"]["name"] == target.name
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/category.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns 'category:id_not_found' if the given ID was not found" do
       response = admin_user_request("/category.get", %{"id" => "cat_12345678901234567890123456"})
 

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/exchange_pair_controller_test.exs
@@ -75,6 +75,15 @@ defmodule AdminAPI.V1.AdminAuth.ExchangePairControllerTest do
       assert response["data"]["id"] == target.id
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/exchange_pair.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns 'exchange:pair_id_not_found' if the given ID was not found" do
       response =
         admin_user_request("/exchange_pair.get", %{"id" => "exg_12345678901234567890123456"})

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/role_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/role_controller_test.exs
@@ -75,6 +75,15 @@ defmodule AdminAPI.V1.AdminAuth.RoleControllerTest do
       assert response["data"]["name"] == target.name
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/role.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns 'role:id_not_found' if the given ID was not found" do
       response = admin_user_request("/role.get", %{"id" => "rol_12345678901234567890123456"})
 

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_consumption_controller_test.exs
@@ -770,6 +770,15 @@ defmodule AdminAPI.V1.AdminAuth.TransactionConsumptionControllerTest do
       assert response["data"]["id"] == transaction_consumption.id
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/transaction_consumption.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns an error when the consumption ID is not found" do
       response =
         admin_user_request("/transaction_consumption.get", %{

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/transaction_request_controller_test.exs
@@ -598,6 +598,17 @@ defmodule AdminAPI.V1.AdminAuth.TransactionRequestControllerTest do
       assert response["data"]["id"] == transaction_request.id
     end
 
+    test "returns :invalid_parameter error when formatted_id is not given" do
+      response = admin_user_request("/transaction_request.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. `formatted_id` is required."
+    end
+
     test "returns an error when the request ID is not found" do
       response =
         admin_user_request("/transaction_request.get", %{

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth/user_auth_controller_test.exs
@@ -156,6 +156,17 @@ defmodule AdminAPI.V1.AdminAuth.UserAuthControllerTest do
       assert response["data"] == %{}
     end
 
+    test "returns :invalid_parameter error when auth_token is not given" do
+      response = admin_user_request("/user.logout", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. `auth_token` is required."
+    end
+
     test "generates activity logs" do
       _user = insert(:user, %{provider_user_id: "1234"})
       admin_user_request("/user.login", %{provider_user_id: "1234"})

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/account_controller_test.exs
@@ -73,6 +73,15 @@ defmodule AdminAPI.V1.ProviderAuth.AccountControllerTest do
       assert response["data"]["name"] == target.name
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = provider_request("/account.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     # The user should not know any information about the account it doesn't have access to.
     # So even the account is not found, the user is unauthorized to know that.
     test "returns 'unauthorized' if the given ID is in correct format but not found" do
@@ -400,6 +409,15 @@ defmodule AdminAPI.V1.ProviderAuth.AccountControllerTest do
 
       account = Account.get(account.id)
       assert account.avatar == nil
+    end
+
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/account.upload_avatar", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided."
     end
 
     test "returns 'unauthorized' if the given account ID was not found" do

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/admin_user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/admin_user_controller_test.exs
@@ -157,6 +157,15 @@ defmodule AdminAPI.V1.ProviderAuth.AdminControllerTest do
       assert response["data"]["email"] == admin.email
     end
 
+    test "returns 'client:invalid_parameter' error when id is not given" do
+      response = provider_request("/account.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns 'unauthorized' if the given ID is not an admin" do
       {:ok, user} = :user |> params_for() |> User.insert()
       response = provider_request("/admin.get", %{"id" => user.id})

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/category_controller_test.exs
@@ -76,6 +76,15 @@ defmodule AdminAPI.V1.ProviderAuth.CategoryControllerTest do
       assert response["data"]["name"] == target.name
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = provider_request("/category.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns 'category:id_not_found' if the given ID was not found" do
       response = provider_request("/category.get", %{"id" => "cat_12345678901234567890123456"})
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/exchange_pair_controller_test.exs
@@ -74,6 +74,15 @@ defmodule AdminAPI.V1.ProviderAuth.ExchangePairControllerTest do
       assert response["data"]["id"] == target.id
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/exchange_pair.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns 'exchange:pair_id_not_found' if the given ID was not found" do
       response =
         provider_request("/exchange_pair.get", %{"id" => "exg_12345678901234567890123456"})

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/role_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/role_controller_test.exs
@@ -75,6 +75,15 @@ defmodule AdminAPI.V1.ProviderAuth.RoleControllerTest do
       assert response["data"]["name"] == target.name
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = provider_request("/role.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns 'role:id_not_found' if the given ID was not found" do
       response = provider_request("/role.get", %{"id" => "rol_12345678901234567890123456"})
 

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_consumption_controller_test.exs
@@ -744,6 +744,15 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionConsumptionControllerTest do
       assert response["data"]["id"] == transaction_consumption.id
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = provider_request("/transaction_consumption.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided. `id` is required."
+    end
+
     test "returns an error when the request ID is not found" do
       response =
         provider_request("/transaction_consumption.get", %{

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/transaction_request_controller_test.exs
@@ -426,6 +426,17 @@ defmodule AdminAPI.V1.ProviderAuth.TransactionRequestControllerTest do
       assert response["data"]["id"] == transaction_request.id
     end
 
+    test "returns :invalid_parameter error when formatted_id is not given" do
+      response = admin_user_request("/transaction_request.get", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. `formatted_id` is required."
+    end
+
     test "returns an error when the request ID is not found" do
       response =
         provider_request("/transaction_request.get", %{

--- a/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/provider_auth/user_auth_controller_test.exs
@@ -156,6 +156,17 @@ defmodule AdminAPI.V1.ProviderAuth.UserAuthControllerTest do
       assert response["data"] == %{}
     end
 
+    test "returns :invalid_parameter error when auth_token is not given" do
+      response = provider_request("/user.logout", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. `auth_token` is required."
+    end
+
     test "generates activity logs" do
       _user = insert(:user, %{provider_user_id: "1234"})
       admin_user_request("/user.login", %{provider_user_id: "1234"})

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -33,6 +33,10 @@ defmodule EWallet.Web.V1.ErrorHandler do
       template:
         "Invalid parameter provided. The queried field is not allowed. Given: '%{field_name}'."
     },
+    missing_id: %{
+      code: "client:invalid_parameter",
+      description: "Invalid parameter provided. `id` is required."
+    },
     missing_master_account: %{
       code: "account:missing_master_account",
       description: "Unable to find the master account."

--- a/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_controller.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/controllers/transaction_request_controller.ex
@@ -46,6 +46,14 @@ defmodule EWalletAPI.V1.TransactionRequestController do
     end
   end
 
+  def get(conn, _) do
+    handle_error(
+      conn,
+      :invalid_parameter,
+      "Invalid parameter provided. `formatted_id` is required."
+    )
+  end
+
   defp respond({:error, error}, conn) when is_atom(error), do: handle_error(conn, error)
 
   defp respond({:error, changeset}, conn) do

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -341,7 +341,7 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
     end
 
     test "returns :invalid_parameter error when id is not given" do
-      response = admin_user_request("/me.get_transaction_request", %{})
+      response = client_request("/me.get_transaction_request", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/transaction_request_controller_test.exs
@@ -340,6 +340,17 @@ defmodule EWalletAPI.V1.TransactionRequestControllerTest do
       assert response["data"]["id"] == transaction_request.id
     end
 
+    test "returns :invalid_parameter error when id is not given" do
+      response = admin_user_request("/me.get_transaction_request", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. `formatted_id` is required."
+    end
+
     test "returns an error when the request ID is not found" do
       response =
         client_request("/me.get_transaction_request", %{


### PR DESCRIPTION
Issue/Task Number: #755 
Closes #755

# Overview

This PR adds input handling for when `id` is not provided to various `/*.get` endpoints.

⚠️ **This PR add/edit the controller tests. This will require migrating these tests manually to the unified controller tests on master branch.**

# Changes

- Add a `handle_error(conn, :missing_id)` or `handle_error(conn, :invalid_parameter, _)` to missing controller fallbacks.

# Implementation Details

Some older code seems to be missing a fallback for when `id` is not provided.

Note that there are still some inconsistency in how error messages are returned. Some endpoints would return simply `"Invalid parameter provided."`, while some others would return ``"Invalid parameter provided. `id` is required."``

But these inconsistencies are a cosmetic issue, since providers should not be parsing the plaintext description and there are a lot of places that can be improved. Will open a separate ticket for this.

# Usage

Try, for example, `/account.get_wallets` without providing an id. It should return a proper error response. E.g.

```
curl 'http://localhost:4000/api/admin/account.get_wallets' \
-H 'Authorization: OMGAdmin <truncated>' \
-H 'Content-Type: application/json;charset=UTF-8' \
-H 'Accept: application/vnd.omisego.v1+json' \
-d '{"per_page":10,"sort_by":"identifier","sort_dir":"desc","owned":true}'
```

# Impact

No changes to the API specs or DB schema.