### PR TITLE
feature: gather VM metrics and forward to AppSignal

### DIFF
--- a/apps/status/.gitignore
+++ b/apps/status/.gitignore
@@ -1,0 +1,17 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/apps/status/README.md
+++ b/apps/status/README.md
@@ -1,0 +1,2 @@
+# Status
+Status is a umbrella application. It's purpose is to gather and send metrics.

--- a/apps/status/config/config.exs
+++ b/apps/status/config/config.exs
@@ -1,0 +1,6 @@
+use Mix.Config
+
+config :status,
+  metrics: true
+
+import_config "#{Mix.env()}.exs"

--- a/apps/status/config/dev.exs
+++ b/apps/status/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/status/config/prod.exs
+++ b/apps/status/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/status/config/test.exs
+++ b/apps/status/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :status,
+  metrics: false

--- a/apps/status/lib/status.ex
+++ b/apps/status/lib/status.ex
@@ -1,0 +1,80 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Status do
+  @moduledoc """
+  Top level application module.
+  """
+  use Application
+  alias Status.Metric.Recorder
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    metrics =
+      Enum.map(vm_metrics(), fn {name, invoke} ->
+        Recorder.prepare_child(%Recorder{
+          name: name,
+          fn: invoke,
+          reporter: &Appsignal.set_gauge/3
+        })
+      end)
+
+    Supervisor.start_link(metrics, strategy: :one_for_one, name: Status.Supervisor)
+  end
+
+  @spec vm_metrics :: maybe_improper_list(atom(), fun()) | []
+  defp vm_metrics, do: do_vm_metrics(is_enabled?() || false)
+
+  defp do_vm_metrics(false), do: []
+
+  defp do_vm_metrics(true) do
+    memory =
+      for type <- ~w(total processes ets binary atom atom_used)a,
+          do: {String.to_atom("erlang_memory_#{type}"), fn -> :erlang.memory(type) end}
+
+    system_info =
+      for type <- ~w(schedulers atom_count process_count port_count)a,
+          do: {String.to_atom("erlang_system_info_#{type}"), fn -> :erlang.system_info(type) end}
+
+    other = [
+      {:erlang_uptime, fn -> :erlang.statistics(:wall_clock) |> elem(0) |> Kernel.div(1000) end},
+      {:erlang_io_input_kb,
+       fn ->
+         {{:input, input}, {:output, _output}} = :erlang.statistics(:io)
+         input |> Kernel.div(1024)
+       end},
+      {:erlang_io_output_kb,
+       fn ->
+         {{:input, _input}, {:output, output}} = :erlang.statistics(:io)
+         output |> Kernel.div(1024)
+       end},
+      {:erlang_total_run_queue_lengths, fn -> :erlang.statistics(:total_run_queue_lengths) end},
+      {:erlang_ets_count, fn -> length(:ets.all()) end}
+    ]
+
+    Enum.concat([memory, system_info, other])
+  end
+
+  @spec is_enabled?() :: boolean() | nil
+  defp is_enabled?() do
+    case {Application.get_env(:status, :metrics), System.get_env("METRICS")} do
+      {true, _} -> true
+      {_, "true"} -> true
+      {false, _} -> false
+      {_, "false"} -> false
+      _ -> nil
+    end
+  end
+end

