### PR TITLE
Allow DB connection pool sharing between repos

### DIFF
--- a/apps/activity_logger/config/config.exs
+++ b/apps/activity_logger/config/config.exs
@@ -7,4 +7,10 @@ config :activity_logger,
   schemas_to_activity_log_config: %{ActivityLogger.System => %{type: "system", identifier: nil}},
   activity_log_types_to_schemas: %{"system" => ActivityLogger.System}
 
+config :activity_logger, ActivityLogger.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  pool: DB.SharedConnectionPool,
+  shared_pool_id: :ewallet,
+  migration_timestamps: [type: :naive_datetime_usec]
+
 import_config "#{Mix.env()}.exs"

--- a/apps/activity_logger/config/config.exs
+++ b/apps/activity_logger/config/config.exs
@@ -10,7 +10,7 @@ config :activity_logger,
 config :activity_logger, ActivityLogger.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: DB.SharedConnectionPool,
-  pool_size: {:system, "EWALLET_POOL_SIZE", 10, {String, :to_integer}},
+  pool_size: {:system, "EWALLET_POOL_SIZE", 15, {String, :to_integer}},
   shared_pool_id: :ewallet,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/apps/activity_logger/config/config.exs
+++ b/apps/activity_logger/config/config.exs
@@ -10,6 +10,7 @@ config :activity_logger,
 config :activity_logger, ActivityLogger.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: DB.SharedConnectionPool,
+  pool_size: {:system, "EWALLET_POOL_SIZE", 10, {String, :to_integer}},
   shared_pool_id: :ewallet,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/apps/activity_logger/config/dev.exs
+++ b/apps/activity_logger/config/dev.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :activity_logger, ActivityLogger.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_dev"},
-  migration_timestamps: [type: :naive_datetime_usec]
+  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_dev"}

--- a/apps/activity_logger/config/prod.exs
+++ b/apps/activity_logger/config/prod.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :activity_logger, ActivityLogger.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_prod"},
-  migration_timestamps: [type: :naive_datetime_usec]
+  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_prod"}

--- a/apps/activity_logger/config/test.exs
+++ b/apps/activity_logger/config/test.exs
@@ -1,9 +1,7 @@
 use Mix.Config
 
 config :activity_logger, ActivityLogger.Repo,
-  adapter: Ecto.Adapters.Postgres,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"},
-  migration_timestamps: [type: :naive_datetime_usec],
   queue_target: 1_000,
   queue_interval: 5_000

--- a/apps/activity_logger/config/test.exs
+++ b/apps/activity_logger/config/test.exs
@@ -3,5 +3,5 @@ use Mix.Config
 config :activity_logger, ActivityLogger.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"},
-  queue_target: 1_000,
-  queue_interval: 5_000
+  queue_target: 10_000,
+  queue_interval: 60_000

