### PR TITLE
Remove 5-association limit from MatchParser #783

### DIFF
--- a/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
@@ -61,6 +61,28 @@ defmodule EWallet.Web.MatchAllQuery do
     end
   end
 
+  # March 11, 2019
+  #
+  # Previous implementations had a 5-assocation limit and required hard-cording it's position.
+  # The original plan to fix this issue was to utilize Ecto's named binding feature. However,
+  # that required creating compile time atoms for every association within our schema. So, named binding
+  # was abandoned. Instead, Dynamic queries with dynamic positiong was used. This allowed for any number
+  # of associations and without the use of compile-time atoms.
+  #
+  # The use of {a, position} within dynamic() is an internal implementation.
+  # Links on this topic:
+  # https://github.com/elixir-ecto/ecto/issues/2832
+  # https://stackoverflow.com/a/54491195/11157034
+  #
+  # It is possible that this feature will become part of the Eto API in the future. (Designed with Ecto 3.0)
+  # If this interanl implementation disappears, one can use the named binding implementation specified in the
+  # Issue 783, link is below. Or revert back to 5-association limit if there are no other paths.
+  #
+  # This only affects do_filter_assoc()
+  #
+  # This was implemented for issue 783: https://github.com/omisego/ewallet/issues/783
+  # Related PR: https://github.com/omisego/ewallet/pull/834
+  #
   def do_filter_assoc(dynamic, position, field, nil, comparator, nil = value) do
     case comparator do
       "eq" -> dynamic([{a, position}], is_nil(field(a, ^field)) and ^dynamic)

--- a/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
@@ -65,18 +65,19 @@ defmodule EWallet.Web.MatchAllQuery do
   #
   # Previous implementations had a 5-assocation limit and required hard-cording it's position.
   # The original plan to fix this issue was to utilize Ecto's named binding feature. However,
-  # that required creating compile time atoms for every association within our schema. So, named binding
-  # was abandoned. Instead, Dynamic queries with dynamic positiong was used. This allowed for any number
-  # of associations and without the use of compile-time atoms.
+  # that required creating compile time atoms for every association within our schema.
+  # So, named binding was abandoned. Instead, Dynamic queries with dynamic positiong was used.
+  # This allowed for any number of associations and without the use of compile-time atoms.
   #
   # The use of {a, position} within dynamic() is an internal implementation.
   # Links on this topic:
   # https://github.com/elixir-ecto/ecto/issues/2832
   # https://stackoverflow.com/a/54491195/11157034
   #
-  # It is possible that this feature will become part of the Eto API in the future. (Designed with Ecto 3.0)
-  # If this interanl implementation disappears, one can use the named binding implementation specified in the
-  # Issue 783, link is below. Or revert back to 5-association limit if there are no other paths.
+  # It is possible that this feature will become part of the Eto API in the future.
+  # (Designed with Ecto 3.0)  If this interanl implementation disappears, one can use
+  # the named binding implementation  specified in Issue 783, link is below. Or revert back
+  # to 5-association limit if there are no other paths.
   #
   # This only affects do_filter_assoc()
   #

--- a/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
@@ -61,7 +61,6 @@ defmodule EWallet.Web.MatchAllQuery do
     end
   end
 
-
   def do_filter_assoc(dynamic, position, field, nil, comparator, nil = value) do
     case comparator do
       "eq" -> dynamic([{a, position}], is_nil(field(a, ^field)) and ^dynamic)
@@ -71,19 +70,33 @@ defmodule EWallet.Web.MatchAllQuery do
   end
 
   def do_filter_assoc(dynamic, position, field, nil, comparator, value) do
-    IO.puts("Position:")
-    IO.inspect(position)
     case comparator do
