### PR TITLE
Hotfix invite page broken

### DIFF
--- a/apps/admin_panel/assets/src/omg-invite-form/index.js
+++ b/apps/admin_panel/assets/src/omg-invite-form/index.js
@@ -37,7 +37,13 @@ const Error = styled.div`
   transition: 0.5s ease max-height, 0.3s ease opacity;
 `
 
-const enhance = compose(withRouter, connect(null, { createUser }))
+const enhance = compose(
+  withRouter,
+  connect(
+    null,
+    { createUser }
+  )
+)
 class ForgetPasswordForm extends Component {
   static propTypes = {
     location: PropTypes.object.isRequired,
@@ -59,29 +65,39 @@ class ForgetPasswordForm extends Component {
   }
   onSubmit = async e => {
     e.preventDefault()
-    const { email, token } = queryString.parse(this.props.location.search)
-    const newPasswordError = !this.validatePassword(this.state.newPassword)
-    const reEnteredNewPasswordError = !this.validateReEnteredNewPassword(
-      this.state.newPassword,
-      this.state.reEnteredNewPassword
-    )
-    this.setState({
-      newPasswordError,
-      reEnteredNewPasswordError,
-      submitStatus: !newPasswordError && !reEnteredNewPasswordError ? 'SUBMITTED' : null
-    })
-    if (!newPasswordError && !reEnteredNewPasswordError) {
-      const result = await this.props.createUser({
-        email,
-        resetToken: token,
-        password: this.state.newPassword,
-        passwordConfirmation: this.state.reEnteredNewPassword
+    try {
+      const { email, token } = queryString.parse(this.props.location.search)
+      const newPasswordError = !this.validatePassword(this.state.newPassword)
+      const reEnteredNewPasswordError = !this.validateReEnteredNewPassword(
+        this.state.newPassword,
+        this.state.reEnteredNewPassword
+      )
+      this.setState({
+        newPasswordError,
+        reEnteredNewPasswordError,
+        submitStatus: !newPasswordError && !reEnteredNewPasswordError ? 'SUBMITTED' : null
       })
-      if (result.data.success) {
-        this.setState({ submitStatus: 'SUCCESS' })
-      } else {
-        this.setState({ submitStatus: 'FAILED', submitErrorText: result.data.data.code })
+      if (!newPasswordError && !reEnteredNewPasswordError) {
+        const result = await this.props.createUser({
+          email,
+          resetToken: token,
+          password: this.state.newPassword,
+          passwordConfirmation: this.state.reEnteredNewPassword
+        })
+        if (result.data) {
+          this.setState({ submitStatus: 'SUCCESS' })
+        } else {
+          this.setState({
+            submitStatus: 'FAILED',
+            submitErrorText: _.get(result, 'error.code', 'Invite Failed.')
+          })
+        }
       }
+    } catch (error) {
+      this.setState({
+        submitStatus: 'FAILED',
+        submitErrorText: 'Something went wrong.'
+      })
     }
   }
   onNewPasswordInputChange = e => {

--- a/apps/admin_panel/assets/src/omg-invite-form/index.js
+++ b/apps/admin_panel/assets/src/omg-invite-form/index.js
@@ -89,14 +89,15 @@ class ForgetPasswordForm extends Component {
         } else {
           this.setState({
             submitStatus: 'FAILED',
-            submitErrorText: _.get(result, 'error.code', 'Invite Failed.')
+            submitErrorText:
+              _.get(result, 'error.code') || _.get(result, 'error.message') || 'Invite Failed.'
           })
         }
       }
     } catch (error) {
       this.setState({
         submitStatus: 'FAILED',
-        submitErrorText: 'Something went wrong.'
+        submitErrorText: _.get(error, 'message', 'Something went wrong.')
       })
     }
   }


### PR DESCRIPTION
Issue/Task Number: - 

# Overview

Unfortunately from some refactoring, the invite error handling breaks. This PR fixes it.

# Changes

- Fix error handling.

# Implementation Details

Due to factoring, we changed how data returns from action. when success it will return `data` if not it will return a error as `error` object so we handle it accordingly.

# Usage

Try inviting someone in.

# Impact

We probably need to deploy a new stable version for this hot fix.
