### PR TITLE
Fix ewallet-builder tag on v1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
   test:
     executor: builder
     docker:
-      - image: omisegoimages/ewallet-builder:stable
+      - image: omisegoimages/ewallet-builder:v1.1
       - image: postgres:9.6-alpine
     steps:
       - checkout
@@ -333,7 +333,7 @@ jobs:
                 --init \
                 --network net0 \
                 --volumes-from srcs \
-              omisegoimages/ewallet-builder:stable \
+              omisegoimages/ewallet-builder:v1.1 \
               sh -c "cd /src/e2e && pipenv install && pipenv run robot tests"
       - notify_slack_failure
 


### PR DESCRIPTION
Issue/Task Number: -

# Overview

This PR fixes the circleci config referring to `ewallet-builder:stable` which is now running Elixir 1.8 image.

# Changes

- Updated circleci config to use `ewallet-builder:v1.1`

# Implementation Details

Downgrading to `ewallet-builder:stable` to pin ewallet v1.1 branch to `ewallet-builder:v1.1` for good.

# Usage

N/A

# Impact

CircleCI only.