### PR TITLE
Fix failed new pagination tests

### DIFF
--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -143,7 +143,7 @@ defmodule EWallet.Web.OrchestratorTest do
       attrs = %{
         "start_by" => "id",
         "start_after" => my_account1.id,
-        "sort_by" => "id",
+        "sort_by" => "inserted_at",
         "search_term" => "my_account"
       }
 
@@ -186,7 +186,8 @@ defmodule EWallet.Web.OrchestratorTest do
             "comparator" => "gt",
             "value" => account1.id
           }
-        ]
+        ],
+        "sort_by" => "inserted_at"
       }
 
       # Is it not error when used with match_any?

--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -133,17 +133,20 @@ defmodule EWallet.Web.OrchestratorTest do
     test "returns records with the given `start_after`, `start_by` and `search_term` matched multiple records" do
       # Add search_term-unmatched records
       insert(:account, name: "account1")
+      :timer.sleep(10)
       insert(:account, name: "account2")
+      :timer.sleep(10)
       insert(:account, name: "account3")
+      :timer.sleep(10)
 
       # Add search_term-matched records.
       my_account1 = insert(:account, name: "my_account1")
+      :timer.sleep(10)
       my_account2 = insert(:account, name: "my_account2")
 
       attrs = %{
         "start_by" => "id",
         "start_after" => my_account1.id,
-        "sort_by" => "inserted_at",
         "search_term" => "my_account"
       }
 
@@ -174,7 +177,9 @@ defmodule EWallet.Web.OrchestratorTest do
 
     test "returns records with the given `start_after`, `start_by` and `match_any` matched multiple records" do
       account1 = insert(:account)
+      :timer.sleep(10)
       account2 = insert(:account)
+      :timer.sleep(10)
       account3 = insert(:account)
 
       attrs = %{
@@ -186,8 +191,7 @@ defmodule EWallet.Web.OrchestratorTest do
             "comparator" => "gt",
             "value" => account1.id
           }
-        ],
-        "sort_by" => "inserted_at"
+        ]
       }
 
       # Is it not error when used with match_any?


### PR DESCRIPTION
Issue/Task Number: #843

Closes #843

# Overview

This PR fixes random failure tests on:

- test/ewallet/web/orchestrator_test.exs:133
- test/ewallet/web/orchestrator_test.exs:175

# Changes

- Added `sort_by: inserted_at`