### PR TITLE
Fix Goth strange behavior

### DIFF
--- a/apps/admin_api/config/config.exs
+++ b/apps/admin_api/config/config.exs
@@ -11,7 +11,14 @@ config :admin_api,
   ecto_repos: [],
   settings: [
     :sender_email,
-    :file_storage_adapter
+    :file_storage_adapter,
+    :aws_access_key_id,
+    :aws_secret_access_key,
+    :aws_region,
+    :aws_bucket,
+    :file_storage_adapter,
+    :gcs_bucket,
+    :gcs_credentials
   ]
 
 # Configs for the endpoint


### PR DESCRIPTION
__This shouldn't be merged into v1.1.__

Issue/Task Number: #801 
closes #801

# Overview

Not having the file storage settings in the Admin API was initializing them at `nil`, breaking the boot for GCS.


