### PR TITLE
Typo & deprecation fixes in EWalletDB and LocalLedgerDB namespaces

### DIFF
--- a/apps/ewallet_db/lib/ewallet_db/application.ex
+++ b/apps/ewallet_db/lib/ewallet_db/application.ex
@@ -16,7 +16,7 @@ defmodule EWalletDB.Application do
   @moduledoc """
   The EWalletDB Data Store
 
-  Kebura's data store lives in this application.
+  The eWallet's data store lives in this application.
   """
   use Application
   alias Appsignal.Ecto

--- a/apps/ewallet_db/lib/ewallet_db/user_query.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user_query.ex
@@ -54,7 +54,7 @@ defmodule EWalletDB.UserQuery do
       :inner,
       [u],
       m in Membership,
-      u.uuid == m.user_uuid and m.account_uuid in ^account_uuids
+      on: u.uuid == m.user_uuid and m.account_uuid in ^account_uuids
     )
     |> distinct(true)
     |> select([c], c)

--- a/apps/local_ledger/lib/local_ledger.ex
+++ b/apps/local_ledger/lib/local_ledger.ex
@@ -1,18 +1,4 @@
-# Copyright 2018-2019 OmiseGO Pte Ltd
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Copyright 2017-2018 OmiseGO
+# Copyright 2017-2019 OmiseGO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/local_ledger_db/lib/local_ledger_db/wallet.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/wallet.ex
@@ -14,7 +14,7 @@
 
 defmodule LocalLedgerDB.Wallet do
   @moduledoc """
-  Ecto Schema representing wallets. A balance is made up of a unique address
+  Ecto Schema representing wallets. A wallet is made up of a unique address
   and the ID associated with it in eWallet DB.
   """
   use Ecto.Schema
@@ -41,7 +41,7 @@ defmodule LocalLedgerDB.Wallet do
   end
 
   @doc """
-  Validate the balance attributes.
+  Validate the wallet attributes.
   """
   def changeset(%Wallet{} = balance, attrs) do
     balance
@@ -51,7 +51,7 @@ defmodule LocalLedgerDB.Wallet do
   end
 
   @doc """
-  Batch load wallets and run the callback for each balance.
+  Batch load wallets and run the callback for each wallet.
   """
   def stream_all(callback) do
     Repo
@@ -68,27 +68,27 @@ defmodule LocalLedgerDB.Wallet do
       |> NaiveDateTime.to_iso8601()
 
     Repo.update_all(
-      from(b in Wallet, where: b.address in ^addresses),
+      from(w in Wallet, where: w.address in ^addresses),
       set: [updated_at: updated_at]
     )
   end
 
   @doc """
-  Use a FOR UPDATE lock on the balance records for which the current wallets
+  Use a FOR UPDATE lock on the wallet records for which the current wallets
   will be calculated.
   """
   def lock(addresses) do
     Repo.all(
       from(
-        b in Wallet,
-        where: b.address in ^addresses,
+        w in Wallet,
+        where: w.address in ^addresses,
         lock: "FOR UPDATE"
       )
     )
   end
 
   @doc """
-  Retrieve a balance from the database using the specified address
+  Retrieve a wallet from the database using the specified address
   or insert a new one before returning it.
   """
   def get_or_insert(%{"address" => address} = attrs) do
@@ -96,8 +96,8 @@ defmodule LocalLedgerDB.Wallet do
       nil ->
         insert(attrs)
 
-      balance ->
-        {:ok, balance}
+      wallet ->
+        {:ok, wallet}
     end
   end
 
@@ -128,7 +128,7 @@ defmodule LocalLedgerDB.Wallet do
     opts = [on_conflict: :nothing, conflict_target: :address]
 
     case Repo.insert(changeset, opts) do
-      {:ok, _balance} ->
+      {:ok, _wallet} ->
         {:ok, get(address)}
 
       {:error, changeset} ->


### PR DESCRIPTION
Issue/Task Number: #610

# Overview

This PR contains the small typo & deprecation fixes carried over from the now-closed #806.

# Changes

- Typo fixes from renamings long time ago.
- Fix deprecated Ecto join without specifying `on:`

# Implementation Details

N/A

# Usage

N/A

# Impact

No changes to DB schema or API specs.