--- a/apps/status/lib/status/metric/recorder.ex
+++ b/apps/status/lib/status/metric/recorder.ex
@@ -1,0 +1,83 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Status.Metric.Recorder do
+  @moduledoc """
+  A GenServer template for metrics recording.
+  """
+  use GenServer
+  @default_interval 5_000
+  @type t :: %__MODULE__{
+          name: atom(),
+          fn: (... -> atom()),
+          key: charlist() | nil,
+          interval: pos_integer(),
+          reporter: (... -> atom()),
+          tref: reference() | nil,
+          node: String.t() | nil
+        }
+  defstruct name: nil,
+            fn: nil,
+            key: nil,
+            interval: @default_interval,
+            reporter: nil,
+            tref: nil,
+            node: nil
+
+  @doc """
+  Returns child_specs for the given metric setup, to be included e.g. in Supervisor's children.
+  """
+  @spec prepare_child(t) :: %{id: atom(), start: tuple()}
+  def prepare_child(opts) do
+    %{id: opts.name, start: {__MODULE__, :start_link, [opts]}}
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: opts.name)
+  end
+
+  def init(opts) do
+    {:ok, tref} = :timer.send_interval(opts.interval, self(), :gather)
+
+    {:ok,
+     %{
+       opts
+       | key: to_charlist(opts.name),
+         interval: get_interval(opts.name) || @default_interval,
+         tref: tref,
+         node: to_string(:erlang.node())
+     }}
+  end
+
+  def handle_info(:gather, state) do
+    # invoke the reporter function and pass the key and value (invoke the fn)
+    _ = state.reporter.(state.key, apply(state.fn(), []), %{node: state.node})
+    {:noreply, state}
+  end
+
+  # check configuration and system env variable, otherwise use the default
+  defp get_interval(name) do
+    case Application.get_env(:status, String.to_atom("#{name}_interval")) do
+      nil ->
+        name
+        |> Atom.to_string()
+        |> String.upcase()
+        |> Kernel.<>("_INTERVAL")
+        |> System.get_env()
+
+      num ->
+        num
+    end
+  end
+end

--- a/apps/status/mix.exs
+++ b/apps/status/mix.exs
@@ -1,0 +1,39 @@
+defmodule Status.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :status,
+      version: "1.2.0-dev",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.8",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ],
+      aliases: aliases(),
+      deps: deps()
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  def application do
+    [
+      mod: {Status, []},
+      extra_applications: [:appsignal, :logger, :sasl, :os_mon]
+    ]
+  end
+
+  defp deps, do: []
+  defp aliases, do: []
+end

--- a/apps/status/test/test_helper.exs
+++ b/apps/status/test/test_helper.exs
@@ -1,0 +1,15 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+Application.ensure_all_started(:status)
+ExUnit.start()

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -35,6 +35,7 @@ release :ewallet do
     local_ledger: :permanent,
     local_ledger_db: :permanent,
     url_dispatcher: :permanent,
+    status: :permanent
   ]
 
   set commands: [


### PR DESCRIPTION
Issue/Task Number:

# Overview

AppSignal VM monitoring umbrella app. 

# Changes

- Added a new umbrella application.
# Implementation Details

Decided for a separate umbrella application because it doesn't fit anywhere else.


# Usage

It's enabled currently in the configuration, a deployment should (after setting up a custom dashboard) start sending the data to AppSignal backend.

AppSignal frontend configuration:
```
-
  title: 'VM dashboard'
  graphs:
    -
      title: 'VM atom over time'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_system_info_atom_count
      tags:
        node: '*'
    -
      title: 'ETS count'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_ets_count
      tags:
        node: '*'
    -
      title: 'IO Input KB'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_io_input_kb
      tags:
        node: '*'
    -
      title: 'IO Output KB'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_io_output_kb
      tags:
        node: '*'
    -
      title: 'Port count'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_system_info_port_count
      tags:
        node: '*'
    -
      title: 'Process count'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_system_info_process_count
      tags:
        node: '*'
    -
      title: 'Number of schedulers'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_system_info_schedulers
      tags:
        node: '*'
    -
      title: erlang_total_run_queue_lengths
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_total_run_queue_lengths
      tags:
        node: '*'
    -
      title: Uptime
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_uptime
      tags:
        node: '*'
    -
      title: 'Atom memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_atom
      tags:
        node: '*'
    -
      title: 'Atom memory used'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_atom_used
      tags:
        node: '*'
    -
      title: 'Binary memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_binary
      tags:
        node: '*'
    -
      title: 'ETS memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_ets
      tags:
        node: '*'
    -
      title: 'Memory processes'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_processes
      tags:
        node: '*'
    -
      title: 'Memory total'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_total
      tags:
        node: '*'
```

# Impact

/
