### PR TITLE
Fix normalizer to make our lives easier

### DIFF
--- a/apps/ewallet/lib/ewallet/cli.ex
+++ b/apps/ewallet/lib/ewallet/cli.ex
@@ -63,7 +63,7 @@ defmodule EWallet.CLI do
   def configure_logger do
     "DEBUG"
     |> System.get_env()
-    |> Normalize.to_boolean()
+    |> Normalize.to_boolean(false)
     |> case do
       true -> Logger.configure(level: :debug)
       false -> Logger.configure(level: :warn)

--- a/apps/utils/lib/helpers/normalize.ex
+++ b/apps/utils/lib/helpers/normalize.ex
@@ -51,7 +51,8 @@ defmodule Utils.Helpers.Normalize do
   def string_to_boolean(value),
     do: raise(ToBooleanError, message: ToBooleanError.error_message(value))
 
-  # We need /1 and /2 separated, because if no default is specified, the app should crash, trying to parse nil as a bool/bin/int
+  # We need /1 and /2 separated, because if no default is specified, the app
+  # should crash, trying to parse nil as a bool/bin/int
   def to_boolean(s) when is_boolean(s), do: s
   def to_boolean(s) when is_binary(s), do: string_to_boolean(s)
   def to_boolean(s) when is_integer(s) and s >= 1, do: true

--- a/apps/utils/lib/helpers/normalize.ex
+++ b/apps/utils/lib/helpers/normalize.ex
@@ -51,12 +51,20 @@ defmodule Utils.Helpers.Normalize do
   def string_to_boolean(value),
     do: raise(ToBooleanError, message: ToBooleanError.error_message(value))
 
+  # We need /1 and /2 separated, because if no default is specified, the app should crash, trying to parse nil as a bool/bin/int
   def to_boolean(s) when is_boolean(s), do: s
   def to_boolean(s) when is_binary(s), do: string_to_boolean(s)
   def to_boolean(s) when is_integer(s) and s >= 1, do: true
 
   def to_boolean(value),
     do: raise(ToBooleanError, message: ToBooleanError.error_message(value))
+
+  # Can be used when having a default value is fine, like DEBUG for seeds
+  def to_boolean(nil, default), do: default
+  def to_boolean(s, _) when is_boolean(s), do: s
+  def to_boolean(s, _) when is_binary(s), do: string_to_boolean(s)
+  def to_boolean(s, _) when is_integer(s) and s >= 1, do: true
+  def to_boolean(_, default), do: default
 
   def to_integer(<<_::binary>> = s), do: :erlang.binary_to_integer(s)
   def to_integer([_ | _] = s), do: :erlang.list_to_integer(s)


### PR DESCRIPTION
Issue/Task Number: #851 
Closes #851

# Overview

Add a `to_boolean/2` function to the `Normalize` module to make it possible for callers to specify a default value. Should only be used when having a default can be considered safe.
