### PR TITLE
Always restart Goth on settings load

### DIFF
--- a/apps/ewallet_config/lib/ewallet_config/config.ex
+++ b/apps/ewallet_config/lib/ewallet_config/config.ex
@@ -107,8 +107,6 @@ defmodule EWalletConfig.Config do
   end
 
   defp reload_registered_apps(registered_apps) do
-    GenServer.call(EWalletConfig.FileStorageSupervisor, :stop_goth)
-
     Enum.each(registered_apps, fn {app, settings} ->
       SettingLoader.load_settings(app, settings)
     end)

--- a/apps/ewallet_config/lib/ewallet_config/loaders/file_storage_settings_loader.ex
+++ b/apps/ewallet_config/lib/ewallet_config/loaders/file_storage_settings_loader.ex
@@ -65,6 +65,7 @@ defmodule EWalletConfig.FileStorageSettingsLoader do
     Application.put_env(:arc, :bucket, gcs_bucket)
     Application.put_env(:goth, :json, gcs_credentials)
 
+    _ = GenServer.call(EWalletConfig.FileStorageSupervisor, :stop_goth)
     {:ok, _pid} = GenServer.call(EWalletConfig.FileStorageSupervisor, :start_goth)
   end
 


### PR DESCRIPTION
Fix an issue where Goth fail to load credentials on application start due to Goth app has already been started and env never got populated there.