-      "eq" -> dynamic([{a, position}], field(a, ^field) == ^value and ^dynamic)
-      "neq" -> dynamic([{a, position}], field(a, ^field) != ^value and ^dynamic)
-      "gt" -> dynamic([{a, position}], field(a, ^field) > ^value and ^dynamic)
-      "gte" -> dynamic([{a, position}], field(a, ^field) >= ^value and ^dynamic)
-      "lt" -> dynamic([{a, position}], field(a, ^field) < ^value and ^dynamic)
-      "lte" -> dynamic([{a, position}], field(a, ^field) <= ^value and ^dynamic)
-      "contains" -> dynamic([{a, position}], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
-      "starts_with" -> dynamic([{a, position}], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+      "eq" ->
+        dynamic([{a, position}], field(a, ^field) == ^value and ^dynamic)
+
+      "neq" ->
+        dynamic([{a, position}], field(a, ^field) != ^value and ^dynamic)
+
+      "gt" ->
+        dynamic([{a, position}], field(a, ^field) > ^value and ^dynamic)
+
+      "gte" ->
+        dynamic([{a, position}], field(a, ^field) >= ^value and ^dynamic)
+
+      "lt" ->
+        dynamic([{a, position}], field(a, ^field) < ^value and ^dynamic)
+
+      "lte" ->
+        dynamic([{a, position}], field(a, ^field) <= ^value and ^dynamic)
+
+      "contains" ->
+        dynamic([{a, position}], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
+
+      "starts_with" ->
+        dynamic([{a, position}], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
+
+      _ ->
+        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
-
 end

--- a/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
@@ -61,147 +61,29 @@ defmodule EWallet.Web.MatchAllQuery do
     end
   end
 
-  def do_filter_assoc(dynamic, 0, field, nil, comparator, nil = value) do
+
+  def do_filter_assoc(dynamic, position, field, nil, comparator, nil = value) do
     case comparator do
-      "eq" -> dynamic([q, a], is_nil(field(a, ^field)) and ^dynamic)
-      "neq" -> dynamic([q, a], not is_nil(field(a, ^field)) and ^dynamic)
+      "eq" -> dynamic([{a, position}], is_nil(field(a, ^field)) and ^dynamic)
+      "neq" -> dynamic([{a, position}], not is_nil(field(a, ^field)) and ^dynamic)
       _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
-  def do_filter_assoc(dynamic, 0, field, nil, comparator, value) do
+  def do_filter_assoc(dynamic, position, field, nil, comparator, value) do
+    IO.puts("Position:")
+    IO.inspect(position)
     case comparator do
-      "eq" -> dynamic([q, a], field(a, ^field) == ^value and ^dynamic)
-      "neq" -> dynamic([q, a], field(a, ^field) != ^value and ^dynamic)
-      "gt" -> dynamic([q, a], field(a, ^field) > ^value and ^dynamic)
-      "gte" -> dynamic([q, a], field(a, ^field) >= ^value and ^dynamic)
-      "lt" -> dynamic([q, a], field(a, ^field) < ^value and ^dynamic)
-      "lte" -> dynamic([q, a], field(a, ^field) <= ^value and ^dynamic)
-      "contains" -> dynamic([q, a], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
-      "starts_with" -> dynamic([q, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
+      "eq" -> dynamic([{a, position}], field(a, ^field) == ^value and ^dynamic)
+      "neq" -> dynamic([{a, position}], field(a, ^field) != ^value and ^dynamic)
+      "gt" -> dynamic([{a, position}], field(a, ^field) > ^value and ^dynamic)
+      "gte" -> dynamic([{a, position}], field(a, ^field) >= ^value and ^dynamic)
+      "lt" -> dynamic([{a, position}], field(a, ^field) < ^value and ^dynamic)
+      "lte" -> dynamic([{a, position}], field(a, ^field) <= ^value and ^dynamic)
+      "contains" -> dynamic([{a, position}], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
+      "starts_with" -> dynamic([{a, position}], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
       _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
-  def do_filter_assoc(dynamic, 1, field, nil, comparator, nil = value) do
-    case comparator do
-      "eq" -> dynamic([q, _, a], is_nil(field(a, ^field)) and ^dynamic)
-      "neq" -> dynamic([q, _, a], not is_nil(field(a, ^field)) and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 1, field, nil, comparator, value) do
-    case comparator do
-      "eq" -> dynamic([q, _, a], field(a, ^field) == ^value and ^dynamic)
-      "neq" -> dynamic([q, _, a], field(a, ^field) != ^value and ^dynamic)
-      "gt" -> dynamic([q, _, a], field(a, ^field) > ^value and ^dynamic)
-      "gte" -> dynamic([q, _, a], field(a, ^field) >= ^value and ^dynamic)
-      "lt" -> dynamic([q, _, a], field(a, ^field) < ^value and ^dynamic)
-      "lte" -> dynamic([q, _, a], field(a, ^field) <= ^value and ^dynamic)
-      "contains" -> dynamic([q, _, a], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
-      "starts_with" -> dynamic([q, _, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 2, field, nil, comparator, nil = value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, a], is_nil(field(a, ^field)) and ^dynamic)
-      "neq" -> dynamic([q, _, _, a], not is_nil(field(a, ^field)) and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 2, field, nil, comparator, value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, a], field(a, ^field) == ^value and ^dynamic)
-      "neq" -> dynamic([q, _, _, a], field(a, ^field) != ^value and ^dynamic)
-      "gt" -> dynamic([q, _, _, a], field(a, ^field) > ^value and ^dynamic)
-      "gte" -> dynamic([q, _, _, a], field(a, ^field) >= ^value and ^dynamic)
-      "lt" -> dynamic([q, _, _, a], field(a, ^field) < ^value and ^dynamic)
-      "lte" -> dynamic([q, _, _, a], field(a, ^field) <= ^value and ^dynamic)
-      "contains" -> dynamic([q, _, _, a], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
-      "starts_with" -> dynamic([q, _, _, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 3, field, nil, comparator, nil = value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, _, a], is_nil(field(a, ^field)) and ^dynamic)
-      "neq" -> dynamic([q, _, _, _, a], not is_nil(field(a, ^field)) and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 3, field, nil, comparator, value) do
-    case comparator do
-      "eq" ->
-        dynamic([q, _, _, _, a], field(a, ^field) == ^value and ^dynamic)
-
-      "neq" ->
-        dynamic([q, _, _, _, a], field(a, ^field) != ^value and ^dynamic)
-
-      "gt" ->
-        dynamic([q, _, _, _, a], field(a, ^field) > ^value and ^dynamic)
-
-      "gte" ->
-        dynamic([q, _, _, _, a], field(a, ^field) >= ^value and ^dynamic)
-
-      "lt" ->
-        dynamic([q, _, _, _, a], field(a, ^field) < ^value and ^dynamic)
-
-      "lte" ->
-        dynamic([q, _, _, _, a], field(a, ^field) <= ^value and ^dynamic)
-
-      "contains" ->
-        dynamic([q, _, _, _, a], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
-
-      "starts_with" ->
-        dynamic([q, _, _, _, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
-
-      _ ->
-        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 4, field, nil, comparator, nil = value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, _, _, a], is_nil(field(a, ^field)) and ^dynamic)
-      "neq" -> dynamic([q, _, _, _, _, a], not is_nil(field(a, ^field)) and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 4, field, nil, comparator, value) do
-    case comparator do
-      "eq" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) == ^value and ^dynamic)
-
-      "neq" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) != ^value and ^dynamic)
-
-      "gt" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) > ^value and ^dynamic)
-
-      "gte" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) >= ^value and ^dynamic)
-
-      "lt" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) < ^value and ^dynamic)
-
-      "lte" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) <= ^value and ^dynamic)
-
-      "contains" ->
-        dynamic([q, _, _, _, _, a], ilike(field(a, ^field), ^"%#{value}%") and ^dynamic)
-
-      "starts_with" ->
-        dynamic([q, _, _, _, _, a], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
-
-      _ ->
-        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
 end

--- a/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
@@ -82,5 +82,4 @@ defmodule EWallet.Web.MatchAnyQuery do
       _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
-
 end

--- a/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
@@ -61,6 +61,28 @@ defmodule EWallet.Web.MatchAnyQuery do
     end
   end
 
+  # March 11, 2019
+  #
+  # Previous implementations had a 5-assocation limit and required hard-cording it's position.
+  # The original plan to fix this issue was to utilize Ecto's named binding feature. However,
+  # that required creating compile time atoms for every association within our schema. So, named binding
+  # was abandoned. Instead, Dynamic queries with dynamic positiong was used. This allowed for any number
+  # of associations and without the use of compile-time atoms.
+  #
+  # The use of {a, position} within dynamic() is an internal implementation.
+  # Links on this topic:
+  # https://github.com/elixir-ecto/ecto/issues/2832
+  # https://stackoverflow.com/a/54491195/11157034
+  #
+  # It is possible that this feature will become part of the Eto API in the future. (Designed with Ecto 3.0)
+  # If this interanl implementation disappears, one can use the named binding implementation specified in the
+  # Issue 783, link is below. Or revert back to 5-association limit if there are no other paths.
+  #
+  # This only affects do_filter_assoc()
+  #
+  # This was implemented for issue 783: https://github.com/omisego/ewallet/issues/783
+  # Related PR: https://github.com/omisego/ewallet/pull/834
+  #
   def do_filter_assoc(dynamic, position, field, nil, comparator, nil = value) do
     case comparator do
       "eq" -> dynamic([{a, position}], is_nil(field(a, ^field)) or ^dynamic)

--- a/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
@@ -65,18 +65,19 @@ defmodule EWallet.Web.MatchAnyQuery do
   #
   # Previous implementations had a 5-assocation limit and required hard-cording it's position.
   # The original plan to fix this issue was to utilize Ecto's named binding feature. However,
-  # that required creating compile time atoms for every association within our schema. So, named binding
-  # was abandoned. Instead, Dynamic queries with dynamic positiong was used. This allowed for any number
-  # of associations and without the use of compile-time atoms.
+  # that required creating compile time atoms for every association within our schema.
+  # So, named binding was abandoned. Instead, Dynamic queries with dynamic positiong was used.
+  # This allowed for any number of associations and without the use of compile-time atoms.
   #
   # The use of {a, position} within dynamic() is an internal implementation.
   # Links on this topic:
   # https://github.com/elixir-ecto/ecto/issues/2832
   # https://stackoverflow.com/a/54491195/11157034
   #
-  # It is possible that this feature will become part of the Eto API in the future. (Designed with Ecto 3.0)
-  # If this interanl implementation disappears, one can use the named binding implementation specified in the
-  # Issue 783, link is below. Or revert back to 5-association limit if there are no other paths.
+  # It is possible that this feature will become part of the Eto API in the future.
+  # (Designed with Ecto 3.0)  If this interanl implementation disappears, one can use
+  # the named binding implementation  specified in Issue 783, link is below. Or revert back
+  # to 5-association limit if there are no other paths.
   #
   # This only affects do_filter_assoc()
   #

--- a/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
@@ -61,130 +61,26 @@ defmodule EWallet.Web.MatchAnyQuery do
     end
   end
 
-  def do_filter_assoc(dynamic, 0, field, nil, comparator, nil = value) do
+  def do_filter_assoc(dynamic, position, field, nil, comparator, nil = value) do
     case comparator do
-      "eq" -> dynamic([q, a], is_nil(field(a, ^field)) or ^dynamic)
-      "neq" -> dynamic([q, a], not is_nil(field(a, ^field)) or ^dynamic)
+      "eq" -> dynamic([{a, position}], is_nil(field(a, ^field)) or ^dynamic)
+      "neq" -> dynamic([{a, position}], not is_nil(field(a, ^field)) or ^dynamic)
       _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
-  def do_filter_assoc(dynamic, 0, field, nil, comparator, value) do
+  def do_filter_assoc(dynamic, position, field, nil, comparator, value) do
     case comparator do
-      "eq" -> dynamic([q, a], field(a, ^field) == ^value or ^dynamic)
-      "neq" -> dynamic([q, a], field(a, ^field) != ^value or ^dynamic)
-      "gt" -> dynamic([q, a], field(a, ^field) > ^value or ^dynamic)
-      "gte" -> dynamic([q, a], field(a, ^field) >= ^value or ^dynamic)
-      "lt" -> dynamic([q, a], field(a, ^field) < ^value or ^dynamic)
-      "lte" -> dynamic([q, a], field(a, ^field) <= ^value or ^dynamic)
-      "contains" -> dynamic([q, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
-      "starts_with" -> dynamic([q, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
+      "eq" -> dynamic([{a, position}], field(a, ^field) == ^value or ^dynamic)
+      "neq" -> dynamic([{a, position}], field(a, ^field) != ^value or ^dynamic)
+      "gt" -> dynamic([{a, position}], field(a, ^field) > ^value or ^dynamic)
+      "gte" -> dynamic([{a, position}], field(a, ^field) >= ^value or ^dynamic)
+      "lt" -> dynamic([{a, position}], field(a, ^field) < ^value or ^dynamic)
+      "lte" -> dynamic([{a, position}], field(a, ^field) <= ^value or ^dynamic)
+      "contains" -> dynamic([{a, position}], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
+      "starts_with" -> dynamic([{a, position}], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
       _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
     end
   end
 
-  def do_filter_assoc(dynamic, 1, field, nil, comparator, nil = value) do
-    case comparator do
-      "eq" -> dynamic([q, _, a], is_nil(field(a, ^field)) or ^dynamic)
-      "neq" -> dynamic([q, _, a], not is_nil(field(a, ^field)) or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 1, field, nil, comparator, value) do
-    case comparator do
-      "eq" -> dynamic([q, _, a], field(a, ^field) == ^value or ^dynamic)
-      "neq" -> dynamic([q, _, a], field(a, ^field) != ^value or ^dynamic)
-      "gt" -> dynamic([q, _, a], field(a, ^field) > ^value or ^dynamic)
-      "gte" -> dynamic([q, _, a], field(a, ^field) >= ^value or ^dynamic)
-      "lt" -> dynamic([q, _, a], field(a, ^field) < ^value or ^dynamic)
-      "lte" -> dynamic([q, _, a], field(a, ^field) <= ^value or ^dynamic)
-      "contains" -> dynamic([q, _, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
-      "starts_with" -> dynamic([q, _, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 2, field, nil, comparator, nil = value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, a], is_nil(field(a, ^field)) or ^dynamic)
-      "neq" -> dynamic([q, _, _, a], not is_nil(field(a, ^field)) or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 2, field, nil, comparator, value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, a], field(a, ^field) == ^value or ^dynamic)
-      "neq" -> dynamic([q, _, _, a], field(a, ^field) != ^value or ^dynamic)
-      "gt" -> dynamic([q, _, _, a], field(a, ^field) > ^value or ^dynamic)
-      "gte" -> dynamic([q, _, _, a], field(a, ^field) >= ^value or ^dynamic)
-      "lt" -> dynamic([q, _, _, a], field(a, ^field) < ^value or ^dynamic)
-      "lte" -> dynamic([q, _, _, a], field(a, ^field) <= ^value or ^dynamic)
-      "contains" -> dynamic([q, _, _, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
-      "starts_with" -> dynamic([q, _, _, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 3, field, nil, comparator, nil = value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, _, a], is_nil(field(a, ^field)) or ^dynamic)
-      "neq" -> dynamic([q, _, _, _, a], not is_nil(field(a, ^field)) or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 3, field, nil, comparator, value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, _, a], field(a, ^field) == ^value or ^dynamic)
-      "neq" -> dynamic([q, _, _, _, a], field(a, ^field) != ^value or ^dynamic)
-      "gt" -> dynamic([q, _, _, _, a], field(a, ^field) > ^value or ^dynamic)
-      "gte" -> dynamic([q, _, _, _, a], field(a, ^field) >= ^value or ^dynamic)
-      "lt" -> dynamic([q, _, _, _, a], field(a, ^field) < ^value or ^dynamic)
-      "lte" -> dynamic([q, _, _, _, a], field(a, ^field) <= ^value or ^dynamic)
-      "contains" -> dynamic([q, _, _, _, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
-      "starts_with" -> dynamic([q, _, _, _, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 4, field, nil, comparator, nil = value) do
-    case comparator do
-      "eq" -> dynamic([q, _, _, _, _, a], is_nil(field(a, ^field)) or ^dynamic)
-      "neq" -> dynamic([q, _, _, _, _, a], not is_nil(field(a, ^field)) or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
-
-  def do_filter_assoc(dynamic, 4, field, nil, comparator, value) do
-    case comparator do
-      "eq" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) == ^value or ^dynamic)
-
-      "neq" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) != ^value or ^dynamic)
-
-      "gt" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) > ^value or ^dynamic)
-
-      "gte" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) >= ^value or ^dynamic)
-
-      "lt" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) < ^value or ^dynamic)
-
-      "lte" ->
-        dynamic([q, _, _, _, _, a], field(a, ^field) <= ^value or ^dynamic)
-
-      "contains" ->
-        dynamic([q, _, _, _, _, a], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
-
-      "starts_with" ->
-        dynamic([q, _, _, _, _, a], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
-
-      _ ->
-        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
-    end
-  end
 end

--- a/apps/ewallet/lib/ewallet/web/filters/match_parser.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_parser.ex
@@ -32,7 +32,6 @@ defmodule EWallet.Web.MatchParser do
   def build_query(queryable, inputs, whitelist, dynamic, query_module, mappings \\ %{}) do
     with rules when is_list(rules) <- parse_rules(inputs, whitelist, mappings),
          {queryable, assoc_positions} <- join_assocs(queryable, rules),
-         true <- Enum.count(assoc_positions) <= 5 || {:error, :too_many_associations},
          {:ok, queryable} <- filter(queryable, assoc_positions, rules, dynamic, query_module),
          queryable <- add_distinct(queryable) do
       queryable
@@ -175,7 +174,7 @@ defmodule EWallet.Web.MatchParser do
               query_module.do_filter(dynamic, field, type, comparator, value)
 
             {field, subfield, type} ->
-              position = assoc_positions[field]
+              position = assoc_positions[field] + 1
               query_module.do_filter_assoc(dynamic, position, subfield, type, comparator, value)
           end
 

--- a/apps/ewallet/test/ewallet/web/filters/match_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/filters/match_parser_test.exs
@@ -118,29 +118,7 @@ defmodule EWallet.Web.MatchParserTest do
   end
 
   describe "build_query/3 with nested fields" do
-    test "supports up to 5 different associations" do
-      whitelist = [
-        from_user: [:id],
-        to_user: [:id],
-        from_token: [:id],
-        to_token: [:id],
-        from_wallet: [:id],
-        to_wallet: [:id]
-      ]
-
-      attrs = [
-        %{"field" => "from_user.id", "comparator" => "eq", "value" => 1234},
-        %{"field" => "to_user.id", "comparator" => "eq", "value" => 1234},
-        %{"field" => "from_token.id", "comparator" => "eq", "value" => 1234},
-        %{"field" => "to_token.id", "comparator" => "eq", "value" => 1234},
-        %{"field" => "from_wallet.id", "comparator" => "eq", "value" => 1234}
-      ]
-
-      assert %Ecto.Query{} =
-               MatchParser.build_query(Transaction, attrs, whitelist, true, MatchAllQuery)
-    end
-
-    test "returns error if more than 5 associations are referenced" do
+    test "supports more than 5 associations are referenced" do
       whitelist = [
         from_user: [:id],
         to_user: [:id],
@@ -159,8 +137,8 @@ defmodule EWallet.Web.MatchParserTest do
         %{"field" => "to_wallet.id", "comparator" => "eq", "value" => 1234}
       ]
 
-      result = MatchParser.build_query(Transaction, attrs, whitelist, true, MatchAllQuery)
-      assert result == {:error, :too_many_associations}
+      assert %Ecto.Query{} =
+                MatchParser.build_query(Transaction, attrs, whitelist, true, MatchAllQuery)
     end
 
     test "returns error if filtering is not allowed on the field" do

--- a/apps/ewallet/test/ewallet/web/filters/match_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/filters/match_parser_test.exs
@@ -138,7 +138,7 @@ defmodule EWallet.Web.MatchParserTest do
       ]
 
       assert %Ecto.Query{} =
-                MatchParser.build_query(Transaction, attrs, whitelist, true, MatchAllQuery)
+               MatchParser.build_query(Transaction, attrs, whitelist, true, MatchAllQuery)
     end
 
     test "returns error if filtering is not allowed on the field" do


### PR DESCRIPTION
Closes #783

Queries are no longer limited by 5-associations.

The issue description suggested using named bindings but I found that using the existing Dynamic Queries with dynamic positioning to be better. Named bindings required creating compile-time atoms for every association within the schema in order to work. This added unnecessary complexity.

Implementation outline:

- do_filter_assoc() was generalized in MatchAllQuery and MatchAnyQuery
- checks for association limit was removed from MatchParser; 'position' variable adjusted.
- Added test case march_parser_tests.ex to check for 6-associations; also removed redundant test for 5-association limit

`{schema, position}` tuple used to bind the dynamic queries is an internal implementation of Ecto Queries. A [proposal](https://groups.google.com/forum/#!topic/elixir-ecto/cs_8XinSvu0) and [issue](https://github.com/elixir-ecto/ecto/issues/2944) has been submitted to add this feature to the public API. 


This PR is a redo of a [past one](https://github.com/omisego/ewallet/pull/834). This new PR was created since it properly rebases to branch v1.2 instead of master.