### PR TITLE
Improve configuration validation

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
@@ -116,6 +116,98 @@ defmodule AdminAPI.V1.ConfigurationControllerTest do
              }
     end
 
+    test_with_auths "updates nil for all unsigned_integer settings", context do
+      response =
+        request("/configuration.update", %{
+          max_per_page: nil,
+          min_password_length: nil,
+          forget_password_request_lifetime: nil,
+          balance_caching_reset_frequency: nil,
+          config_pid: context[:config_pid]
+        })
+
+      assert response["success"] == true
+      data = response["data"]["data"]
+
+      assert data["max_per_page"] == %{
+               "code" => "client:invalid_parameter",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "messages" => %{"value" => ["invalid_type_for_value"]},
+               "object" => "error"
+             }
+
+      assert data["min_password_length"] == %{
+               "code" => "client:invalid_parameter",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "messages" => %{"value" => ["invalid_type_for_value"]},
+               "object" => "error"
+             }
+
+      assert data["forget_password_request_lifetime"] == %{
+               "code" => "client:invalid_parameter",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "messages" => %{"value" => ["invalid_type_for_value"]},
+               "object" => "error"
+             }
+
+      assert data["balance_caching_reset_frequency"] == %{
+               "code" => "client:invalid_parameter",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "messages" => %{"value" => ["invalid_type_for_value"]},
+               "object" => "error"
+             }
+    end
+
+    test_with_auths "updates negative integer for all unsigned_integer settings", context do
+      response =
+        request("/configuration.update", %{
+          max_per_page: -1,
+          min_password_length: -1,
+          forget_password_request_lifetime: -1,
+          balance_caching_reset_frequency: -1,
+          config_pid: context[:config_pid]
+        })
+
+      assert response["success"] == true
+      data = response["data"]["data"]
+
+      assert data["max_per_page"] == %{
+               "code" => "client:invalid_parameter",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "messages" => %{"value" => ["invalid_type_for_value"]},
+               "object" => "error"
+             }
+
+      assert data["min_password_length"] == %{
+               "code" => "client:invalid_parameter",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "messages" => %{"value" => ["invalid_type_for_value"]},
+               "object" => "error"
+             }
+
+      assert data["forget_password_request_lifetime"] == %{
+               "code" => "client:invalid_parameter",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "messages" => %{"value" => ["invalid_type_for_value"]},
+               "object" => "error"
+             }
+
+      assert data["balance_caching_reset_frequency"] == %{
+               "code" => "client:invalid_parameter",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "messages" => %{"value" => ["invalid_type_for_value"]},
+               "object" => "error"
+             }
+    end
+
     test_with_auths "reloads app env", context do
       response =
         request("/configuration.update", %{

--- a/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
@@ -109,7 +109,8 @@ defmodule AdminAPI.V1.ConfigurationControllerTest do
 
       assert data["max_per_page"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+               "description" =>
+                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
                "messages" => %{"value" => ["invalid_type_for_value"]},
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
@@ -109,7 +109,7 @@ defmodule AdminAPI.V1.ConfigurationControllerTest do
 
       assert data["max_per_page"] == %{
                "code" => "client:invalid_parameter",
-               "description" => "Invalid parameter provided. `value` must be of type 'integer'.",
+               "description" => "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
                "messages" => %{"value" => ["invalid_type_for_value"]},
                "object" => "error"
              }

--- a/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
@@ -143,7 +143,7 @@ defmodule AdminAPI.V1.ConfigurationControllerTest do
       assert data["balance_caching_reset_frequency"] == error
     end
 
-    test_with_auths "returns errors when updating unsigned_integer settings with negative integers", context do
+    test_with_auths "returns errors when updating unsigned_integer settings with -1", context do
       response =
         request("/configuration.update", %{
           max_per_page: -1,

--- a/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
@@ -116,7 +116,7 @@ defmodule AdminAPI.V1.ConfigurationControllerTest do
              }
     end
 
-    test_with_auths "updates nil for all unsigned_integer settings", context do
+    test_with_auths "returns errors when updating unsigned_integer settings with nil", context do
       response =
         request("/configuration.update", %{
           max_per_page: nil,
@@ -143,7 +143,7 @@ defmodule AdminAPI.V1.ConfigurationControllerTest do
       assert data["balance_caching_reset_frequency"] == error
     end
 
-    test_with_auths "updates negative integer for all unsigned_integer settings", context do
+    test_with_auths "returns errors when updating unsigned_integer settings with negative integers", context do
       response =
         request("/configuration.update", %{
           max_per_page: -1,

--- a/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/configuration_controller_test.exs
@@ -129,37 +129,18 @@ defmodule AdminAPI.V1.ConfigurationControllerTest do
       assert response["success"] == true
       data = response["data"]["data"]
 
-      assert data["max_per_page"] == %{
-               "code" => "client:invalid_parameter",
-               "description" =>
-                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
-               "messages" => %{"value" => ["invalid_type_for_value"]},
-               "object" => "error"
-             }
+      error = %{
+        "code" => "client:invalid_parameter",
+        "description" =>
+          "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+        "messages" => %{"value" => ["invalid_type_for_value"]},
+        "object" => "error"
+      }
 
-      assert data["min_password_length"] == %{
-               "code" => "client:invalid_parameter",
-               "description" =>
-                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
-               "messages" => %{"value" => ["invalid_type_for_value"]},
-               "object" => "error"
-             }
-
-      assert data["forget_password_request_lifetime"] == %{
-               "code" => "client:invalid_parameter",
-               "description" =>
-                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
-               "messages" => %{"value" => ["invalid_type_for_value"]},
-               "object" => "error"
-             }
-
-      assert data["balance_caching_reset_frequency"] == %{
-               "code" => "client:invalid_parameter",
-               "description" =>
-                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
-               "messages" => %{"value" => ["invalid_type_for_value"]},
-               "object" => "error"
-             }
+      assert data["max_per_page"] == error
+      assert data["min_password_length"] == error
+      assert data["forget_password_request_lifetime"] == error
+      assert data["balance_caching_reset_frequency"] == error
     end
 
     test_with_auths "updates negative integer for all unsigned_integer settings", context do
@@ -175,37 +156,18 @@ defmodule AdminAPI.V1.ConfigurationControllerTest do
       assert response["success"] == true
       data = response["data"]["data"]
 
-      assert data["max_per_page"] == %{
-               "code" => "client:invalid_parameter",
-               "description" =>
-                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
-               "messages" => %{"value" => ["invalid_type_for_value"]},
-               "object" => "error"
-             }
+      error = %{
+        "code" => "client:invalid_parameter",
+        "description" =>
+          "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
+        "messages" => %{"value" => ["invalid_type_for_value"]},
+        "object" => "error"
+      }
 
-      assert data["min_password_length"] == %{
-               "code" => "client:invalid_parameter",
-               "description" =>
-                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
-               "messages" => %{"value" => ["invalid_type_for_value"]},
-               "object" => "error"
-             }
-
-      assert data["forget_password_request_lifetime"] == %{
-               "code" => "client:invalid_parameter",
-               "description" =>
-                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
-               "messages" => %{"value" => ["invalid_type_for_value"]},
-               "object" => "error"
-             }
-
-      assert data["balance_caching_reset_frequency"] == %{
-               "code" => "client:invalid_parameter",
-               "description" =>
-                 "Invalid parameter provided. `value` must be of type 'unsigned_integer'.",
-               "messages" => %{"value" => ["invalid_type_for_value"]},
-               "object" => "error"
-             }
+      assert data["max_per_page"] == error
+      assert data["min_password_length"] == error
+      assert data["forget_password_request_lifetime"] == error
+      assert data["balance_caching_reset_frequency"] == error
     end
 
     test_with_auths "reloads app env", context do

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -38,21 +38,21 @@ config :ewallet_config,
     "max_per_page" => %{
       key: "max_per_page",
       value: 100,
-      type: "integer",
+      type: "unsigned_integer",
       position: 103,
       description: "The maximum number of records that can be returned for a list."
     },
     "min_password_length" => %{
       key: "min_password_length",
       value: 8,
-      type: "integer",
+      type: "unsigned_integer",
       position: 104,
       description: "The minimum length for passwords."
     },
     "forget_password_request_lifetime" => %{
       key: "forget_password_request_lifetime",
       value: 10,
-      type: "integer",
+      type: "unsigned_integer",
       position: 105,
       description: "The duration (in minutes) that a forget password request will be valid for."
     },
@@ -136,7 +136,7 @@ config :ewallet_config,
     "balance_caching_reset_frequency" => %{
       key: "balance_caching_reset_frequency",
       value: 10,
-      type: "integer",
+      type: "unsigned_integer",
       position: 301,
       parent: "balance_caching_strategy",
       parent_value: "since_last_cached",

--- a/apps/ewallet_config/lib/ewallet_config/setting_validator.ex
+++ b/apps/ewallet_config/lib/ewallet_config/setting_validator.ex
@@ -79,6 +79,10 @@ defmodule EWalletConfig.SettingValidator do
   # Setting's type-value validator
   #
 
+  defp valid_setting_type?(nil, "integer"), do: false
+
+  defp valid_setting_type?(nil, "unsigned_integer"), do: false
+
   defp valid_setting_type?(nil, _), do: true
 
   defp valid_setting_type?(value, "string") when is_binary(value), do: true

--- a/apps/ewallet_config/priv/repo/reporters/seeds_settings.exs
+++ b/apps/ewallet_config/priv/repo/reporters/seeds_settings.exs
@@ -41,4 +41,5 @@ defmodule EWalletDB.Repo.Reporters.SeedsSettingsReporter do
   defp inspect_value(%{value: value, type: "string"}), do: ~s("#{value}")
   defp inspect_value(%{value: value, type: "boolean"}), do: value
   defp inspect_value(%{value: value, type: "integer"}), do: value
+  defp inspect_value(%{value: value, type: "unsigned_integer"}), do: value
 end


### PR DESCRIPTION
Issue/Task Number: #661

Closes #661

# Overview
This PR prevents the following setting fields to be updated as `nil` or negative integer:

- `max_per_page`
- `min_password_length`
- `forget_password_request_lifetime`
- `balance_caching_reset_frequency`

# Changes

- Change the following settings from `integer` to `unsigned-integer`
    - `max_per_page`
    - `min_password_length`
    - `forget_password_request_lifetime`
    - `balance_caching_reset_frequency`
