### PR TITLE
Fix wrongly merged controller tests

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
@@ -118,8 +118,8 @@ defmodule AdminAPI.V1.AccountControllerTest do
       assert Enum.at(accounts, 0)["name"] == "Account 5"
     end
 
-    test "returns :invalid_parameter error when id is not given" do
-      response = admin_user_request("/account.get", %{})
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/account.get", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
@@ -699,8 +699,8 @@ defmodule AdminAPI.V1.AccountControllerTest do
       assert account.avatar == nil
     end
 
-    test "returns :invalid_parameter error when id is not given" do
-      response = admin_user_request("/account.upload_avatar", %{})
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/account.upload_avatar", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/account_wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_wallet_controller_test.exs
@@ -163,8 +163,8 @@ defmodule AdminAPI.V1.AccountWalletControllerTest do
       assert Enum.member?(wallets, {account_3.id, "secondary_4"})
     end
 
-    test "returns :invalid_parameter error when id is not given" do
-      response = admin_user_request("/account.get_wallets_and_user_wallets", %{})
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/account.get_wallets_and_user_wallets", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"
@@ -314,8 +314,8 @@ defmodule AdminAPI.V1.AccountWalletControllerTest do
       assert Enum.member?(wallets, {account_3.id, "secondary_4"})
     end
 
-    test "returns :invalid_parameter error when id is not given" do
-      response = admin_user_request("/account.get_wallets", %{})
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/account.get_wallets", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_user_controller_test.exs
@@ -156,8 +156,8 @@ defmodule AdminAPI.V1.AdminUserControllerTest do
       assert response["data"]["email"] == admin.email
     end
 
-    test "returns 'client:invalid_parameter' error when id is not given" do
-      response = admin_user_request("/account.get", %{})
+    test_with_auths "returns 'client:invalid_parameter' error when id is not given" do
+      response = request("/account.get", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/category_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/category_controller_test.exs
@@ -76,8 +76,8 @@ defmodule AdminAPI.V1.CategoryControllerTest do
       assert response["data"]["name"] == target.name
     end
 
-    test "returns :invalid_parameter error when id is not given" do
-      response = admin_user_request("/category.get", %{})
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/category.get", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/exchange_pair_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/exchange_pair_controller_test.exs
@@ -75,8 +75,8 @@ defmodule AdminAPI.V1.ExchangePairControllerTest do
       assert response["data"]["id"] == target.id
     end
 
-    test "returns :invalid_parameter error when id is not given" do
-      response = admin_user_request("/exchange_pair.get", %{})
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/exchange_pair.get", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/role_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/role_controller_test.exs
@@ -75,8 +75,8 @@ defmodule AdminAPI.V1.RoleControllerTest do
       assert response["data"]["name"] == target.name
     end
 
-    test "returns :invalid_parameter error when id is not given" do
-      response = provider_request("/role.get", %{})
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/role.get", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/transaction_consumption_controller_test.exs
@@ -770,8 +770,8 @@ defmodule AdminAPI.V1.TransactionConsumptionControllerTest do
       assert response["data"]["id"] == transaction_consumption.id
     end
 
-    test "returns :invalid_parameter error when id is not given" do
-      response = admin_user_request("/transaction_consumption.get", %{})
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/transaction_consumption.get", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/transaction_request_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/transaction_request_controller_test.exs
@@ -637,8 +637,8 @@ defmodule AdminAPI.V1.TransactionRequestControllerTest do
       assert response["data"]["id"] == transaction_request.id
     end
 
-    test "returns :invalid_parameter error when formatted_id is not given" do
-      response = admin_user_request("/transaction_request.get", %{})
+    test_with_auths "returns :invalid_parameter error when formatted_id is not given" do
+      response = request("/transaction_request.get", %{})
 
       refute response["success"]
       assert response["data"]["object"] == "error"

--- a/apps/admin_api/test/admin_api/v1/controllers/user_auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/user_auth_controller_test.exs
@@ -177,6 +177,17 @@ defmodule AdminAPI.V1.UserAuthControllerTest do
       assert response["data"] == %{}
     end
 
+    test_with_auths "returns :invalid_parameter error when auth_token is not given" do
+      response = request("/user.logout", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "Invalid parameter provided. `auth_token` is required."
+    end
+
     defp assert_logout_logs(logs, originator, target) do
       assert Enum.count(logs) == 1
 
@@ -212,17 +223,6 @@ defmodule AdminAPI.V1.UserAuthControllerTest do
       timestamp
       |> get_all_activity_logs_since()
       |> assert_logout_logs(get_test_admin(), auth_token)
-    end
-
-    test "returns :invalid_parameter error when auth_token is not given" do
-      response = provider_request("/user.logout", %{})
-
-      refute response["success"]
-      assert response["data"]["object"] == "error"
-      assert response["data"]["code"] == "client:invalid_parameter"
-
-      assert response["data"]["description"] ==
-               "Invalid parameter provided. `auth_token` is required."
     end
 
     test "generates activity logs for a provider request" do


### PR DESCRIPTION
Issue/Task Number: 784
Closes #784 

# Overview

This PR fixes some controller tests that was merged without using the new `test_with_auths` macro.

# Changes

- Use `test_with_auths` where required

# Implementation Details

N/A

# Usage

Run tests

# Impact

N/A