### PR TITLE
prevent creating new atoms from external sources

### DIFF
--- a/apps/ewallet/lib/ewallet/web/sort_parser.ex
+++ b/apps/ewallet/lib/ewallet/web/sort_parser.ex
@@ -38,9 +38,12 @@ defmodule EWallet.Web.SortParser do
     field =
       mapped_fields
       |> Map.get(field, field)
-      |> String.to_atom()
+      |> String.to_existing_atom()
 
     if Enum.member?(allowed_fields, field), do: field, else: nil
+  rescue
+    ArgumentError ->
+      nil
   end
 
   defp get_sort_field(_, _, _), do: nil


### PR DESCRIPTION
Issue/Task Number:

# Overview
This is a potential security issue if incoming `field` is not validated and you create new atoms on the spot. You can test this with the bellow test and observe how :erlang.system_info(:atom_count) is getting bigger. 

> Atoms are not garbage-collected. Once an atom is created, it is never removed. The emulator terminates if the limit for the number of atoms (1,048,576 by default) is reached.

# Changes

- Map the incoming string with an existing atom from the table, throw ArgumentError if the atom doesn't exist

# Implementation Details

The implementation presupposes that all atoms from `allowed_fields` are already loaded in the release VM.

# Usage


```
@tag timeout: 100_000_000
    test "can sort a field by descending order" do
      prepare_test_accounts()
      master_account = Account.get_master_account()

      attrs = %{"sort_by" => "description1", "sort_dir" => "desc"}
      Ecto.Adapters.SQL.Sandbox.mode(EWalletDB.Repo, {:shared, self()})
      # Exclude master account before retrieval, it was inserted globally
      list = Enum.chunk_every(1..1_000_000, 5_000)

      Enum.each(list, fn x ->
        spawn(fn ->
          Enum.each(x, fn i ->
            attrs = %{"sort_by" => "description#{i}", "sort_dir" => "desc"}

            sorted =
              Account
              |> where([a], a.uuid != ^master_account.uuid)
              |> SortParser.to_query(attrs, [:description])
              |> Repo.all()
          end)
        end)
      end)

      :timer.sleep(10_000_000)
      assert Enum.at(sorted, 0).description == "Account ZZZ"
      assert Enum.at(sorted, 1).description == "Account DDD"
      assert Enum.at(sorted, 2).description == "Account AAA"
    end
```
