### PR TITLE
feature: gather VM metrics and forward to AppSignal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ build-test: deps-ewallet
 test: test-ewallet test-assets
 
 test-ewallet: clean-test-assets build-test
-	env MIX_ENV=test mix do ecto.create, ecto.migrate, test
+	env MIX_ENV=test SERVE_LOCAL_STATIC=false METRICS=false mix do ecto.create, ecto.migrate, test
 
 test-assets: build-assets
 	cd apps/admin_panel/assets && \

--- a/apps/status/.gitignore
+++ b/apps/status/.gitignore
@@ -1,0 +1,17 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/apps/status/README.md
+++ b/apps/status/README.md
@@ -1,0 +1,2 @@
+# Status
+Status is a umbrella application. It's purpose is to gather and send metrics.

--- a/apps/status/config/config.exs
+++ b/apps/status/config/config.exs
@@ -1,0 +1,6 @@
+use Mix.Config
+
+config :status,
+  metrics: true
+
+import_config "#{Mix.env()}.exs"

--- a/apps/status/config/dev.exs
+++ b/apps/status/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/status/config/prod.exs
+++ b/apps/status/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/status/config/test.exs
+++ b/apps/status/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :status,
+  metrics: false

--- a/apps/status/lib/status.ex
+++ b/apps/status/lib/status.ex
@@ -1,0 +1,80 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Status do
+  @moduledoc """
+  Top level application module.
+  """
+  use Application
+  alias Status.Metric.Recorder
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    metrics =
+      Enum.map(vm_metrics(), fn {name, invoke} ->
+        Recorder.prepare_child(%Recorder{
+          name: name,
+          fn: invoke,
+          reporter: &Appsignal.set_gauge/3
+        })
+      end)
+
+    Supervisor.start_link(metrics, strategy: :one_for_one, name: Status.Supervisor)
+  end
+
+  @spec vm_metrics :: maybe_improper_list(atom(), fun()) | []
+  defp vm_metrics, do: do_vm_metrics(is_enabled?() || false)
+
+  defp do_vm_metrics(false), do: []
+
+  defp do_vm_metrics(true) do
+    memory =
+      for type <- ~w(total processes ets binary atom atom_used)a,
+          do: {String.to_atom("erlang_memory_#{type}"), fn -> :erlang.memory(type) end}
+
+    system_info =
+      for type <- ~w(schedulers atom_count process_count port_count)a,
+          do: {String.to_atom("erlang_system_info_#{type}"), fn -> :erlang.system_info(type) end}
+
+    other = [
+      {:erlang_uptime, fn -> :erlang.statistics(:wall_clock) |> elem(0) |> Kernel.div(1000) end},
+      {:erlang_io_input_kb,
+       fn ->
+         {{:input, input}, {:output, _output}} = :erlang.statistics(:io)
+         input |> Kernel.div(1024)
+       end},
+      {:erlang_io_output_kb,
+       fn ->
+         {{:input, _input}, {:output, output}} = :erlang.statistics(:io)
+         output |> Kernel.div(1024)
+       end},
+      {:erlang_total_run_queue_lengths, fn -> :erlang.statistics(:total_run_queue_lengths) end},
+      {:erlang_ets_count, fn -> length(:ets.all()) end}
+    ]
+
+    Enum.concat([memory, system_info, other])
+  end
+
+  @spec is_enabled?() :: boolean() | nil
+  defp is_enabled?() do
+    case {Application.get_env(:status, :metrics), System.get_env("METRICS")} do
+      {true, _} -> true
+      {_, "true"} -> true
+      {false, _} -> false
+      {_, "false"} -> false
+      _ -> nil
+    end
+  end
+end

