### PR TITLE
Update docker-gen.sh to use omisego/ewallet:stable after v1.1.0 release

### DIFF
--- a/docker-gen.sh
+++ b/docker-gen.sh
@@ -64,7 +64,7 @@ if [ -z "$IMAGE_NAME" ]; then
    if [ $DEV_MODE = 1 ]; then
        IMAGE_NAME="omisegoimages/ewallet-builder:v1.2"
    else
-       IMAGE_NAME="omisego/ewallet:v1.1-dev"
+       IMAGE_NAME="omisego/ewallet:stable"
    fi
 fi
 


### PR DESCRIPTION
Issue/Task Number: #775 
Requires #788

# Overview

Updates docker-gen.sh to point to `omisego/ewallet:stable` now that v1.1.0 is the new stable.

⚠️ **Need to wait for the latest stable build to appear on [omisego/ewallet dockerhub](https://hub.docker.com/r/omisego/ewallet/tags) before merging.**

# Changes

Updated `docker-gen.sh` to generate override that points to the stable docker tag.

# Implementation Details

N/A

# Usage

N/A

# Impact

N/A