--- a/apps/activity_logger/mix.exs
+++ b/apps/activity_logger/mix.exs
@@ -41,6 +41,7 @@ defmodule ActivityLogger.MixProject do
     [
       {:appsignal, "~> 1.9"},
       {:cloak, "~> 0.9.1"},
+      {:db, in_umbrella: true},
       {:deferred_config, "~> 0.1.0"},
       {:ecto_sql, "~> 3.0"},
       {:ex_machina, "~> 2.2", only: :test},

--- a/apps/db/lib/db/shared_connection_pool.ex
+++ b/apps/db/lib/db/shared_connection_pool.ex
@@ -1,0 +1,57 @@
+# Copyright 2019 OmiseGO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule DB.SharedConnectionPool do
+  @moduledoc """
+  A singleton connection pool that can share connections across repos. Each pool is
+  identified by a `shared_pool_id`.
+
+  The actual pool GenServer and its logic are handled by `DBConnection.ConnectionPool`.
+  """
+  alias DBConnection.ConnectionPool
+
+  @doc """
+  Prepare a child spec for a connection pool.
+
+  The returned spec will start only one pool for a given unique `:shared_pool_id` option.
+  """
+  def child_spec({mod, opts}) do
+    opts = Keyword.put_new(opts, :name, pool_name(opts))
+    Supervisor.Spec.worker(__MODULE__, [{mod, opts}])
+  end
+
+  @doc """
+  Start a connection pool.
+  """
+  def start_link({mod, opts}) do
+    case GenServer.start_link(ConnectionPool, {mod, opts}, start_opts(opts)) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      error -> error
+    end
+  end
+
+  # Attempt to build a unique pool name using this module's full name and the `shared_pool_id`.
+  defp pool_name(opts) do
+    case Keyword.fetch(opts, :shared_pool_id) do
+      {:ok, pool} -> String.to_atom("#{__MODULE__}-#{pool}")
+      :error -> __MODULE__
+    end
+  end
+
+  # Exact same as `DBConnection.ConnectionPool`
+  defp start_opts(opts) do
+    Keyword.take(opts, [:name, :spawn_opt])
+  end
+end

--- a/apps/db/lib/db/shared_connection_pool.ex
+++ b/apps/db/lib/db/shared_connection_pool.ex
@@ -17,6 +17,9 @@ defmodule DB.SharedConnectionPool do
   A singleton connection pool that can share connections across repos. Each pool is
   identified by a `shared_pool_id`.
 
+  If `:shared_pool_id` is not given, a single connection pool is used across all repos
+  that are configured to `pool: DB.SharedConnectionPool`.
+
   The actual pool GenServer and its logic are handled by `DBConnection.ConnectionPool`.
   """
   alias DBConnection.ConnectionPool

--- a/apps/db/mix.exs
+++ b/apps/db/mix.exs
@@ -1,0 +1,36 @@
+defmodule DB.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :db,
+      version: "1.2.0-dev",
+      elixir: "~> 1.8",
+      start_permanent: Mix.env == :prod,
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ],
+      deps: deps()
+    ]
+  end
+
+  # Configuration for the OTP application.
+  #
+  # Type `mix help compile.app` for more information.
+  def application do
+    []
+  end
+
+  # Specifies your project dependencies.
+  #
+  # Type `mix help deps` for examples and options.
+  defp deps do
+    [
+      {:db_connection, "~> 2.0"}
+    ]
+  end
+end

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -228,6 +228,7 @@ config :ewallet_config,
 config :ewallet_config, EWalletConfig.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: DB.SharedConnectionPool,
+  pool_size: {:system, "EWALLET_POOL_SIZE", 10, {String, :to_integer}},
   shared_pool_id: :ewallet,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -225,4 +225,10 @@ config :ewallet_config,
     }
   }
 
+config :ewallet_config, EWalletConfig.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  pool: DB.SharedConnectionPool,
+  shared_pool_id: :ewallet,
+  migration_timestamps: [type: :naive_datetime_usec]
+
 import_config "#{Mix.env()}.exs"

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -228,7 +228,7 @@ config :ewallet_config,
 config :ewallet_config, EWalletConfig.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: DB.SharedConnectionPool,
-  pool_size: {:system, "EWALLET_POOL_SIZE", 10, {String, :to_integer}},
+  pool_size: {:system, "EWALLET_POOL_SIZE", 15, {String, :to_integer}},
   shared_pool_id: :ewallet,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/apps/ewallet_config/config/dev.exs
+++ b/apps/ewallet_config/config/dev.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :ewallet_config, EWalletConfig.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_dev"},
-  migration_timestamps: [type: :naive_datetime_usec]
+  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_dev"}

--- a/apps/ewallet_config/config/prod.exs
+++ b/apps/ewallet_config/config/prod.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :ewallet_config, EWalletConfig.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_prod"},
-  migration_timestamps: [type: :naive_datetime_usec]
+  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_prod"}

--- a/apps/ewallet_config/config/test.exs
+++ b/apps/ewallet_config/config/test.exs
@@ -3,5 +3,5 @@ use Mix.Config
 config :ewallet_config, EWalletConfig.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"},
-  queue_target: 1_000,
-  queue_interval: 5_000
+  queue_target: 10_000,
+  queue_interval: 60_000

--- a/apps/ewallet_config/config/test.exs
+++ b/apps/ewallet_config/config/test.exs
@@ -1,9 +1,7 @@
 use Mix.Config
 
 config :ewallet_config, EWalletConfig.Repo,
-  adapter: Ecto.Adapters.Postgres,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"},
-  migration_timestamps: [type: :naive_datetime_usec],
   queue_target: 1_000,
   queue_interval: 5_000

--- a/apps/ewallet_config/mix.exs
+++ b/apps/ewallet_config/mix.exs
@@ -45,6 +45,7 @@ defmodule EWalletConfig.MixProject do
       {:arc_ecto, github: "omisego/arc_ecto"},
       {:bcrypt_elixir, "~> 1.0"},
       {:cloak, "~> 0.9.1"},
+      {:db, in_umbrella: true},
       {:deferred_config, "~> 0.1.0"},
       {:ecto_sql, "~> 3.0"},
       {:plug, "~> 1.0"},

--- a/apps/ewallet_db/config/config.exs
+++ b/apps/ewallet_db/config/config.exs
@@ -19,6 +19,7 @@ config :ewallet_db,
 config :ewallet_db, EWalletDB.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: DB.SharedConnectionPool,
+  pool_size: {:system, "EWALLET_POOL_SIZE", 10, {String, :to_integer}},
   shared_pool_id: :ewallet,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/apps/ewallet_db/config/config.exs
+++ b/apps/ewallet_db/config/config.exs
@@ -16,4 +16,10 @@ config :ewallet_db,
     :master_account
   ]
 
+config :ewallet_db, EWalletDB.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  pool: DB.SharedConnectionPool,
+  shared_pool_id: :ewallet,
+  migration_timestamps: [type: :naive_datetime_usec]
+
 import_config "#{Mix.env()}.exs"

--- a/apps/ewallet_db/config/config.exs
+++ b/apps/ewallet_db/config/config.exs
@@ -19,7 +19,7 @@ config :ewallet_db,
 config :ewallet_db, EWalletDB.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: DB.SharedConnectionPool,
-  pool_size: {:system, "EWALLET_POOL_SIZE", 10, {String, :to_integer}},
+  pool_size: {:system, "EWALLET_POOL_SIZE", 15, {String, :to_integer}},
   shared_pool_id: :ewallet,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/apps/ewallet_db/config/dev.exs
+++ b/apps/ewallet_db/config/dev.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :ewallet_db, EWalletDB.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_dev"},
-  migration_timestamps: [type: :naive_datetime_usec]
+  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_dev"}

--- a/apps/ewallet_db/config/prod.exs
+++ b/apps/ewallet_db/config/prod.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :ewallet_db, EWalletDB.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_prod"},
-  migration_timestamps: [type: :naive_datetime_usec]
+  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_prod"}

--- a/apps/ewallet_db/config/test.exs
+++ b/apps/ewallet_db/config/test.exs
@@ -3,5 +3,5 @@ use Mix.Config
 config :ewallet_db, EWalletDB.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"},
-  queue_target: 1_500,
-  queue_interval: 5_000
+  queue_target: 10_000,
+  queue_interval: 60_000

--- a/apps/ewallet_db/config/test.exs
+++ b/apps/ewallet_db/config/test.exs
@@ -1,9 +1,7 @@
 use Mix.Config
 
 config :ewallet_db, EWalletDB.Repo,
-  adapter: Ecto.Adapters.Postgres,
   pool: Ecto.Adapters.SQL.Sandbox,
-  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"},
-  migration_timestamps: [type: :naive_datetime_usec],
+  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"}
   queue_target: 1_500,
   queue_interval: 5_000

--- a/apps/ewallet_db/config/test.exs
+++ b/apps/ewallet_db/config/test.exs
@@ -2,6 +2,6 @@ use Mix.Config
 
 config :ewallet_db, EWalletDB.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
-  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"}
+  url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"},
   queue_target: 1_500,
   queue_interval: 5_000

--- a/apps/ewallet_db/mix.exs
+++ b/apps/ewallet_db/mix.exs
@@ -49,6 +49,7 @@ defmodule EWalletDB.Mixfile do
       {:arc_ecto, github: "omisego/arc_ecto"},
       {:bcrypt_elixir, "~> 1.0"},
       {:cloak, "~> 0.9.1"},
+      {:db, in_umbrella: true},
       {:deferred_config, "~> 0.1.0"},
       {:ecto_sql, "~> 3.0"},
       {:ewallet_config, in_umbrella: true},

--- a/apps/local_ledger_db/config/config.exs
+++ b/apps/local_ledger_db/config/config.exs
@@ -8,7 +8,7 @@ config :local_ledger_db,
 config :local_ledger_db, LocalLedgerDB.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: DB.SharedConnectionPool,
-  pool_size: {:system, "LOCAL_LEDGER_POOL_SIZE", 10, {String, :to_integer}},
+  pool_size: {:system, "LOCAL_LEDGER_POOL_SIZE", 5, {String, :to_integer}},
   shared_pool_id: :local_ledger,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/apps/local_ledger_db/config/config.exs
+++ b/apps/local_ledger_db/config/config.exs
@@ -8,6 +8,7 @@ config :local_ledger_db,
 config :local_ledger_db, LocalLedgerDB.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool: DB.SharedConnectionPool,
+  pool_size: {:system, "LOCAL_LEDGER_POOL_SIZE", 10, {String, :to_integer}},
   shared_pool_id: :local_ledger,
   migration_timestamps: [type: :naive_datetime_usec]
 

--- a/apps/local_ledger_db/config/config.exs
+++ b/apps/local_ledger_db/config/config.exs
@@ -5,32 +5,10 @@ use Mix.Config
 config :local_ledger_db,
   ecto_repos: [LocalLedgerDB.Repo]
 
-# Import environment specific config. This must remain at the bottom
-# of this file so it overrides the configuration defined above.
+config :local_ledger_db, LocalLedgerDB.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  pool: DB.SharedConnectionPool,
+  shared_pool_id: :local_ledger,
+  migration_timestamps: [type: :naive_datetime_usec]
+
 import_config "#{Mix.env()}.exs"
-
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :local_ledger_db, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:local_ledger_db, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"

--- a/apps/local_ledger_db/config/dev.exs
+++ b/apps/local_ledger_db/config/dev.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :local_ledger_db, LocalLedgerDB.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: {:system, "LOCAL_LEDGER_DATABASE_URL", "postgres://localhost/local_ledger_dev"},
-  migration_timestamps: [type: :naive_datetime_usec]
+  url: {:system, "LOCAL_LEDGER_DATABASE_URL", "postgres://localhost/local_ledger_dev"}

--- a/apps/local_ledger_db/config/prod.exs
+++ b/apps/local_ledger_db/config/prod.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
 config :local_ledger_db, LocalLedgerDB.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: {:system, "LOCAL_LEDGER_DATABASE_URL", "postgres://localhost/local_ledger_prod"},
-  migration_timestamps: [type: :naive_datetime_usec]
+  url: {:system, "LOCAL_LEDGER_DATABASE_URL", "postgres://localhost/local_ledger_prod"}

--- a/apps/local_ledger_db/config/test.exs
+++ b/apps/local_ledger_db/config/test.exs
@@ -3,5 +3,5 @@ use Mix.Config
 config :local_ledger_db, LocalLedgerDB.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: {:system, "LOCAL_LEDGER_DATABASE_URL", "postgres://localhost/local_ledger_test"},
-  queue_target: 1_000,
-  queue_interval: 5_000
+  queue_target: 10_000,
+  queue_interval: 60_000

--- a/apps/local_ledger_db/config/test.exs
+++ b/apps/local_ledger_db/config/test.exs
@@ -1,9 +1,7 @@
 use Mix.Config
 
 config :local_ledger_db, LocalLedgerDB.Repo,
-  adapter: Ecto.Adapters.Postgres,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: {:system, "LOCAL_LEDGER_DATABASE_URL", "postgres://localhost/local_ledger_test"},
-  migration_timestamps: [type: :naive_datetime_usec],
   queue_target: 1_000,
   queue_interval: 5_000

--- a/apps/local_ledger_db/mix.exs
+++ b/apps/local_ledger_db/mix.exs
@@ -36,6 +36,7 @@ defmodule LocalLedgerDB.Mixfile do
     [
       {:appsignal, "~> 1.9"},
       {:cloak, "~> 0.9.1"},
+      {:db, in_umbrella: true},
       {:deferred_config, "~> 0.1.0"},
       {:ecto_sql, "~> 3.0"},
       {:ewallet_config, in_umbrella: true},

--- a/docs/setup/advanced/env.md
+++ b/docs/setup/advanced/env.md
@@ -4,10 +4,10 @@
 
 Below are the general environment variables needed for the eWallet to run.
 
-- `MIX_ENV`: Environment in which the application is being ran. `prod` for production.
+- `MIX_ENV`: The environment in which the application is being ran. `prod` for production.
 - `PORT`: The port that the application listens on.
-- `EWALLET_SECRET_KEY`: Encryption key used to encrypt some data in the database.
-- `LOCAL_LEDGER_SECRET_KEY`: Encryption key used to encrypt some data in the database.
+- `EWALLET_SECRET_KEY`: The encryption key used to encrypt data in the `ewallet` database.
+- `LOCAL_LEDGER_SECRET_KEY`: The encryption key used to encrypt data in the `local_ledger` database.
 
 To generate a new secret key using Elixir:
 
@@ -20,8 +20,14 @@ $ elixir -e "IO.puts 32 |> :crypto.strong_rand_bytes() |> Base.encode64()"
 
 The eWallet needs access to two different databases: one for the eWallet itself and one for the local ledger. The following environment variables need to be set.
 
-- `DATABASE_URL`
-- `LOCAL_LEDGER_DATABASE_URL`
+- `DATABASE_URL`: The connection URI for the `ewallet` database.
+- `LOCAL_LEDGER_DATABASE_URL`: The connection URI for the `local_ledger` database.
+- `EWALLET_POOL_SIZE`: The connection pool size for the `ewallet` database. _Defaults to `10`._
+- `LOCAL_LEDGER_POOL_SIZE`: The connection pool size for the `local_ledger` database. _Defaults to `10`._
+
+See the connection URI format at [Postgres' Connection URIs](https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6).
+
+See the suggestion for finding the optimal pool size at [How to Find the Optimal Database Connection Pool Size](https://wiki.postgresql.org/wiki/Number_Of_Database_Connections#How_to_Find_the_Optimal_Database_Connection_Pool_Size)
 
 ## Application Monitoring
 


### PR DESCRIPTION
Issue/Task Number: #327
Closes #327 

# Overview

This PR implements `DB.SharedConnectionPool` to let repos that connect to the same database reuse the same connection pool, so we don't max out DB connections limit. Then exposes the pool for `ewallet` and `local_ledger` databases via ENV vars.

# Changes

- Implemented `DB.SharedConnectionPool`
- Configure `ActivityLogger.Repo`, `EWalletConfig.Repo`, `EWalletDB.Repo` to use `DB.SharedConnectionPool` with `shared_pool_id: :ewallet`
- Configure `LocalLedgerDB.Repo` to use `DB.SharedConnectionPool` with `shared_pool_id: :local_ledger`
- Move common repo configs such as `:adapter` and `:migration_timestamps` into the main config files.

# Implementation Details

Currently each repo has its own independent connection pools. With the default `pool_size: 10`, this means `ActivityLogger.Repo`, `EWalletConfig.Repo`, `EWalletDB.Repo`, `LocalLedgerDB.Repo` combined are making 40 persistent connections to the database per app instance. Having 3 app nodes would have already saturated over 100+ connections to the database. Since, the first 3 repos actually connect to the same database, they should be able to share connections without losing performance.

After tracing down how Ecto repos create connections, it turned out that the connection pool can be specified with `:pool` as a repo configs, and it uses `DBConnection.ConnectionPool`, which is basically wrapped as a GenServer, so it's really easy to spawn a new GenServer or share an existing one by giving the GenServer a name.

With this, a new `DB.SharedConnectionPool` module is created. It manages whether to create or reuse a connection pool based on the provided `:shared_pool_id`, while still rely on the original `DBConnection.ConnectionPool` for its pool implementation.

Behind the scene, pretty much all it does is managing the name of the `DBConnection.ConnectionPool` spawned.

## Limitations

Since this design is based on minimizing interference with Ecto, it's still relying on the database connection info that is configured for each Ecto repo in `config.exs` of each app. This means that it's indeterministic of which specific sub-app will the configs be taken from to start the pool. It could be `EWalletDB.Repo` or `ActivityLogger.Repo`, etc.

But configs for `shared_pool_id: :ewallet` will never be used to start repos with `shared_pool_id: :local_ledger`, so it should be safe as long as the configs of the repos with the same `:shared_pool_id` are identical.

Worst case is that the repo configs are not identical, and behaviors of that shared pool become inconsistent across application restarts.

## How to setup a shared connection pool in code

If more repos in the future would like to join an existing shared pool, set that repo's pool to `DB.SharedConnectionPool` and set `:shared_pool_id` to the pool id you wish to join, e.g.

```elixir
config :ewallet_db, EWalletDB.Repo,
  pool: DB.SharedConnectionPool,
  shared_pool_id: :ewallet
```

If `:shared_pool_id` is not given, a single connection pool is used across all repos that are configured to `pool: DB.SharedConnectionPool` without a `:shared_pool_id`.

# Usage

From provider's perspective, the shared pools are hardcoded, but the size of each shared pool can be configured via ENV vars. For example:

```shell
export EWALLET_POOL_SIZE=15
export LOCAL_LEDGER_POOL_SIZE=5
```

Using 15 & 5 (the current defaults set in this PR's code) gives produces:

```
postgres=> select datname, COUNT(datname) from pg_stat_activity GROUP BY datname;
   datname    | count
--------------+-------
 ewallet      |    15
 local_ledger |    5
(2 rows)
```

# Impact

No changes to DB schema or API specs. However pool size can be configured, see Usage above on how to set pool size.