--- a/apps/status/lib/status.ex
+++ b/apps/status/lib/status.ex
@@ -18,6 +18,7 @@ defmodule Status do
   """
   use Application
   alias Status.Metric.Recorder
+  alias Utils.Helpers.Normalize
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
@@ -69,11 +70,11 @@ defmodule Status do
 
   @spec is_enabled?() :: boolean() | nil
   defp is_enabled?() do
-    case {Application.get_env(:status, :metrics), System.get_env("METRICS")} do
+    case {Application.get_env(:status, :metrics), Normalize.to_boolean(System.get_env("METRICS"))} do
       {true, _} -> true
-      {_, "true"} -> true
+      {_, true} -> true
       {false, _} -> false
-      {_, "false"} -> false
+      {_, false} -> false
       _ -> nil
     end
   end

--- a/apps/status/lib/status.ex
+++ b/apps/status/lib/status.ex
@@ -71,10 +71,10 @@ defmodule Status do
   @spec is_enabled?() :: boolean() | nil
   defp is_enabled?() do
     case {Application.get_env(:status, :metrics), Normalize.to_boolean(System.get_env("METRICS"))} do
-      {true, _} -> true
       {_, true} -> true
-      {false, _} -> false
       {_, false} -> false
+      {true, _} -> true
+      {false, _} -> false
       _ -> nil
     end
   end

--- a/apps/status/lib/status/metric/recorder.ex
+++ b/apps/status/lib/status/metric/recorder.ex
@@ -17,6 +17,7 @@ defmodule Status.Metric.Recorder do
   A GenServer template for metrics recording.
   """
   use GenServer
+  alias Utils.Helpers.Normalize
   @default_interval 5_000
   @type t :: %__MODULE__{
           name: atom(),
@@ -75,6 +76,7 @@ defmodule Status.Metric.Recorder do
         |> String.upcase()
         |> Kernel.<>("_INTERVAL")
         |> System.get_env()
+        |> Normalize.to_integer()
 
       num ->
         num

--- a/apps/status/lib/status/metric/recorder.ex
+++ b/apps/status/lib/status/metric/recorder.ex
@@ -1,0 +1,83 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Status.Metric.Recorder do
+  @moduledoc """
+  A GenServer template for metrics recording.
+  """
+  use GenServer
+  @default_interval 5_000
+  @type t :: %__MODULE__{
+          name: atom(),
+          fn: (... -> atom()),
+          key: charlist() | nil,
+          interval: pos_integer(),
+          reporter: (... -> atom()),
+          tref: reference() | nil,
+          node: String.t() | nil
+        }
+  defstruct name: nil,
+            fn: nil,
+            key: nil,
+            interval: @default_interval,
+            reporter: nil,
+            tref: nil,
+            node: nil
+
+  @doc """
+  Returns child_specs for the given metric setup, to be included e.g. in Supervisor's children.
+  """
+  @spec prepare_child(t) :: %{id: atom(), start: tuple()}
+  def prepare_child(opts) do
+    %{id: opts.name, start: {__MODULE__, :start_link, [opts]}}
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: opts.name)
+  end
+
+  def init(opts) do
+    {:ok, tref} = :timer.send_interval(opts.interval, self(), :gather)
+
+    {:ok,
+     %{
+       opts
+       | key: to_charlist(opts.name),
+         interval: get_interval(opts.name) || @default_interval,
+         tref: tref,
+         node: to_string(:erlang.node())
+     }}
+  end
+
+  def handle_info(:gather, state) do
+    # invoke the reporter function and pass the key and value (invoke the fn)
+    _ = state.reporter.(state.key, apply(state.fn(), []), %{node: state.node})
+    {:noreply, state}
+  end
+
+  # check configuration and system env variable, otherwise use the default
+  defp get_interval(name) do
+    case Application.get_env(:status, String.to_atom("#{name}_interval")) do
+      nil ->
+        name
+        |> Atom.to_string()
+        |> String.upcase()
+        |> Kernel.<>("_INTERVAL")
+        |> System.get_env()
+
+      num ->
+        num
+    end
+  end
+end

--- a/apps/status/mix.exs
+++ b/apps/status/mix.exs
@@ -1,0 +1,39 @@
+defmodule Status.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :status,
+      version: "1.2.0-dev",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.8",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ],
+      aliases: aliases(),
+      deps: deps()
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  def application do
+    [
+      mod: {Status, []},
+      extra_applications: [:appsignal, :logger, :sasl, :os_mon]
+    ]
+  end
+
+  defp deps, do: []
+  defp aliases, do: []
+end

