### PR TITLE
Fix settings being loaded before all settings are refreshed.

### DIFF
--- a/apps/ewallet_config/lib/ewallet_config/config.ex
+++ b/apps/ewallet_config/lib/ewallet_config/config.ex
@@ -107,6 +107,8 @@ defmodule EWalletConfig.Config do
   end
 
   defp reload_registered_apps(registered_apps) do
+    GenServer.call(EWalletConfig.FileStorageSupervisor, :stop_goth)
+
     Enum.each(registered_apps, fn {app, settings} ->
       SettingLoader.load_settings(app, settings)
     end)

--- a/apps/ewallet_config/lib/ewallet_config/loaders/file_storage_settings_loader.ex
+++ b/apps/ewallet_config/lib/ewallet_config/loaders/file_storage_settings_loader.ex
@@ -65,7 +65,6 @@ defmodule EWalletConfig.FileStorageSettingsLoader do
     Application.put_env(:arc, :bucket, gcs_bucket)
     Application.put_env(:goth, :json, gcs_credentials)
 
-    _ = GenServer.call(EWalletConfig.FileStorageSupervisor, :stop_goth)
     {:ok, _pid} = GenServer.call(EWalletConfig.FileStorageSupervisor, :start_goth)
   end
 

--- a/apps/ewallet_config/lib/ewallet_config/setting_loader.ex
+++ b/apps/ewallet_config/lib/ewallet_config/setting_loader.ex
@@ -29,8 +29,12 @@ defmodule EWalletConfig.SettingLoader do
 
     Enum.each(settings, fn key ->
       load_setting(app, key, stored_settings)
+    end)
 
-      # Do specific settings loader if defined.
+    # After loading all the settings, loop through one more time to apply
+    # specific settings loaders, if defined. This has to be a separate loop from above
+    # to make sure that loaders get latest values for all dependent settings.
+    Enum.each(settings, fn key ->
       case Map.fetch(@settings_to_loaders, key) do
         {:ok, loader_module} -> loader_module.load(app)
         _ -> :noop


### PR DESCRIPTION
Issue/Task Number: #795 
Closes #795 

# Overview

Fixes settings loader not waiting for all settings to be refreshed before the specific loaders begin.

This causes the file adapter settings loader to use stale values for `gcs_*` and `aws_*` settings.

# Changes

- Reverted #793 as that did not fix the issue
- Separated settings value loading and the specific loader loop so that settings are always fully populated first.

# Implementation Details

This is a bug introduced by #777 where the way specific loaders get triggered was changed. The specific loaders were moved into the same loop as settings loader and thus means that it gets triggered before all its dependent settings were populated. For example:

**Before #777:**

```elixir
config :ewallet_db,
  settings: [
    :base_url,
    :min_password_length,
    :file_storage_adapter,
    :aws_bucket,
    :aws_region,
    :aws_access_key_id,
    :aws_secret_access_key,
    :gcs_bucket,
    :gcs_credentials
  ]
```

```elixir
Enum.each(settings, fn key ->
  load_setting(app, key, stored_settings)
end)

if Enum.member?(settings, :file_storage_adapter) do
  FileStorageSettingsLoader.load(app)
end
```

Translates to:

1. `:file_storage_adapter` gets updated
2. `:gcs_/aws_*` get updated
3. `*Loader.load()` is triggered

Above worked fine because the specific loader always get called after the settings loader.

**After #777:**

```elixir
Enum.each(settings, fn key ->
  load_setting(app, key, stored_settings)

  # Do specific settings loader if defined.
  case Map.fetch(@settings_to_loaders, key) do
    {:ok, loader_module} -> loader_module.load(app)
    _ -> :noop
  end
end)
```

Translates to:

1. `:file_storage_adapter` is updated
2. `*Loader.load(app)` is triggered
2. `:gcs_/aws_*` are updated

Hence the upload failure from file storage settings not being populated & loaded in the correct oder.

# Usage

Try from admin panel:

1. Set file storage adapter to a cloud adapter and set its values
2. Change a user's avatar -> the avatar should be set successfully
3. Change an account's avatar -> the avatar should be set successfully
4. Create a transaction export -> the export should be successful and downloadable.

# Impact

No DB schema or API spec changes.

This PR will be applied to `v1.1` as well as port to `master`.