### PR TITLE
Prevent creating new atoms from external sources

### DIFF
--- a/apps/ewallet/lib/ewallet/web/sort_parser.ex
+++ b/apps/ewallet/lib/ewallet/web/sort_parser.ex
@@ -38,9 +38,12 @@ defmodule EWallet.Web.SortParser do
     field =
       mapped_fields
       |> Map.get(field, field)
-      |> String.to_atom()
+      |> String.to_existing_atom()
 
     if Enum.member?(allowed_fields, field), do: field, else: nil
+  rescue
+    ArgumentError ->
+      nil
   end
 
   defp get_sort_field(_, _, _), do: nil


### PR DESCRIPTION
Issue/Task Number: N/A

# Overview

Prevent creating new atoms from external sources.

This is @InoMurko's work on #820 but applied to `v1.2` branch.

# Changes

- Use `String.to_existing_atom` in `SortParser`

# Implementation Details

Ideally a merge would ensure better branch compatibility but `master` already has other code that cannot go into `v1.2`. So a cherry pick instead.

# Usage

N/A

# Impact

No changes to DB schema nor API specs.