--- a/apps/status/mix.exs
+++ b/apps/status/mix.exs
@@ -34,6 +34,6 @@ defmodule Status.Mixfile do
     ]
   end
 
-  defp deps, do: []
+  defp deps, do: [{:utils, in_umbrella: true}]
   defp aliases, do: []
 end

--- a/apps/status/test/test_helper.exs
+++ b/apps/status/test/test_helper.exs
@@ -1,0 +1,15 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+Application.ensure_all_started(:status)
+ExUnit.start()

--- a/apps/utils/lib/helpers/normalize.ex
+++ b/apps/utils/lib/helpers/normalize.ex
@@ -28,4 +28,9 @@ defmodule Utils.Helpers.Normalize do
   def to_boolean(s) when is_binary(s), do: string_to_boolean(s)
   def to_boolean(s) when is_integer(s) and s >= 1, do: true
   def to_boolean(_), do: false
+
+  def to_integer(<<_::binary>> = s), do: :erlang.binary_to_integer(s)
+  def to_integer([_ | _] = s), do: :erlang.list_to_integer(s)
+  def to_integer(s) when is_integer(s), do: s
+  def to_integer(s) when is_float(s), do: :erlang.round(s)
 end

--- a/apps/utils/lib/helpers/normalize.ex
+++ b/apps/utils/lib/helpers/normalize.ex
@@ -16,21 +16,51 @@ defmodule Utils.Helpers.Normalize do
   @moduledoc """
   Module to normalize strings.
   """
+  defmodule ToBooleanError do
+    defexception message: "Could not represent the value as boolean."
+    def error_message(value), do: "Could not represent the value (#{inspect(value)}) as boolean."
+  end
 
-  def string_to_boolean(<<"T", _::binary>>), do: true
-  def string_to_boolean(<<"Y", _::binary>>), do: true
-  def string_to_boolean(<<"t", _::binary>>), do: true
-  def string_to_boolean(<<"y", _::binary>>), do: true
-  def string_to_boolean(<<"1", _::binary>>), do: true
-  def string_to_boolean(_), do: false
+  defmodule ToIntegerError do
+    defexception message: "Could not represent the value as an integer."
+    def error_message(value), do: "Could not represent the value (#{value}) as an integer."
+  end
+
+  def string_to_boolean(<<"T">>), do: true
+  def string_to_boolean(<<"Y">>), do: true
+  def string_to_boolean(<<"t">>), do: true
+  def string_to_boolean(<<"y">>), do: true
+  def string_to_boolean(<<"1">>), do: true
+  def string_to_boolean(<<"True">>), do: true
+  def string_to_boolean(<<"true">>), do: true
+  def string_to_boolean(<<"yes">>), do: true
+  def string_to_boolean(<<"Yes">>), do: true
+
+  def string_to_boolean(<<"F">>), do: false
+  def string_to_boolean(<<"N">>), do: false
+  def string_to_boolean(<<"f">>), do: false
+  def string_to_boolean(<<"n">>), do: false
+  def string_to_boolean(<<"0">>), do: false
+  def string_to_boolean(<<"False">>), do: false
+  def string_to_boolean(<<"false">>), do: false
+  def string_to_boolean(<<"no">>), do: false
+  def string_to_boolean(<<"No">>), do: false
+
+  def string_to_boolean(<<>>), do: nil
+
+  def string_to_boolean(value),
+    do: raise(ToBooleanError, message: ToBooleanError.error_message(value))
 
   def to_boolean(s) when is_boolean(s), do: s
   def to_boolean(s) when is_binary(s), do: string_to_boolean(s)
   def to_boolean(s) when is_integer(s) and s >= 1, do: true
-  def to_boolean(_), do: false
+
+  def to_boolean(value),
+    do: raise(ToBooleanError, message: ToBooleanError.error_message(value))
 
   def to_integer(<<_::binary>> = s), do: :erlang.binary_to_integer(s)
   def to_integer([_ | _] = s), do: :erlang.list_to_integer(s)
   def to_integer(s) when is_integer(s), do: s
   def to_integer(s) when is_float(s), do: :erlang.round(s)
