### PR TITLE
Remove ability to configure NODE_NAME

### DIFF
--- a/apps/ewallet_api/config/prod.exs
+++ b/apps/ewallet_api/config/prod.exs
@@ -8,7 +8,7 @@ config :ewallet_api, EWalletAPI.V1.Endpoint,
 config :peerage,
   via: Peerage.Via.Dns,
   dns_name: {:system, "NODE_DNS", "localhost"},
-  app_name: {:system, "NODE_NAME", "ewallet"}
+  app_name: "ewallet"
 
 # For production, we often load configuration from external
 # sources, such as your system environment. For this reason,

--- a/docs/setup/advanced/clustering.md
+++ b/docs/setup/advanced/clustering.md
@@ -5,7 +5,7 @@
 Some feature such as WebSockets require that Erlang nodes are connected. We support automatic clustering via DNS in `prod` environment using [Peerage](https://github.com/mrluc/peerage). To use automatic clustering, you must run the application in the following manner (in additional to standard configuration):
 
 ```
-$ env MIX_ENV=prod ODE_DNS=ewallet.default.svc.cluster.local \
+$ env MIX_ENV=prod NODE_DNS=ewallet.default.svc.cluster.local \
   elixir \
     --erl '-kernel inet_dist_listen_min 6900' \
     --erl '-kernel inet_dist_listen_max 6909' \

--- a/docs/setup/advanced/clustering.md
+++ b/docs/setup/advanced/clustering.md
@@ -1,11 +1,11 @@
 # Clustering
 
-__Note: This is experimental and is subjected to change.__
+**Note: This is experimental and is subjected to change.**
 
 Some feature such as WebSockets require that Erlang nodes are connected. We support automatic clustering via DNS in `prod` environment using [Peerage](https://github.com/mrluc/peerage). To use automatic clustering, you must run the application in the following manner (in additional to standard configuration):
 
 ```
-$ env MIX_ENV=prod NODE_NAME=ewallet NODE_DNS=ewallet.default.svc.cluster.local \
+$ env MIX_ENV=prod ODE_DNS=ewallet.default.svc.cluster.local \
   elixir \
     --erl '-kernel inet_dist_listen_min 6900' \
     --erl '-kernel inet_dist_listen_max 6909' \
@@ -16,16 +16,15 @@ $ env MIX_ENV=prod NODE_NAME=ewallet NODE_DNS=ewallet.default.svc.cluster.local 
 
 The following environment variables are being used:
 
-* `MIX_ENV=prod` -- automatic clustering is only configured for production
-* `NODE_NAME=ewallet` -- name of the node, usually "ewallet"
-* `NODE_DNS=ewallet.default.svc.cluster.local` -- dns name to discover nodes (you have to change this)
+-   `MIX_ENV=prod` -- automatic clustering is only configured for production
+-   `NODE_DNS=ewallet.default.svc.cluster.local` -- dns name to discover nodes (you have to change this)
 
 The following options are being used:
 
-* `--erl '-kernel inet_dist_listen_min 6900'` -- min port for erlang to connect to nodes
-* `--erl '-kernel inet_dist_listen_max 6909'` -- max port for erlang to connect to nodes
-* `--name ewallet@127.0.0.1` -- name of the node, must be `NODE_NAME@NODE_HOST` (hostname or ip)
-* `--cookie secure_random_string` -- secure and random string used for node authentication
+-   `--erl '-kernel inet_dist_listen_min 6900'` -- min port for erlang to connect to nodes
+-   `--erl '-kernel inet_dist_listen_max 6909'` -- max port for erlang to connect to nodes
+-   `--name ewallet@127.0.0.1` -- name of the node, must be `ewallet@NODE_HOST` (hostname or ip)
+-   `--cookie secure_random_string` -- secure and random string used for node authentication
 
 Additionally, you will have to make sure that port `4369` and ports in the `inet_dist_listen_min` and `inet_dist_listen_max` range are accessible via firewall in order to allow nodes to communicate with each other.
 
@@ -33,8 +32,8 @@ Additionally, you will have to make sure that port `4369` and ports in the `inet
 
 The official Docker image has automatic clustering support built-in. You will need to set the following environment variables:
 
-* `NODE_DNS` -- dns name to discover nodes (e.g. [Kubernetes service DNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/))
-* `NODE_HOST` -- host name or ip address of the current container (e.g. Kubernetes Pod IP)
+-   `NODE_DNS` -- dns name to discover nodes (e.g. [Kubernetes service DNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/))
+-   `NODE_HOST` -- host name or ip address of the current container (e.g. Kubernetes Pod IP)
 
 In Kubernetes, this can be done by adding the following to `spec.template.spec.containers[*].env[*]` (assuming eWallet service is created as "ewallet"):
 

--- a/rootfs/entrypoint
+++ b/rootfs/entrypoint
@@ -6,7 +6,7 @@ s6-setuidgid ewallet
 
 ## NODE_HOST
 ##
-## Used in clustering; combine with NODE_NAME, this is used for identifying
+## Used in clustering; combine with an app name, this is used for identifying
 ## and connecting each nodes. By default use the container hostname.
 ##
 backtick -n default_host { s6-hostname }
@@ -29,14 +29,6 @@ backtick -n default_cookie {
 importas -iu default_cookie default_cookie
 importas -D $default_cookie ERLANG_COOKIE ERLANG_COOKIE
 s6-env ERLANG_COOKIE=$ERLANG_COOKIE
-
-## NODE_NAME
-##
-## Used in clustering; NODE_NAME along with NODE_HOST are used for identifying
-## and connecting each nodes. By default use "ewallet".
-##
-importas -D ewallet NODE_NAME NODE_NAME
-s6-env NODE_NAME=$NODE_NAME
 
 ## NODE_DNS
 ##


### PR DESCRIPTION
Closes #791 

We're no longer using `NODE_NAME` to set the name of an application for clustering (since in `vm.args` we now use a release name, which is "ewallet") so this PR remove all mentions of NODE_NAME and fix potential clustering but if NODE_NAME were happened to be set.