### PR TITLE
Add token avatar

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -18,11 +18,10 @@ defmodule AdminAPI.V1.TokenController do
   """
   use AdminAPI, :controller
   import AdminAPI.V1.ErrorHandler
-  alias Ecto.{Changeset}
+  alias Ecto.Changeset
   alias EWallet.{Helper, MintGate, TokenPolicy, MintPolicy, AdapterHelper}
   alias EWallet.Web.{Orchestrator, Originator, Paginator, V1.TokenOverlay}
   alias EWalletDB.{Account, Mint, Token}
-  alias Ecto.Changeset
 
   @doc """
   Retrieves a list of tokens.

--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -18,6 +18,7 @@ defmodule AdminAPI.V1.TokenController do
   """
   use AdminAPI, :controller
   import AdminAPI.V1.ErrorHandler
+  alias Ecto.{Changeset}
   alias EWallet.{Helper, MintGate, TokenPolicy, MintPolicy, AdapterHelper}
   alias EWallet.Web.{Orchestrator, Originator, Paginator, V1.TokenOverlay}
   alias EWalletDB.{Account, Mint, Token}
@@ -200,7 +201,7 @@ defmodule AdminAPI.V1.TokenController do
       changeset when is_map(changeset) ->
         handle_error(conn, :invalid_parameter, changeset)
 
-      {:error, changeset} when is_map(changeset) ->
+      {:error, %Changeset{} = changeset} ->
         handle_error(conn, :invalid_parameter, changeset)
 
       {:error, code} ->

--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -208,7 +208,8 @@ defmodule AdminAPI.V1.TokenController do
     end
   end
 
-  def upload_avatar(conn, _), do: handle_error(conn, :invalid_parameter)
+  def upload_avatar(conn, _),
+    do: handle_error(conn, :invalid_parameter, "`id` and `avatar` are required")
 
   # Respond with a list of tokens
   defp respond_multiple(%Paginator{} = paged_tokens, conn) do

--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -187,7 +187,7 @@ defmodule AdminAPI.V1.TokenController do
   @spec upload_avatar(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def upload_avatar(conn, %{"id" => id, "avatar" => _} = attrs) do
     with %Token{} = token <- Token.get(id) || {:error, :unauthorized},
-         :ok <- permit(:update, conn.assigns, token.id),
+         {:ok, _} <- authorize(:update, conn.assigns, token),
          :ok <- AdapterHelper.check_adapter_status(),
          attrs <- Originator.set_in_attrs(attrs, conn.assigns),
          %{} = saved <- Token.store_avatar(token, attrs),

--- a/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/token_controller.ex
@@ -198,7 +198,7 @@ defmodule AdminAPI.V1.TokenController do
       nil ->
         handle_error(conn, :invalid_parameter)
 
-      changeset when is_map(changeset) ->
+      %Changeset{} = changeset ->
         handle_error(conn, :invalid_parameter, changeset)
 
       {:error, %Changeset{} = changeset} ->

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -57,6 +57,7 @@ defmodule AdminAPI.V1.Router do
     post("/token.stats", TokenController, :stats)
     post("/token.get_mints", MintController, :all_for_token)
     post("/token.mint", MintController, :mint)
+    post("/token.upload_avatar", TokenController, :upload_avatar)
 
     # Transaction endpoints
     post("/transaction.all", TransactionController, :all)

--- a/apps/admin_api/priv/spec.json
+++ b/apps/admin_api/priv/spec.json
@@ -1909,6 +1909,9 @@
                                       "subunit_to_unit": {
                                         "type": "integer"
                                       },
+                                      "avatar": {
+                                        "type": "object"
+                                      },
                                       "created_at": {
                                         "type": "string",
                                         "format": "date-time"
@@ -1933,6 +1936,7 @@
                                       "symbol",
                                       "name",
                                       "subunit_to_unit",
+                                      "avatar",
                                       "created_at",
                                       "updated_at",
                                       "enabled"
@@ -1956,6 +1960,9 @@
                               "subunit_to_unit": 100,
                               "created_at": "2018-01-01T00:00:00Z",
                               "updated_at": "2018-01-01T10:00:00Z",
+                              "avatar": {
+                                "original": "file_url"
+                              },
                               "enabled": true,
                               "metadata": {},
                               "encrypted_metadata": {}
@@ -2151,6 +2158,9 @@
                             "subunit_to_unit": {
                               "type": "integer"
                             },
+                            "avatar": {
+                              "type": "object"
+                            },
                             "created_at": {
                               "type": "string",
                               "format": "date-time"
@@ -2175,6 +2185,7 @@
                             "symbol",
                             "name",
                             "subunit_to_unit",
+                            "avatar",
                             "created_at",
                             "updated_at",
                             "enabled"
@@ -2191,6 +2202,9 @@
                           "created_at": "2018-01-01T00:00:00Z",
                           "updated_at": "2018-01-01T10:00:00Z",
                           "enabled": true,
+                          "avatar": {
+                            "original": "file_url"
+                          },
                           "metadata": {},
                           "encrypted_metadata": {}
                         }
@@ -2430,6 +2444,9 @@
                             "subunit_to_unit": {
                               "type": "integer"
                             },
+                            "avatar": {
+                              "type": "object"
+                            },
                             "created_at": {
                               "type": "string",
                               "format": "date-time"
@@ -2454,6 +2471,7 @@
                             "symbol",
                             "name",
                             "subunit_to_unit",
+                            "avatar",
                             "created_at",
                             "updated_at",
                             "enabled"
@@ -2470,6 +2488,9 @@
                           "created_at": "2018-01-01T00:00:00Z",
                           "updated_at": "2018-01-01T10:00:00Z",
                           "enabled": true,
+                          "avatar": {
+                            "original": "file_url"
+                          },
                           "metadata": {},
                           "encrypted_metadata": {}
                         }
@@ -2693,6 +2714,9 @@
                             "subunit_to_unit": {
                               "type": "integer"
                             },
+                            "avatar": {
+                              "type": "object"
+                            },
                             "created_at": {
                               "type": "string",
                               "format": "date-time"
@@ -2717,6 +2741,7 @@
                             "symbol",
                             "name",
                             "subunit_to_unit",
+                            "avatar",
                             "created_at",
                             "updated_at",
                             "enabled"
@@ -2733,6 +2758,254 @@
                           "created_at": "2018-01-01T00:00:00Z",
                           "updated_at": "2018-01-01T10:00:00Z",
                           "enabled": true,
+                          "avatar": {
+                            "original": "file_url"
+                          },
+                          "metadata": {},
+                          "encrypted_metadata": {}
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Returns an internal server error",
+            "content": {
+              "application/vnd.omisego.v1+json": {
+                "schema": {
+                  "description": "The response schema for an error",
+                  "allOf": [
+                    {
+                      "description": "The response schema for a successful operation",
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "string"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        },
+                        "data": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "version",
+                        "success",
+                        "data"
+                      ],
+                      "example": {
+                        "version": "1",
+                        "success": true,
+                        "data": {}
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "description": "The object schema for an error",
+                          "type": "object",
+                          "properties": {
+                            "object": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "messages": {
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "object",
+                            "code",
+                            "description",
+                            "messages"
+                          ],
+                          "example": {
+                            "object": "error",
+                            "code": "server:internal_server_error",
+                            "description": "Something went wrong on the server",
+                            "messages": {
+                              "error_key": "error_reason"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ],
+                      "example": {
+                        "success": false,
+                        "data": {
+                          "object": "error",
+                          "code": "server:internal_server_error",
+                          "description": "Something went wrong on the server",
+                          "messages": {
+                            "error_key": "error_reason"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token.upload_avatar": {
+      "post": {
+        "tags": [
+          "Token"
+        ],
+        "summary": "Uploads avatar for a token",
+        "operationId": "token_upload_avatar",
+        "security": [
+          {
+            "ProviderAuth": []
+          },
+          {
+            "AdminAuth": []
+          }
+        ],
+        "requestBody": {
+          "description": "The parameters to use for uploading a token's avatar. Only supports .jpg, .jpeg, .gif and .png.",
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "avatar": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "id",
+                  "avatar"
+                ],
+                "example": {
+                  "id": "tok_ABC_01ce846km1syzwezxfmgdn7dt7",
+                  "avatar": "/path/to/file"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns a single tokens",
+            "content": {
+              "application/vnd.omisego.v1+json": {
+                "schema": {
+                  "description": "The response schema for a token",
+                  "allOf": [
+                    {
+                      "description": "The response schema for a successful operation",
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "string"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        },
+                        "data": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "version",
+                        "success",
+                        "data"
+                      ],
+                      "example": {
+                        "version": "1",
+                        "success": true,
+                        "data": {}
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "description": "The object schema for a token",
+                          "properties": {
+                            "object": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "symbol": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "subunit_to_unit": {
+                              "type": "integer"
+                            },
+                            "avatar": {
+                              "type": "object"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "metadata": {
+                              "type": "object"
+                            },
+                            "encrypted_metadata": {
+                              "type": "object"
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "object",
+                            "id",
+                            "symbol",
+                            "name",
+                            "subunit_to_unit",
+                            "avatar",
+                            "created_at",
+                            "updated_at",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "example": {
+                        "data": {
+                          "object": "token",
+                          "id": "tok_abc_01cbfge9qhmsdbjyb7a8e8pxt3",
+                          "symbol": "ABC",
+                          "name": "ABC Point",
+                          "subunit_to_unit": 100,
+                          "created_at": "2018-01-01T00:00:00Z",
+                          "updated_at": "2018-01-01T10:00:00Z",
+                          "enabled": true,
+                          "avatar": {
+                            "original": "file_url"
+                          },
                           "metadata": {},
                           "encrypted_metadata": {}
                         }
@@ -2930,6 +3203,9 @@
                             "subunit_to_unit": {
                               "type": "integer"
                             },
+                            "avatar": {
+                              "type": "object"
+                            },
                             "created_at": {
                               "type": "string",
                               "format": "date-time"
@@ -2954,6 +3230,7 @@
                             "symbol",
                             "name",
                             "subunit_to_unit",
+                            "avatar",
                             "created_at",
                             "updated_at",
                             "enabled"
@@ -2970,6 +3247,9 @@
                           "created_at": "2018-01-01T00:00:00Z",
                           "updated_at": "2018-01-01T10:00:00Z",
                           "enabled": true,
+                          "avatar": {
+                            "original": "file_url"
+                          },
                           "metadata": {},
                           "encrypted_metadata": {}
                         }
@@ -3141,6 +3421,9 @@
                         "subunit_to_unit": {
                           "type": "integer"
                         },
+                        "avatar": {
+                          "type": "object"
+                        },
                         "created_at": {
                           "type": "string",
                           "format": "date-time"
@@ -3165,6 +3448,7 @@
                         "symbol",
                         "name",
                         "subunit_to_unit",
+                        "avatar",
                         "created_at",
                         "updated_at",
                         "enabled"
@@ -3580,6 +3864,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -3604,6 +3891,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -3880,6 +4168,9 @@
                                                   "subunit_to_unit": {
                                                     "type": "integer"
                                                   },
+                                                  "avatar": {
+                                                    "type": "object"
+                                                  },
                                                   "created_at": {
                                                     "type": "string",
                                                     "format": "date-time"
@@ -3904,6 +4195,7 @@
                                                   "symbol",
                                                   "name",
                                                   "subunit_to_unit",
+                                                  "avatar",
                                                   "created_at",
                                                   "updated_at",
                                                   "enabled"
@@ -3942,6 +4234,9 @@
                                                   "subunit_to_unit": {
                                                     "type": "integer"
                                                   },
+                                                  "avatar": {
+                                                    "type": "object"
+                                                  },
                                                   "created_at": {
                                                     "type": "string",
                                                     "format": "date-time"
@@ -3966,6 +4261,7 @@
                                                   "symbol",
                                                   "name",
                                                   "subunit_to_unit",
+                                                  "avatar",
                                                   "created_at",
                                                   "updated_at",
                                                   "enabled"
@@ -4265,6 +4561,9 @@
                             "subunit_to_unit": {
                               "type": "integer"
                             },
+                            "avatar": {
+                              "type": "object"
+                            },
                             "created_at": {
                               "type": "string",
                               "format": "date-time"
@@ -4289,6 +4588,7 @@
                             "symbol",
                             "name",
                             "subunit_to_unit",
+                            "avatar",
                             "created_at",
                             "updated_at",
                             "enabled"
@@ -4677,6 +4977,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -4701,6 +5004,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -4728,6 +5032,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -4752,6 +5059,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -5033,6 +5341,9 @@
                                 "subunit_to_unit": {
                                   "type": "integer"
                                 },
+                                "avatar": {
+                                  "type": "object"
+                                },
                                 "created_at": {
                                   "type": "string",
                                   "format": "date-time"
@@ -5057,6 +5368,7 @@
                                 "symbol",
                                 "name",
                                 "subunit_to_unit",
+                                "avatar",
                                 "created_at",
                                 "updated_at",
                                 "enabled"
@@ -5084,6 +5396,9 @@
                                 "subunit_to_unit": {
                                   "type": "integer"
                                 },
+                                "avatar": {
+                                  "type": "object"
+                                },
                                 "created_at": {
                                   "type": "string",
                                   "format": "date-time"
@@ -5108,6 +5423,7 @@
                                 "symbol",
                                 "name",
                                 "subunit_to_unit",
+                                "avatar",
                                 "created_at",
                                 "updated_at",
                                 "enabled"
@@ -5485,6 +5801,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -5509,6 +5828,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -5536,6 +5856,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -5560,6 +5883,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -5937,6 +6261,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -5961,6 +6288,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -5988,6 +6316,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -6012,6 +6343,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -6385,6 +6717,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -6409,6 +6744,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -6436,6 +6772,9 @@
                                           "subunit_to_unit": {
                                             "type": "integer"
                                           },
+                                          "avatar": {
+                                            "type": "object"
+                                          },
                                           "created_at": {
                                             "type": "string",
                                             "format": "date-time"
@@ -6460,6 +6799,7 @@
                                           "symbol",
                                           "name",
                                           "subunit_to_unit",
+                                          "avatar",
                                           "created_at",
                                           "updated_at",
                                           "enabled"
@@ -13322,6 +13662,9 @@
                                                 "subunit_to_unit": {
                                                   "type": "integer"
                                                 },
+                                                "avatar": {
+                                                  "type": "object"
+                                                },
                                                 "created_at": {
                                                   "type": "string",
                                                   "format": "date-time"
@@ -13346,6 +13689,7 @@
                                                 "symbol",
                                                 "name",
                                                 "subunit_to_unit",
+                                                "avatar",
                                                 "created_at",
                                                 "updated_at",
                                                 "enabled"
@@ -14108,6 +14452,9 @@
                                                 "subunit_to_unit": {
                                                   "type": "integer"
                                                 },
+                                                "avatar": {
+                                                  "type": "object"
+                                                },
                                                 "created_at": {
                                                   "type": "string",
                                                   "format": "date-time"
@@ -14132,6 +14479,7 @@
                                                 "symbol",
                                                 "name",
                                                 "subunit_to_unit",
+                                                "avatar",
                                                 "created_at",
                                                 "updated_at",
                                                 "enabled"
@@ -14591,6 +14939,9 @@
                                               "subunit_to_unit": {
                                                 "type": "integer"
                                               },
+                                              "avatar": {
+                                                "type": "object"
+                                              },
                                               "created_at": {
                                                 "type": "string",
                                                 "format": "date-time"
@@ -14615,6 +14966,7 @@
                                               "symbol",
                                               "name",
                                               "subunit_to_unit",
+                                              "avatar",
                                               "created_at",
                                               "updated_at",
                                               "enabled"
@@ -14653,6 +15005,9 @@
                                               "subunit_to_unit": {
                                                 "type": "integer"
                                               },
+                                              "avatar": {
+                                                "type": "object"
+                                              },
                                               "created_at": {
                                                 "type": "string",
                                                 "format": "date-time"
@@ -14677,6 +15032,7 @@
                                               "symbol",
                                               "name",
                                               "subunit_to_unit",
+                                              "avatar",
                                               "created_at",
                                               "updated_at",
                                               "enabled"
@@ -21683,6 +22039,9 @@
                                                 "subunit_to_unit": {
                                                   "type": "integer"
                                                 },
+                                                "avatar": {
+                                                  "type": "object"
+                                                },
                                                 "created_at": {
                                                   "type": "string",
                                                   "format": "date-time"
@@ -21707,6 +22066,7 @@
                                                 "symbol",
                                                 "name",
                                                 "subunit_to_unit",
+                                                "avatar",
                                                 "created_at",
                                                 "updated_at",
                                                 "enabled"
@@ -22174,6 +22534,9 @@
                                               "subunit_to_unit": {
                                                 "type": "integer"
                                               },
+                                              "avatar": {
+                                                "type": "object"
+                                              },
                                               "created_at": {
                                                 "type": "string",
                                                 "format": "date-time"
@@ -22198,6 +22561,7 @@
                                               "symbol",
                                               "name",
                                               "subunit_to_unit",
+                                              "avatar",
                                               "created_at",
                                               "updated_at",
                                               "enabled"
@@ -22236,6 +22600,9 @@
                                               "subunit_to_unit": {
                                                 "type": "integer"
                                               },
+                                              "avatar": {
+                                                "type": "object"
+                                              },
                                               "created_at": {
                                                 "type": "string",
                                                 "format": "date-time"
@@ -22260,6 +22627,7 @@
                                               "symbol",
                                               "name",
                                               "subunit_to_unit",
+                                              "avatar",
                                               "created_at",
                                               "updated_at",
                                               "enabled"
@@ -23844,6 +24212,9 @@
                                                 "subunit_to_unit": {
                                                   "type": "integer"
                                                 },
+                                                "avatar": {
+                                                  "type": "object"
+                                                },
                                                 "created_at": {
                                                   "type": "string",
                                                   "format": "date-time"
@@ -23868,6 +24239,7 @@
                                                 "symbol",
                                                 "name",
                                                 "subunit_to_unit",
+                                                "avatar",
                                                 "created_at",
                                                 "updated_at",
                                                 "enabled"
@@ -24511,6 +24883,9 @@
                                       "subunit_to_unit": {
                                         "type": "integer"
                                       },
+                                      "avatar": {
+                                        "type": "object"
+                                      },
                                       "created_at": {
                                         "type": "string",
                                         "format": "date-time"
@@ -24535,6 +24910,7 @@
                                       "symbol",
                                       "name",
                                       "subunit_to_unit",
+                                      "avatar",
                                       "created_at",
                                       "updated_at",
                                       "enabled"
@@ -25106,6 +25482,9 @@
                                       "subunit_to_unit": {
                                         "type": "integer"
                                       },
+                                      "avatar": {
+                                        "type": "object"
+                                      },
                                       "created_at": {
                                         "type": "string",
                                         "format": "date-time"
@@ -25130,6 +25509,7 @@
                                       "symbol",
                                       "name",
                                       "subunit_to_unit",
+                                      "avatar",
                                       "created_at",
                                       "updated_at",
                                       "enabled"
@@ -26218,6 +26598,9 @@
                                       "subunit_to_unit": {
                                         "type": "integer"
                                       },
+                                      "avatar": {
+                                        "type": "object"
+                                      },
                                       "created_at": {
                                         "type": "string",
                                         "format": "date-time"
@@ -26242,6 +26625,7 @@
                                       "symbol",
                                       "name",
                                       "subunit_to_unit",
+                                      "avatar",
                                       "created_at",
                                       "updated_at",
                                       "enabled"
@@ -26675,6 +27059,9 @@
                                               "subunit_to_unit": {
                                                 "type": "integer"
                                               },
+                                              "avatar": {
+                                                "type": "object"
+                                              },
                                               "created_at": {
                                                 "type": "string",
                                                 "format": "date-time"
@@ -26699,6 +27086,7 @@
                                               "symbol",
                                               "name",
                                               "subunit_to_unit",
+                                              "avatar",
                                               "created_at",
                                               "updated_at",
                                               "enabled"
@@ -26737,6 +27125,9 @@
                                               "subunit_to_unit": {
                                                 "type": "integer"
                                               },
+                                              "avatar": {
+                                                "type": "object"
+                                              },
                                               "created_at": {
                                                 "type": "string",
                                                 "format": "date-time"
@@ -26761,6 +27152,7 @@
                                               "symbol",
                                               "name",
                                               "subunit_to_unit",
+                                              "avatar",
                                               "created_at",
                                               "updated_at",
                                               "enabled"
@@ -27391,6 +27783,9 @@
                                     "subunit_to_unit": {
                                       "type": "integer"
                                     },
+                                    "avatar": {
+                                      "type": "object"
+                                    },
                                     "created_at": {
                                       "type": "string",
                                       "format": "date-time"
@@ -27415,6 +27810,7 @@
                                     "symbol",
                                     "name",
                                     "subunit_to_unit",
+                                    "avatar",
                                     "created_at",
                                     "updated_at",
                                     "enabled"
@@ -27453,6 +27849,9 @@
                                     "subunit_to_unit": {
                                       "type": "integer"
                                     },
+                                    "avatar": {
+                                      "type": "object"
+                                    },
                                     "created_at": {
                                       "type": "string",
                                       "format": "date-time"
@@ -27477,6 +27876,7 @@
                                     "symbol",
                                     "name",
                                     "subunit_to_unit",
+                                    "avatar",
                                     "created_at",
                                     "updated_at",
                                     "enabled"
@@ -27857,6 +28257,9 @@
                                     "subunit_to_unit": {
                                       "type": "integer"
                                     },
+                                    "avatar": {
+                                      "type": "object"
+                                    },
                                     "created_at": {
                                       "type": "string",
                                       "format": "date-time"
@@ -27881,6 +28284,7 @@
                                     "symbol",
                                     "name",
                                     "subunit_to_unit",
+                                    "avatar",
                                     "created_at",
                                     "updated_at",
                                     "enabled"
@@ -27919,6 +28323,9 @@
                                     "subunit_to_unit": {
                                       "type": "integer"
                                     },
+                                    "avatar": {
+                                      "type": "object"
+                                    },
                                     "created_at": {
                                       "type": "string",
                                       "format": "date-time"
@@ -27943,6 +28350,7 @@
                                     "symbol",
                                     "name",
                                     "subunit_to_unit",
+                                    "avatar",
                                     "created_at",
                                     "updated_at",
                                     "enabled"
@@ -28282,6 +28690,9 @@
                                     "subunit_to_unit": {
                                       "type": "integer"
                                     },
+                                    "avatar": {
+                                      "type": "object"
+                                    },
                                     "created_at": {
                                       "type": "string",
                                       "format": "date-time"
@@ -28306,6 +28717,7 @@
                                     "symbol",
                                     "name",
                                     "subunit_to_unit",
+                                    "avatar",
                                     "created_at",
                                     "updated_at",
                                     "enabled"
@@ -28333,6 +28745,9 @@
                                     "subunit_to_unit": {
                                       "type": "integer"
                                     },
+                                    "avatar": {
+                                      "type": "object"
+                                    },
                                     "created_at": {
                                       "type": "string",
                                       "format": "date-time"
@@ -28357,6 +28772,7 @@
                                     "symbol",
                                     "name",
                                     "subunit_to_unit",
+                                    "avatar",
                                     "created_at",
                                     "updated_at",
                                     "enabled"

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -894,7 +894,7 @@ paths:
         - AdminAuth: []
       requestBody:
         description: >-
-          The parameters to use for uploading a oken's avatar. Only supports
+          The parameters to use for uploading a token's avatar. Only supports
           .jpg, .jpeg, .gif and .png.
         required: true
         content:
@@ -913,7 +913,7 @@ paths:
                 id: tok_ABC_01ce846km1syzwezxfmgdn7dt7
                 avatar: /path/to/file
       responses:
-        '200': *ref_15
+        '200': *ref_11
         '500': *ref_2
   /token.enable_or_disable:
     post:

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -681,6 +681,8 @@ paths:
                                       type: string
                                     subunit_to_unit:
                                       type: integer
+                                    avatar:
+                                      type: object
                                     created_at:
                                       type: string
                                       format: date-time
@@ -699,6 +701,7 @@ paths:
                                     - symbol
                                     - name
                                     - subunit_to_unit
+                                    - avatar
                                     - created_at
                                     - updated_at
                                     - enabled
@@ -713,6 +716,8 @@ paths:
                             subunit_to_unit: 100
                             created_at: '2018-01-01T00:00:00Z'
                             updated_at: '2018-01-01T10:00:00Z'
+                            avatar:
+                              original: file_url
                             enabled: true
                             metadata: {}
                             encrypted_metadata: {}
@@ -765,6 +770,8 @@ paths:
                         created_at: '2018-01-01T00:00:00Z'
                         updated_at: '2018-01-01T10:00:00Z'
                         enabled: true
+                        avatar:
+                          original: file_url
                         metadata: {}
                         encrypted_metadata: {}
         '500': *ref_2
@@ -875,6 +882,38 @@ paths:
                 description: an awesome updated description
       responses:
         '200': *ref_11
+        '500': *ref_2
+  /token.upload_avatar:
+    post:
+      tags:
+        - Token
+      summary: Uploads avatar for a token
+      operationId: token_upload_avatar
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        description: >-
+          The parameters to use for uploading a oken's avatar. Only supports
+          .jpg, .jpeg, .gif and .png.
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                id:
+                  type: string
+                avatar:
+                  type: string
+                  format: binary
+              required:
+                - id
+                - avatar
+              example:
+                id: tok_ABC_01ce846km1syzwezxfmgdn7dt7
+                avatar: /path/to/file
+      responses:
+        '200': *ref_15
         '500': *ref_2
   /token.enable_or_disable:
     post:

--- a/apps/admin_api/priv/swagger/swagger.yaml
+++ b/apps/admin_api/priv/swagger/swagger.yaml
@@ -114,6 +114,8 @@ paths:
     $ref: 'token/paths.yaml#/token.create'
   /token.update:
     $ref: 'token/paths.yaml#/token.update'
+  /token.upload_avatar:
+    $ref: 'token/paths.yaml#/token.upload_avatar'
   /token.enable_or_disable:
     $ref: 'token/paths.yaml#/token.enable_or_disable'
   /token.stats:

--- a/apps/admin_api/priv/swagger/token/paths.yaml
+++ b/apps/admin_api/priv/swagger/token/paths.yaml
@@ -83,6 +83,23 @@ token.enable_or_disable:
       '500':
         $ref: '../../../../ewallet/priv/swagger/shared/responses.yaml#/InternalServerError'
 
+token.upload_avatar:
+  post:
+    tags:
+      - Token
+    summary: Uploads avatar for a token
+    operationId: token_upload_avatar
+    security:
+      - ProviderAuth: []
+      - AdminAuth: []
+    requestBody:
+      $ref: 'request_bodies.yaml#/TokenUploadBody'
+    responses:
+      '200':
+        $ref: 'responses.yaml#/TokenResponse'
+      '500':
+        $ref: '../../../../ewallet/priv/swagger/shared/responses.yaml#/InternalServerError'
+
 token.stats:
   post:
     tags:

--- a/apps/admin_api/priv/swagger/token/request_bodies.yaml
+++ b/apps/admin_api/priv/swagger/token/request_bodies.yaml
@@ -162,3 +162,22 @@ TokenMintBody:
         example:
           id: tok_ABC_01ce846km1syzwezxfmgdn7dt7
           amount: 1000
+
+TokenUploadBody:
+  description: The parameters to use for uploading a oken's avatar. Only supports .jpg, .jpeg, .gif and .png.
+  required: true
+  content:
+    application/x-www-form-urlencoded:
+      schema:
+        properties:
+          id:
+            type: string
+          avatar:
+            type: string
+            format: binary
+        required:
+          - id
+          - avatar
+        example:
+          id: tok_ABC_01ce846km1syzwezxfmgdn7dt7
+          avatar: /path/to/file

--- a/apps/admin_api/priv/swagger/token/request_bodies.yaml
+++ b/apps/admin_api/priv/swagger/token/request_bodies.yaml
@@ -164,7 +164,7 @@ TokenMintBody:
           amount: 1000
 
 TokenUploadBody:
-  description: The parameters to use for uploading a oken's avatar. Only supports .jpg, .jpeg, .gif and .png.
+  description: The parameters to use for uploading a token's avatar. Only supports .jpg, .jpeg, .gif and .png.
   required: true
   content:
     application/x-www-form-urlencoded:

--- a/apps/admin_api/priv/swagger/token/response_schemas.yaml
+++ b/apps/admin_api/priv/swagger/token/response_schemas.yaml
@@ -17,6 +17,7 @@ TokenResponseSchema:
           created_at: '2018-01-01T00:00:00Z'
           updated_at: '2018-01-01T10:00:00Z'
           enabled: true
+          avatar: {original: file_url}
           metadata: {}
           encrypted_metadata: {}
 
@@ -46,6 +47,7 @@ TokensResponseSchema:
             subunit_to_unit: 100
             created_at: '2018-01-01T00:00:00Z'
             updated_at: '2018-01-01T10:00:00Z'
+            avatar: {'original': 'file_url'}
             enabled: true
             metadata: {}
             encrypted_metadata: {}

--- a/apps/admin_api/test/admin_api/v1/controllers/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/token_controller_test.exs
@@ -879,7 +879,7 @@ defmodule AdminAPI.V1.TokenControllerTest do
       refute response["success"]
       assert response["data"]["object"] == "error"
       assert response["data"]["code"] == "client:invalid_parameter"
-      assert response["data"]["description"] == "Invalid parameter provided."
+      assert response["data"]["description"] == "`id` and `avatar` are required"
     end
 
     test_with_auths "returns 'unauthorized' if the given token ID was not found" do

--- a/apps/admin_api/test/admin_api/v1/controllers/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/token_controller_test.exs
@@ -832,6 +832,8 @@ defmodule AdminAPI.V1.TokenControllerTest do
 
       response = request("/token.upload_avatar", attrs)
       assert response["success"]
+      token = Token.get(attrs.id)
+      assert token.avatar != nil
 
       attrs = %{
         id: token.id,

--- a/apps/admin_api/test/admin_api/v1/controllers/token_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/token_controller_test.exs
@@ -732,4 +732,171 @@ defmodule AdminAPI.V1.TokenControllerTest do
       timestamp |> get_all_activity_logs_since() |> assert_enable_logs(get_test_key(), token)
     end
   end
+
+  describe "/token.upload_avatar" do
+    test_with_auths "uploads an avatar for the specified token" do
+      token = insert(:token)
+
+      attrs = %{
+        id: token.id,
+        avatar: %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      }
+
+      response = request("/token.upload_avatar", attrs)
+
+      assert response["success"]
+      assert response["data"]["object"] == "token"
+
+      assert response["data"]["avatar"]["large"] =~
+               "http://localhost:4000/public/uploads/test/token/avatars/#{attrs.id}/large.png?v="
+
+      assert response["data"]["avatar"]["original"] =~
+               "http://localhost:4000/public/uploads/test/token/avatars/#{attrs.id}/original.jpg?v="
+
+      assert response["data"]["avatar"]["small"] =~
+               "http://localhost:4000/public/uploads/test/token/avatars/#{attrs.id}/small.png?v="
+
+      assert response["data"]["avatar"]["thumb"] =~
+               "http://localhost:4000/public/uploads/test/token/avatars/#{attrs.id}/thumb.png?v="
+    end
+
+    test_with_auths "fails to upload an invalid file" do
+      token = insert(:token)
+
+      attrs = %{
+        "id" => token.id,
+        "avatar" => %Plug.Upload{
+          path: "test/support/assets/file.json",
+          filename: "file.json"
+        }
+      }
+
+      response = request("/token.upload_avatar", attrs)
+
+      refute response["success"]
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
+    test_with_auths "returns an error when 'avatar' is not sent" do
+      token = insert(:token)
+
+      attrs = %{
+        "id" => token.id
+      }
+
+      response = request("/token.upload_avatar", attrs)
+
+      refute response["success"]
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
+    test_with_auths "removes the avatar from a token" do
+      token = insert(:token)
+
+      attrs = %{
+        id: token.id,
+        avatar: %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      }
+
+      response = request("/token.upload_avatar", attrs)
+      assert response["success"]
+
+      attrs = %{
+        id: token.id,
+        avatar: nil
+      }
+
+      response = request("/token.upload_avatar", attrs)
+
+      assert response["success"]
+      token = Token.get(attrs.id)
+      assert token.avatar == nil
+    end
+
+    test_with_auths "removes the avatar from a token with empty string" do
+      token = insert(:token)
+
+      attrs = %{
+        id: token.id,
+        avatar: %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      }
+
+      response = request("/token.upload_avatar", attrs)
+      assert response["success"]
+
+      attrs = %{
+        id: token.id,
+        avatar: ""
+      }
+
+      response = request("/token.upload_avatar", attrs)
+
+      assert response["success"]
+      token = Token.get(attrs.id)
+      assert token.avatar == nil
+    end
+
+    test_with_auths "removes the avatar from a token with 'null' string" do
+      token = insert(:token)
+
+      attrs = %{
+        id: token.id,
+        avatar: %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      }
+
+      response = request("/token.upload_avatar", attrs)
+      assert response["success"]
+
+      attrs = %{
+        id: token.id,
+        avatar: "null"
+      }
+
+      response = request("/token.upload_avatar", attrs)
+
+      assert response["success"]
+      token = Token.get(attrs.id)
+      assert token.avatar == nil
+    end
+
+    test_with_auths "returns :invalid_parameter error when id is not given" do
+      response = request("/token.upload_avatar", %{})
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided."
+    end
+
+    test_with_auths "returns 'unauthorized' if the given token ID was not found" do
+      attrs = %{
+        id: "fake",
+        avatar: %Plug.Upload{
+          path: "test/support/assets/test.jpg",
+          filename: "test.jpg"
+        }
+      }
+
+      response = request("/token.upload_avatar", attrs)
+
+      refute response["success"]
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "unauthorized"
+
+      assert response["data"]["description"] ==
+               "You are not allowed to perform the requested operation."
+    end
+  end
 end

--- a/apps/admin_api/test/admin_api/v1/controllers/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/wallet_controller_test.exs
@@ -129,8 +129,6 @@ defmodule AdminAPI.V1.WalletControllerTest do
       transfer!(master_wallet.address, user_wallet.address, btc, 150_000 * btc.subunit_to_unit)
       transfer!(master_wallet.address, user_wallet.address, omg, 12_000 * omg.subunit_to_unit)
 
-      expected_avatar = %{"large" => nil, "original" => nil, "small" => nil, "thumb" => nil}
-
       response =
         request("/user.get_wallets", %{
           provider_user_id: user.provider_user_id
@@ -177,7 +175,12 @@ defmodule AdminAPI.V1.WalletControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "avatar" => expected_avatar,
+                           "avatar" => %{
+                             "large" => nil,
+                             "original" => nil,
+                             "small" => nil,
+                             "thumb" => nil
+                           },
                            "created_at" => DateFormatter.to_iso8601(btc.inserted_at),
                            "updated_at" => DateFormatter.to_iso8601(btc.updated_at)
                          }
@@ -194,7 +197,12 @@ defmodule AdminAPI.V1.WalletControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "avatar" => expected_avatar,
+                           "avatar" => %{
+                             "large" => nil,
+                             "original" => nil,
+                             "small" => nil,
+                             "thumb" => nil
+                           },
                            "created_at" => DateFormatter.to_iso8601(omg.inserted_at),
                            "updated_at" => DateFormatter.to_iso8601(omg.updated_at)
                          }

--- a/apps/admin_api/test/admin_api/v1/controllers/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/wallet_controller_test.exs
@@ -129,6 +129,8 @@ defmodule AdminAPI.V1.WalletControllerTest do
       transfer!(master_wallet.address, user_wallet.address, btc, 150_000 * btc.subunit_to_unit)
       transfer!(master_wallet.address, user_wallet.address, omg, 12_000 * omg.subunit_to_unit)
 
+      expected_avatar = %{"large" => nil, "original" => nil, "small" => nil, "thumb" => nil}
+
       response =
         request("/user.get_wallets", %{
           provider_user_id: user.provider_user_id
@@ -175,6 +177,7 @@ defmodule AdminAPI.V1.WalletControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
+                           "avatar" => expected_avatar,
                            "created_at" => DateFormatter.to_iso8601(btc.inserted_at),
                            "updated_at" => DateFormatter.to_iso8601(btc.updated_at)
                          }
@@ -191,6 +194,7 @@ defmodule AdminAPI.V1.WalletControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
+                           "avatar" => expected_avatar,
                            "created_at" => DateFormatter.to_iso8601(omg.inserted_at),
                            "updated_at" => DateFormatter.to_iso8601(omg.updated_at)
                          }

--- a/apps/admin_api/test/admin_api/v1/views/token_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/token_view_test.exs
@@ -34,10 +34,10 @@ defmodule AdminAPI.V1.TokenViewTest do
           encrypted_metadata: %{},
           enabled: true,
           avatar: %{
-            "large" => nil,
-            "original" => nil,
-            "small" => nil,
-            "thumb" => nil
+            large: nil,
+            original: nil,
+            small: nil,
+            thumb: nil
           },
           subunit_to_unit: token.subunit_to_unit,
           created_at: DateFormatter.to_iso8601(token.inserted_at),
@@ -77,10 +77,10 @@ defmodule AdminAPI.V1.TokenViewTest do
               encrypted_metadata: %{},
               enabled: true,
               avatar: %{
-                "large" => nil,
-                "original" => nil,
-                "small" => nil,
-                "thumb" => nil
+                large: nil,
+                original: nil,
+                small: nil,
+                thumb: nil
               },
               subunit_to_unit: token1.subunit_to_unit,
               created_at: DateFormatter.to_iso8601(token1.inserted_at),
@@ -94,7 +94,12 @@ defmodule AdminAPI.V1.TokenViewTest do
               metadata: %{},
               encrypted_metadata: %{},
               enabled: true,
-              avatar: expected_avatar,
+              avatar: %{
+                large: nil,
+                original: nil,
+                small: nil,
+                thumb: nil
+              },
               subunit_to_unit: token2.subunit_to_unit,
               created_at: DateFormatter.to_iso8601(token2.inserted_at),
               updated_at: DateFormatter.to_iso8601(token2.updated_at)

--- a/apps/admin_api/test/admin_api/v1/views/token_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/token_view_test.exs
@@ -22,6 +22,8 @@ defmodule AdminAPI.V1.TokenViewTest do
     test "renders token.json with correct response structure" do
       token = insert(:token)
 
+      expected_avatar = %{large: nil, original: nil, small: nil, thumb: nil}
+
       expected = %{
         version: @expected_version,
         success: true,
@@ -33,6 +35,7 @@ defmodule AdminAPI.V1.TokenViewTest do
           metadata: %{},
           encrypted_metadata: %{},
           enabled: true,
+          avatar: expected_avatar,
           subunit_to_unit: token.subunit_to_unit,
           created_at: DateFormatter.to_iso8601(token.inserted_at),
           updated_at: DateFormatter.to_iso8601(token.updated_at)
@@ -45,6 +48,8 @@ defmodule AdminAPI.V1.TokenViewTest do
     test "renders tokens.json with correct response structure" do
       token1 = insert(:token)
       token2 = insert(:token)
+
+      expected_avatar = %{large: nil, original: nil, small: nil, thumb: nil}
 
       paginator = %Paginator{
         data: [token1, token2],
@@ -70,6 +75,7 @@ defmodule AdminAPI.V1.TokenViewTest do
               metadata: %{},
               encrypted_metadata: %{},
               enabled: true,
+              avatar: expected_avatar,
               subunit_to_unit: token1.subunit_to_unit,
               created_at: DateFormatter.to_iso8601(token1.inserted_at),
               updated_at: DateFormatter.to_iso8601(token1.updated_at)
@@ -82,6 +88,7 @@ defmodule AdminAPI.V1.TokenViewTest do
               metadata: %{},
               encrypted_metadata: %{},
               enabled: true,
+              avatar: expected_avatar,
               subunit_to_unit: token2.subunit_to_unit,
               created_at: DateFormatter.to_iso8601(token2.inserted_at),
               updated_at: DateFormatter.to_iso8601(token2.updated_at)

--- a/apps/admin_api/test/admin_api/v1/views/token_view_test.exs
+++ b/apps/admin_api/test/admin_api/v1/views/token_view_test.exs
@@ -22,8 +22,6 @@ defmodule AdminAPI.V1.TokenViewTest do
     test "renders token.json with correct response structure" do
       token = insert(:token)
 
-      expected_avatar = %{large: nil, original: nil, small: nil, thumb: nil}
-
       expected = %{
         version: @expected_version,
         success: true,
@@ -35,7 +33,12 @@ defmodule AdminAPI.V1.TokenViewTest do
           metadata: %{},
           encrypted_metadata: %{},
           enabled: true,
-          avatar: expected_avatar,
+          avatar: %{
+            "large" => nil,
+            "original" => nil,
+            "small" => nil,
+            "thumb" => nil
+          },
           subunit_to_unit: token.subunit_to_unit,
           created_at: DateFormatter.to_iso8601(token.inserted_at),
           updated_at: DateFormatter.to_iso8601(token.updated_at)
@@ -48,8 +51,6 @@ defmodule AdminAPI.V1.TokenViewTest do
     test "renders tokens.json with correct response structure" do
       token1 = insert(:token)
       token2 = insert(:token)
-
-      expected_avatar = %{large: nil, original: nil, small: nil, thumb: nil}
 
       paginator = %Paginator{
         data: [token1, token2],
@@ -75,7 +76,12 @@ defmodule AdminAPI.V1.TokenViewTest do
               metadata: %{},
               encrypted_metadata: %{},
               enabled: true,
-              avatar: expected_avatar,
+              avatar: %{
+                "large" => nil,
+                "original" => nil,
+                "small" => nil,
+                "thumb" => nil
+              },
               subunit_to_unit: token1.subunit_to_unit,
               created_at: DateFormatter.to_iso8601(token1.inserted_at),
               updated_at: DateFormatter.to_iso8601(token1.updated_at)

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/token_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/token_serializer.ex
@@ -21,6 +21,7 @@ defmodule EWallet.Web.V1.TokenSerializer do
   alias EWallet.Web.V1.PaginatorSerializer
   alias EWalletDB.Token
   alias Utils.Helpers.DateFormatter
+  alias EWalletDB.Uploaders.Avatar
 
   def serialize(%Paginator{} = paginator) do
     PaginatorSerializer.serialize(paginator, &serialize/1)
@@ -40,6 +41,7 @@ defmodule EWallet.Web.V1.TokenSerializer do
       metadata: token.metadata || %{},
       encrypted_metadata: token.encrypted_metadata || %{},
       enabled: token.enabled,
+      avatar: Avatar.urls({token.avatar, token}),
       created_at: DateFormatter.to_iso8601(token.inserted_at),
       updated_at: DateFormatter.to_iso8601(token.updated_at)
     }

--- a/apps/ewallet/priv/swagger/token/schemas.yaml
+++ b/apps/ewallet/priv/swagger/token/schemas.yaml
@@ -12,6 +12,8 @@ TokenSchema:
       type: string
     subunit_to_unit:
       type: integer
+    avatar:
+      type: object
     created_at:
       type: string
       format: date-time
@@ -30,6 +32,7 @@ TokenSchema:
     - symbol
     - name
     - subunit_to_unit
+    - avatar
     - created_at
     - updated_at
     - enabled

--- a/apps/ewallet/test/ewallet/web/v1/serializers/token_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/token_serializer_test.exs
@@ -21,6 +21,8 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
     test "serializes into correct V1 token format" do
       token = build(:token)
 
+      expected_avatar = %{large: nil, original: nil, small: nil, thumb: nil}
+
       expected = %{
         object: "token",
         id: token.id,
@@ -30,6 +32,7 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
         metadata: token.metadata,
         encrypted_metadata: token.encrypted_metadata,
         enabled: true,
+        avatar: expected_avatar,
         created_at: token.inserted_at,
         updated_at: token.updated_at
       }
@@ -48,6 +51,8 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
       token2 = build(:token)
       tokens = [token1, token2]
 
+      expected_avatar = %{large: nil, original: nil, small: nil, thumb: nil}
+
       expected = [
         %{
           object: "token",
@@ -58,6 +63,7 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
           metadata: token1.metadata,
           encrypted_metadata: token1.encrypted_metadata,
           enabled: true,
+          avatar: expected_avatar,
           created_at: token1.inserted_at,
           updated_at: token1.updated_at
         },
@@ -70,6 +76,7 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
           metadata: token2.metadata,
           encrypted_metadata: token2.encrypted_metadata,
           enabled: true,
+          avatar: expected_avatar,
           created_at: token2.inserted_at,
           updated_at: token2.updated_at
         }

--- a/apps/ewallet/test/ewallet/web/v1/serializers/token_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/token_serializer_test.exs
@@ -21,8 +21,6 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
     test "serializes into correct V1 token format" do
       token = build(:token)
 
-      expected_avatar = %{large: nil, original: nil, small: nil, thumb: nil}
-
       expected = %{
         object: "token",
         id: token.id,
@@ -32,7 +30,7 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
         metadata: token.metadata,
         encrypted_metadata: token.encrypted_metadata,
         enabled: true,
-        avatar: expected_avatar,
+        avatar: %{large: nil, original: nil, small: nil, thumb: nil},
         created_at: token.inserted_at,
         updated_at: token.updated_at
       }
@@ -51,8 +49,6 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
       token2 = build(:token)
       tokens = [token1, token2]
 
-      expected_avatar = %{large: nil, original: nil, small: nil, thumb: nil}
-
       expected = [
         %{
           object: "token",
@@ -63,7 +59,7 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
           metadata: token1.metadata,
           encrypted_metadata: token1.encrypted_metadata,
           enabled: true,
-          avatar: expected_avatar,
+          avatar: %{large: nil, original: nil, small: nil, thumb: nil},
           created_at: token1.inserted_at,
           updated_at: token1.updated_at
         },

--- a/apps/ewallet/test/ewallet/web/v1/serializers/token_serializer_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/serializers/token_serializer_test.exs
@@ -72,7 +72,7 @@ defmodule EWallet.Web.V1.TokenSerializerTest do
           metadata: token2.metadata,
           encrypted_metadata: token2.encrypted_metadata,
           enabled: true,
-          avatar: expected_avatar,
+          avatar: %{large: nil, original: nil, small: nil, thumb: nil},
           created_at: token2.inserted_at,
           updated_at: token2.updated_at
         }

--- a/apps/ewallet_api/priv/spec.json
+++ b/apps/ewallet_api/priv/spec.json
@@ -2276,6 +2276,9 @@
                                                 "subunit_to_unit": {
                                                   "type": "integer"
                                                 },
+                                                "avatar": {
+                                                  "type": "object"
+                                                },
                                                 "created_at": {
                                                   "type": "string",
                                                   "format": "date-time"
@@ -2300,6 +2303,7 @@
                                                 "symbol",
                                                 "name",
                                                 "subunit_to_unit",
+                                                "avatar",
                                                 "created_at",
                                                 "updated_at",
                                                 "enabled"
@@ -2748,6 +2752,9 @@
                                               "subunit_to_unit": {
                                                 "type": "integer"
                                               },
+                                              "avatar": {
+                                                "type": "object"
+                                              },
                                               "created_at": {
                                                 "type": "string",
                                                 "format": "date-time"
@@ -2772,6 +2779,7 @@
                                               "symbol",
                                               "name",
                                               "subunit_to_unit",
+                                              "avatar",
                                               "created_at",
                                               "updated_at",
                                               "enabled"
@@ -2810,6 +2818,9 @@
                                               "subunit_to_unit": {
                                                 "type": "integer"
                                               },
+                                              "avatar": {
+                                                "type": "object"
+                                              },
                                               "created_at": {
                                                 "type": "string",
                                                 "format": "date-time"
@@ -2834,6 +2845,7 @@
                                               "symbol",
                                               "name",
                                               "subunit_to_unit",
+                                              "avatar",
                                               "created_at",
                                               "updated_at",
                                               "enabled"
@@ -3186,6 +3198,9 @@
                                     "subunit_to_unit": {
                                       "type": "integer"
                                     },
+                                    "avatar": {
+                                      "type": "object"
+                                    },
                                     "created_at": {
                                       "type": "string",
                                       "format": "date-time"
@@ -3210,6 +3225,7 @@
                                     "symbol",
                                     "name",
                                     "subunit_to_unit",
+                                    "avatar",
                                     "created_at",
                                     "updated_at",
                                     "enabled"
@@ -3248,6 +3264,9 @@
                                     "subunit_to_unit": {
                                       "type": "integer"
                                     },
+                                    "avatar": {
+                                      "type": "object"
+                                    },
                                     "created_at": {
                                       "type": "string",
                                       "format": "date-time"
@@ -3272,6 +3291,7 @@
                                     "symbol",
                                     "name",
                                     "subunit_to_unit",
+                                    "avatar",
                                     "created_at",
                                     "updated_at",
                                     "enabled"

--- a/apps/ewallet_api/priv/spec.yaml
+++ b/apps/ewallet_api/priv/spec.yaml
@@ -746,6 +746,8 @@ paths:
                                                 type: string
                                               subunit_to_unit:
                                                 type: integer
+                                              avatar:
+                                                type: object
                                               created_at:
                                                 type: string
                                                 format: date-time
@@ -764,6 +766,7 @@ paths:
                                               - symbol
                                               - name
                                               - subunit_to_unit
+                                              - avatar
                                               - created_at
                                               - updated_at
                                               - enabled

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
@@ -51,6 +51,8 @@ defmodule EWalletAPI.V1.SelfControllerTest do
       transfer!(master_wallet.address, user_wallet.address, btc, 150_000 * btc.subunit_to_unit)
       transfer!(master_wallet.address, user_wallet.address, omg, 12_000 * omg.subunit_to_unit)
 
+      expected_avatar = %{"large" => nil, "original" => nil, "small" => nil, "thumb" => nil}
+
       response = client_request("/me.get_wallets")
 
       assert response == %{
@@ -73,12 +75,7 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                      "created_at" => DateFormatter.to_iso8601(user_wallet.inserted_at),
                      "updated_at" => DateFormatter.to_iso8601(user_wallet.updated_at),
                      "user" => %{
-                       "avatar" => %{
-                         "large" => nil,
-                         "original" => nil,
-                         "small" => nil,
-                         "thumb" => nil
-                       },
+                       "avatar" => expected_avatar,
                        "created_at" => DateFormatter.to_iso8601(user.inserted_at),
                        "email" => nil,
                        "encrypted_metadata" => %{},
@@ -107,6 +104,7 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
+                           "avatar" => expected_avatar,
                            "created_at" => DateFormatter.to_iso8601(btc.inserted_at),
                            "updated_at" => DateFormatter.to_iso8601(btc.updated_at)
                          }
@@ -123,6 +121,7 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
+                           "avatar" => expected_avatar,
                            "created_at" => DateFormatter.to_iso8601(omg.inserted_at),
                            "updated_at" => DateFormatter.to_iso8601(omg.updated_at)
                          }

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
@@ -51,8 +51,6 @@ defmodule EWalletAPI.V1.SelfControllerTest do
       transfer!(master_wallet.address, user_wallet.address, btc, 150_000 * btc.subunit_to_unit)
       transfer!(master_wallet.address, user_wallet.address, omg, 12_000 * omg.subunit_to_unit)
 
-      expected_avatar = %{"large" => nil, "original" => nil, "small" => nil, "thumb" => nil}
-
       response = client_request("/me.get_wallets")
 
       assert response == %{
@@ -75,7 +73,12 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                      "created_at" => DateFormatter.to_iso8601(user_wallet.inserted_at),
                      "updated_at" => DateFormatter.to_iso8601(user_wallet.updated_at),
                      "user" => %{
-                       "avatar" => expected_avatar,
+                       "avatar" => %{
+                        "large" => nil,
+                        "original" => nil,
+                        "small" => nil,
+                        "thumb" => nil
+                      },
                        "created_at" => DateFormatter.to_iso8601(user.inserted_at),
                        "email" => nil,
                        "encrypted_metadata" => %{},

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
@@ -107,7 +107,12 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "avatar" => expected_avatar,
+                           "avatar" => %{
+                             "large" => nil,
+                             "original" => nil,
+                             "small" => nil,
+                             "thumb" => nil
+                           },
                            "created_at" => DateFormatter.to_iso8601(btc.inserted_at),
                            "updated_at" => DateFormatter.to_iso8601(btc.updated_at)
                          }
@@ -124,7 +129,12 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                            "metadata" => %{},
                            "encrypted_metadata" => %{},
                            "enabled" => true,
-                           "avatar" => expected_avatar,
+                           "avatar" => %{
+                             "large" => nil,
+                             "original" => nil,
+                             "small" => nil,
+                             "thumb" => nil
+                           },
                            "created_at" => DateFormatter.to_iso8601(omg.inserted_at),
                            "updated_at" => DateFormatter.to_iso8601(omg.updated_at)
                          }

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/self_controller_test.exs
@@ -74,11 +74,11 @@ defmodule EWalletAPI.V1.SelfControllerTest do
                      "updated_at" => DateFormatter.to_iso8601(user_wallet.updated_at),
                      "user" => %{
                        "avatar" => %{
-                        "large" => nil,
-                        "original" => nil,
-                        "small" => nil,
-                        "thumb" => nil
-                      },
+                         "large" => nil,
+                         "original" => nil,
+                         "small" => nil,
+                         "thumb" => nil
+                       },
                        "created_at" => DateFormatter.to_iso8601(user.inserted_at),
                        "email" => nil,
                        "encrypted_metadata" => %{},

--- a/apps/ewallet_db/priv/repo/migrations/20190301125055_add_avatar_to_tokens.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20190301125055_add_avatar_to_tokens.exs
@@ -1,0 +1,9 @@
+defmodule EWalletDB.Repo.Migrations.AddAvatarToTokens do
+  use Ecto.Migration
+
+  def change do
+    alter table(:token) do
+      add :avatar, :string
+    end
+  end
+end


### PR DESCRIPTION
Issue/Task Number: #816

Closes #816

Requires #730 

# Overview

This PR implemented an endpoint `token.upload_avatar` for providing a way to upload token's avatar

# Changes

- Added an endpoint `token.upload_avatar` to router
- Added field `avatar` to schema.
- Added `AddAvatarToTokens` migration script.

# Implementation Details

Everything is the same to `account.upload_avatar`.

# Usage

Try uploading an avatar with Postman or something.

`token.upload_avatar`

    {
      id: "tok_BTC_1234",
      avatar: <binary>
    }

# Impact

Run `ecto.migrate` to add `avatar` field to `token` table.

# Todo

- [x] Add tests