+  def to_integer(value), do: raise(ToIntegerError, message: ToIntegerError.error_message(value))
 end

--- a/apps/utils/test/utils/helpers/normalize_test.exs
+++ b/apps/utils/test/utils/helpers/normalize_test.exs
@@ -66,4 +66,55 @@ defmodule Utils.Helpers.NormalizeTest do
       refute Normalize.to_boolean(-1)
     end
   end
+
+  describe "to_integer/1" do
+    test "keeps integers as integers" do
+      assert 1 == Normalize.to_integer(1)
+      assert 2 == Normalize.to_integer(2)
+      assert 65_535 == Normalize.to_integer(65_535)
+      assert 99_999 == Normalize.to_integer(99_999)
+      assert 0 == Normalize.to_integer(0)
+      assert -1 == Normalize.to_integer(-1)
+    end
+
+    test "converts binaries to integer" do
+      assert 1 == Normalize.to_integer(<<"1">>)
+      assert 2 == Normalize.to_integer(<<"2">>)
+      assert 65_535 == Normalize.to_integer(<<"65535">>)
+      assert 99_999 == Normalize.to_integer(<<"99999">>)
+      assert 999_991 == Normalize.to_integer(<<"99999", "1">>)
+      assert 0 == Normalize.to_integer(<<"0">>)
+      assert -1 == Normalize.to_integer(<<"-1">>)
+    end
+
+    test "converts lists to integer" do
+      assert 1 == Normalize.to_integer('1')
+      assert 2 == Normalize.to_integer('2')
+      assert 65_535 == Normalize.to_integer('65535')
+      assert 99_999 == Normalize.to_integer('99999')
+      assert 999_991 == Normalize.to_integer('999991')
+      assert 0 == Normalize.to_integer('0')
+      assert -1 == Normalize.to_integer('-1')
+    end
+
+    test "converts floats to integer" do
+      assert 1 == Normalize.to_integer(1.0)
+      assert 2 == Normalize.to_integer(2.0)
+      assert 65_535 == Normalize.to_integer(65_535.0)
+      assert 99_999 == Normalize.to_integer(99_999.0)
+      assert 999_991 == Normalize.to_integer(999_991.0)
+      assert 0 == Normalize.to_integer(0.0)
+      assert -1 == Normalize.to_integer(-1.0)
+
+      assert 1 == Normalize.to_integer(1.1)
+      assert 2 == Normalize.to_integer(2.2)
+      assert 65_535 == Normalize.to_integer(65_535.3)
+      assert 99_999 == Normalize.to_integer(99_999.4)
+      assert 999_992 == Normalize.to_integer(999_991.5)
+      assert 0 == Normalize.to_integer(0.0)
+      assert -1 == Normalize.to_integer(-1.0)
+      assert -1 == Normalize.to_integer(-1.4)
+      assert -2 == Normalize.to_integer(-1.5)
+    end
+  end
 end

--- a/apps/utils/test/utils/helpers/normalize_test.exs
+++ b/apps/utils/test/utils/helpers/normalize_test.exs
@@ -15,6 +15,7 @@
 defmodule Utils.Helpers.NormalizeTest do
   use ExUnit.Case, async: true
   alias Utils.Helpers.Normalize
+  alias Utils.Helpers.Normalize.ToBooleanError
 
   describe "string_to_boolean/1" do
     test "converts strings to boolean" do
@@ -22,17 +23,18 @@ defmodule Utils.Helpers.NormalizeTest do
       assert Normalize.string_to_boolean("Yes")
       assert Normalize.string_to_boolean("true")
       assert Normalize.string_to_boolean("True")
-      assert Normalize.string_to_boolean("yup")
-      assert Normalize.string_to_boolean("yo")
-      assert Normalize.string_to_boolean("yawn")
       assert Normalize.string_to_boolean("1")
-      refute Normalize.string_to_boolean("nope")
-      refute Normalize.string_to_boolean("no")
       refute Normalize.string_to_boolean("false")
       refute Normalize.string_to_boolean("0")
-      refute Normalize.string_to_boolean(1)
-      refute Normalize.string_to_boolean(true)
-      refute Normalize.string_to_boolean(false)
+      refute Normalize.string_to_boolean("no")
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean("nope") end)
+
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean("yup") end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean("yo") end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean("yawn") end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean(1) end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean(true) end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean(false) end)
     end
   end
 
@@ -42,14 +44,14 @@ defmodule Utils.Helpers.NormalizeTest do
       assert Normalize.to_boolean("Yes")
       assert Normalize.to_boolean("true")
       assert Normalize.to_boolean("True")
-      assert Normalize.to_boolean("yup")
-      assert Normalize.to_boolean("yo")
-      assert Normalize.to_boolean("yawn")
       assert Normalize.to_boolean("1")
-      refute Normalize.to_boolean("nope")
-      refute Normalize.to_boolean("no")
       refute Normalize.to_boolean("false")
       refute Normalize.to_boolean("0")
+      refute Normalize.to_boolean("no")
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean("nope") end)
+      assert_raise(ToBooleanError, fn -> assert Normalize.to_boolean("yup") end)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean("yo") end)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean("yawn") end)
     end
 
     test "converts boolean to boolean" do
@@ -62,8 +64,8 @@ defmodule Utils.Helpers.NormalizeTest do
       assert Normalize.to_boolean(2)
       assert Normalize.to_boolean(65_535)
       assert Normalize.to_boolean(99_999)
-      refute Normalize.to_boolean(0)
-      refute Normalize.to_boolean(-1)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean(0) end)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean(-1) end)
     end
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       LOCAL_LEDGER_DATABASE_URL: "postgresql://postgres:passw0rd@postgres:5432/local_ledger"
       EWALLET_SECRET_KEY: "CHANGE_ME"
       LOCAL_LEDGER_SECRET_KEY: "CHANGE_ME"
+      SERVE_LOCAL_STATIC: false
     ports:
       - "4000:4000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       EWALLET_SECRET_KEY: "CHANGE_ME"
       LOCAL_LEDGER_SECRET_KEY: "CHANGE_ME"
       SERVE_LOCAL_STATIC: false
+      METRICS: false
     ports:
       - "4000:4000"
 

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -33,6 +33,7 @@ release :ewallet do
     local_ledger: :permanent,
     local_ledger_db: :permanent,
     url_dispatcher: :permanent,
+    status: :permanent
   ]
 
   set commands: [


### PR DESCRIPTION
Issue/Task Number:

# Overview

AppSignal VM monitoring umbrella app. 

# Changes

- Added a new umbrella application.
# Implementation Details

Decided for a separate umbrella application because it doesn't fit anywhere else.


# Usage

It's enabled currently in the configuration, a deployment should (after setting up a custom dashboard) start sending the data to AppSignal backend.

AppSignal frontend configuration:
```
-
  title: 'VM dashboard'
  graphs:
    -
      title: 'VM atom over time'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_system_info_atom_count
      tags:
        node: '*'
    -
      title: 'ETS count'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_ets_count
      tags:
        node: '*'
    -
      title: 'IO Input KB'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_io_input_kb
      tags:
        node: '*'
    -
      title: 'IO Output KB'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_io_output_kb
      tags:
        node: '*'
    -
      title: 'Port count'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_system_info_port_count
      tags:
        node: '*'
    -
      title: 'Process count'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_system_info_process_count
      tags:
        node: '*'
    -
      title: 'Number of schedulers'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_system_info_schedulers
      tags:
        node: '*'
    -
      title: erlang_total_run_queue_lengths
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_total_run_queue_lengths
      tags:
        node: '*'
    -
      title: Uptime
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_uptime
      tags:
        node: '*'
    -
      title: 'Atom memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_atom
      tags:
        node: '*'
    -
      title: 'Atom memory used'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_atom_used
      tags:
        node: '*'
    -
      title: 'Binary memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_binary
      tags:
        node: '*'
    -
      title: 'ETS memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_ets
      tags:
        node: '*'
    -
      title: 'Memory processes'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_processes
      tags:
        node: '*'
    -
      title: 'Memory total'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_total
      tags:
        node: '*'
```

# Impact

/
