### PR TITLE
Create/update admin users without memberships

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
@@ -103,7 +103,8 @@ defmodule AdminAPI.V1.AccountMembershipController do
            Role.get_by(name: attrs["role_name"]) || {:error, :role_name_not_found},
          {:ok, redirect_url} <- UserGate.validate_redirect_url(attrs["redirect_url"]),
          originator <- Originator.extract(conn.assigns),
-         {:ok, _} <- UserGate.assign_or_invite(user_or_email, account, role, redirect_url, originator) do
+         {:ok, _} <-
+           UserGate.assign_or_invite(user_or_email, account, role, redirect_url, originator) do
       render(conn, :empty, %{success: true})
     else
       {true, :user_id_not_found} ->

--- a/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
@@ -17,16 +17,14 @@ defmodule AdminAPI.V1.AccountMembershipController do
   import AdminAPI.V1.ErrorHandler
 
   alias EWallet.{
-    InviteEmail,
     AccountMembershipPolicy,
     AdminUserPolicy,
     AccountPolicy,
-    EmailValidator,
     Bouncer.Permission,
     UserGate
   }
 
-  alias EWallet.Web.{Inviter, Orchestrator, Originator, UrlValidator, V1.MembershipOverlay}
+  alias EWallet.Web.{Orchestrator, Originator, V1.MembershipOverlay}
   alias EWalletDB.{Account, Membership, Role, User}
 
   @doc """

--- a/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/account_membership_controller.ex
@@ -22,7 +22,8 @@ defmodule AdminAPI.V1.AccountMembershipController do
     AdminUserPolicy,
     AccountPolicy,
     EmailValidator,
-    Bouncer.Permission
+    Bouncer.Permission,
+    UserGate
   }
 
   alias EWallet.Web.{Inviter, Orchestrator, Originator, UrlValidator, V1.MembershipOverlay}
@@ -91,17 +92,18 @@ defmodule AdminAPI.V1.AccountMembershipController do
   def assign_user(conn, attrs) do
     with %Account{} = account <- Account.get(attrs["account_id"]) || {:error, :unauthorized},
          {:ok, _} <- authorize(:get, conn.assigns, account),
+         {:ok, _} <- authorize(:create, conn.assigns, %User{}),
          {:ok, _} <-
            authorize(:create, conn.assigns, %Membership{
              account: account,
              account_uuid: account.uuid
            }),
-         {:ok, user_or_email} <- get_user_or_email(attrs),
+         {:ok, user_or_email} <- UserGate.get_user_or_email(attrs),
          %Role{} = role <-
            Role.get_by(name: attrs["role_name"]) || {:error, :role_name_not_found},
-         {:ok, redirect_url} <- validate_redirect_url(attrs["redirect_url"]),
+         {:ok, redirect_url} <- UserGate.validate_redirect_url(attrs["redirect_url"]),
          originator <- Originator.extract(conn.assigns),
-         {:ok, _} <- assign_or_invite(user_or_email, account, role, redirect_url, originator) do
+         {:ok, _} <- UserGate.assign_or_invite(user_or_email, account, role, redirect_url, originator) do
       render(conn, :empty, %{success: true})
     else
       {true, :user_id_not_found} ->
@@ -119,71 +121,6 @@ defmodule AdminAPI.V1.AccountMembershipController do
 
       {:error, code, description} ->
         handle_error(conn, code, description)
-    end
-  end
-
-  # Get user or email specifically for `assign_user/2` above.
-  #
-  # Returns:
-  # - `%User{}` if user_id is provided and found.
-  # - `:unauthorized` if `user_id` is provided but not found.
-  # - `%User{}` if email is provided and found.
-  # - `string` email if email provided but not found.
-  #
-  # If both `user_id` and `email` are provided, only `user_id` is attempted.
-  # Hence the pattern matching for `%{"user_id" => _}` comes first.
-  defp get_user_or_email(%{"user_id" => user_id}) do
-    case User.get(user_id) do
-      %User{} = user -> {:ok, user}
-      _ -> {:error, :unauthorized}
-    end
-  end
-
-  defp get_user_or_email(%{"email" => nil}) do
-    {:error, :invalid_email}
-  end
-
-  defp get_user_or_email(%{"email" => email}) do
-    case User.get_by_email(email) do
-      %User{} = user -> {:ok, user}
-      nil -> {:ok, email}
-    end
-  end
-
-  defp validate_redirect_url(url) do
-    if UrlValidator.allowed_redirect_url?(url) do
-      {:ok, url}
-    else
-      {:error, :prohibited_url, param_name: "redirect_url", url: url}
-    end
-  end
-
-  defp assign_or_invite(email, account, role, redirect_url, originator) when is_binary(email) do
-    case EmailValidator.validate(email) do
-      {:ok, email} ->
-        Inviter.invite_admin(
-          email,
-          account,
-          role,
-          redirect_url,
-          originator,
-          &InviteEmail.create/2
-        )
-
-      error ->
-        error
-    end
-  end
-
-  defp assign_or_invite(user, account, role, redirect_url, originator) do
-    case User.get_status(user) do
-      :pending_confirmation ->
-        user
-        |> User.get_invite()
-        |> Inviter.send_email(redirect_url, &InviteEmail.create/2)
-
-      :active ->
-        Membership.assign(user, account, role, originator)
     end
   end
 

--- a/apps/admin_api/lib/admin_api/v1/controllers/admin_user_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/admin_user_controller.ex
@@ -71,11 +71,12 @@ defmodule AdminAPI.V1.AdminUserController do
     end
   end
 
-  def create(conn, _attrs),
-    do: handle_error(conn, :invalid_parameter, "`redirect_url` is required.")
+  def create(conn, _attrs) do
+    handle_error(conn, :invalid_parameter, "`email` and `redirect_url` are required.")
+  end
 
   @doc """
-  Updates a new admin user.
+  Updates an admin user.
 
   The requesting user must have the permissions to update admin users.
   Admin users can't update themselves through this endpoint.

--- a/apps/admin_api/lib/admin_api/v1/controllers/admin_user_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/admin_user_controller.ex
@@ -15,8 +15,10 @@
 defmodule AdminAPI.V1.AdminUserController do
   use AdminAPI, :controller
   import AdminAPI.V1.ErrorHandler
-  alias AdminAPI.V1.UserView
-  alias EWallet.{AdminUserPolicy, UserFetcher, UserGate}
+  alias AdminAPI.UpdateEmailAddressEmail
+  alias AdminAPI.V1.AdminUserView
+  alias Bamboo.Email
+  alias EWallet.{Mailer, AdminUserPolicy, UserFetcher, UpdateEmailGate, UserGate}
   alias EWallet.Web.{Orchestrator, Originator, Paginator, V1.UserOverlay}
   alias EWalletDB.{User, AuthToken}
 
@@ -51,27 +53,72 @@ defmodule AdminAPI.V1.AdminUserController do
 
   def get(conn, _), do: handle_error(conn, :missing_id)
 
-
   @doc """
   Creates a new admin user.
 
   The requesting user must have the permissions to create admin users.
   """
   @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def create(conn, %{"redirect_url" => redirect_url} = attrs) do
+  def create(conn, %{"email" => email, "redirect_url" => redirect_url} = attrs)
+      when not is_nil(email) and not is_nil(redirect_url) do
     with {:ok, _} <- authorize(:create, conn.assigns, %User{global_role: attrs["global_role"]}),
-         {:ok, user_or_email} <- UserGate.get_user_or_email(attrs),
          attrs <- Originator.set_in_attrs(attrs, conn.assigns),
+         attrs <- Map.put(attrs, "is_admin", true),
+         {:ok, user_or_email} <- UserGate.get_user_or_email(attrs),
          {:ok, redirect_url} <- UserGate.validate_redirect_url(redirect_url),
          {:ok, _invite} <- UserGate.invite_global_user(attrs, redirect_url) do
-      render(conn, UserView, :empty, %{success: true})
+      render(conn, :empty, %{success: true})
     else
-      error ->
-        handle_error(conn, error)
+      {:error, error} -> handle_error(conn, error)
     end
   end
 
-  def create(conn, _attrs), do: handle_error(conn, :invalid_parameter, "`redirect_url` is required.")
+  def create(conn, _attrs),
+    do: handle_error(conn, :invalid_parameter, "`redirect_url` is required.")
+
+  @doc """
+  Updates a new admin user.
+
+  The requesting user must have the permissions to update admin users.
+  Admin users can't update themselves through this endpoint.
+  """
+  @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def update(conn, %{"id" => user_id} = attrs) do
+    with %User{} = original <- User.get(user_id) || {:error, :unauthorized},
+         {:ok, _} <- authorize(:update, conn.assigns, original),
+         attrs <- Originator.set_in_attrs(attrs, conn.assigns),
+         true <- attrs["originator"].uuid != original.uuid || {:error, :unauthorized},
+         {:ok, updated} <- User.update(original, attrs),
+         {:ok, updated} <- update_email(updated, attrs),
+         {:ok, updated} <- Orchestrator.one(updated, UserOverlay, attrs) do
+      render(conn, :admin_user, %{admin_user: updated})
+    else
+      {:error, error} -> handle_error(conn, error)
+      {:error, code, description} -> handle_error(conn, code, description)
+    end
+  end
+
+  def update(conn, _), do: handle_error(conn, :invalid_parameter, "`id` is required.")
+
+  defp update_email(user, %{"email" => email, "redirect_url" => redirect_url} = attrs)
+       when not is_nil(email) and not is_nil(redirect_url) do
+    with {:ok, redirect_url} <- UserGate.validate_redirect_url(redirect_url),
+         {:ok, request} <- UpdateEmailGate.update(user, email),
+         %Email{} = email <- UpdateEmailAddressEmail.create(request, redirect_url),
+         %Email{} <- Mailer.deliver_now(email) do
+      {:ok, user}
+    else
+      error ->
+        error
+    end
+  end
+
+  defp update_email(user, %{"email" => email} = attrs) when not is_nil(email) do
+    {:error, :invalid_parameter,
+     "A valid `redirect_url` is required when updating an admin user's email."}
+  end
+
+  defp update_email(user, _), do: {:ok, user}
 
   @doc """
   Enable or disable a user.
@@ -99,7 +146,7 @@ defmodule AdminAPI.V1.AdminUserController do
 
   # Respond with a list of admins
   defp respond_multiple(%Paginator{} = paged_users, conn) do
-    render(conn, UserView, :users, %{users: paged_users})
+    render(conn, :admin_users, %{admin_users: paged_users})
   end
 
   defp respond_multiple({:error, code, description}, conn) do
@@ -112,7 +159,7 @@ defmodule AdminAPI.V1.AdminUserController do
 
   # Respond with a single admin
   defp respond_single(%User{} = user, conn) do
-    render(conn, UserView, :user, %{user: user})
+    render(conn, :admin_user, %{admin_user: user})
   end
 
   @spec authorize(:all | :create | :get | :update, map(), %User{} | nil) ::

--- a/apps/admin_api/lib/admin_api/v1/controllers/invite_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/invite_controller.ex
@@ -17,7 +17,7 @@ defmodule AdminAPI.V1.InviteController do
   import AdminAPI.V1.ErrorHandler
   alias AdminAPI.V1.UserView
   alias EWallet.Web.{Originator, Preloader}
-  alias EWalletDB.{Invite, User}
+  alias EWalletDB.{Repo, Invite, User}
 
   @doc """
   Validates the user's invite token and activates the user.
@@ -32,7 +32,7 @@ defmodule AdminAPI.V1.InviteController do
     with %Invite{} = invite <- Invite.get(email, token) || {:error, :invite_not_found},
          {:ok, invite} <- Preloader.preload_one(invite, :user),
          {:ok, _} <- Invite.accept(invite, password, password_confirmation),
-         originator <- Originator.get_initial_originator(invite),
+         originator <- Originator.get_initial_originator(invite, Repo),
          {:ok, _} <- User.set_admin(invite.user, true, originator) do
       render(conn, UserView, :user, %{user: invite.user})
     else

--- a/apps/admin_api/lib/admin_api/v1/controllers/self_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/self_controller.ex
@@ -19,7 +19,7 @@ defmodule AdminAPI.V1.SelfController do
   alias AdminAPI.V1.{AccountHelper, AccountView, UserView}
   alias Bamboo.Email
   alias Ecto.Changeset
-  alias EWallet.{Mailer, UpdateEmailGate, AdapterHelper, AdminUserPolicy}
+  alias EWallet.{Mailer, UserGate, UpdateEmailGate, AdapterHelper, AdminUserPolicy}
   alias EWallet.Web.{Orchestrator, Originator, UrlValidator}
   alias EWallet.Web.V1.AccountOverlay
   alias EWalletDB.{Account, User}
@@ -75,7 +75,7 @@ defmodule AdminAPI.V1.SelfController do
       when not is_nil(email) and not is_nil(redirect_url) do
     with %User{} = user <- conn.assigns[:admin_user] || {:error, :unauthorized},
          {:ok, _} <- authorize(:update_email, conn.assigns, user),
-         {:ok, redirect_url} <- validate_redirect_url(redirect_url),
+         {:ok, redirect_url} <- UserGate.validate_redirect_url(redirect_url),
          {:ok, request} <- UpdateEmailGate.update(user, email),
          %Email{} = email <- UpdateEmailAddressEmail.create(request, redirect_url),
          %Email{} <- Mailer.deliver_now(email) do
@@ -90,14 +90,6 @@ defmodule AdminAPI.V1.SelfController do
   end
 
   def update_email(conn, _), do: handle_error(conn, :invalid_parameter)
-
-  defp validate_redirect_url(url) do
-    if UrlValidator.allowed_redirect_url?(url) do
-      {:ok, url}
-    else
-      {:error, :prohibited_url, param_name: "redirect_url", url: url}
-    end
-  end
 
   @doc """
   Verifies the user's new email.

--- a/apps/admin_api/lib/admin_api/v1/controllers/self_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/self_controller.ex
@@ -20,7 +20,7 @@ defmodule AdminAPI.V1.SelfController do
   alias Bamboo.Email
   alias Ecto.Changeset
   alias EWallet.{Mailer, UserGate, UpdateEmailGate, AdapterHelper, AdminUserPolicy}
-  alias EWallet.Web.{Orchestrator, Originator, UrlValidator}
+  alias EWallet.Web.{Orchestrator, Originator}
   alias EWallet.Web.V1.AccountOverlay
   alias EWalletDB.{Account, User}
 

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -147,6 +147,7 @@ defmodule AdminAPI.V1.Router do
     # Admin endpoints
     post("/admin.all", AdminUserController, :all)
     post("/admin.get", AdminUserController, :get)
+    post("/admin.create", AdminUserController, :create)
     post("/admin.enable_or_disable", AdminUserController, :enable_or_disable)
 
     # Role endpoints

--- a/apps/admin_api/lib/admin_api/v1/router.ex
+++ b/apps/admin_api/lib/admin_api/v1/router.ex
@@ -148,6 +148,7 @@ defmodule AdminAPI.V1.Router do
     post("/admin.all", AdminUserController, :all)
     post("/admin.get", AdminUserController, :get)
     post("/admin.create", AdminUserController, :create)
+    post("/admin.update", AdminUserController, :update)
     post("/admin.enable_or_disable", AdminUserController, :enable_or_disable)
 
     # Role endpoints

--- a/apps/admin_api/lib/admin_api/v1/views/admin_user_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/admin_user_view.ex
@@ -14,8 +14,7 @@
 
 defmodule AdminAPI.V1.AdminUserView do
   use AdminAPI, :view
-  alias EWallet.Web.V1.ResponseSerializer
-  alias EWallet.Web.V1.AdminUserSerializer
+  alias EWallet.Web.V1.{ResponseSerializer, AdminUserSerializer}
 
   def render("admin_user.json", %{admin_user: admin_user}) do
     admin_user

--- a/apps/admin_api/lib/admin_api/v1/views/admin_user_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/admin_user_view.ex
@@ -1,0 +1,35 @@
+# Copyright 2018-2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule AdminAPI.V1.AdminUserView do
+  use AdminAPI, :view
+  alias EWallet.Web.V1.ResponseSerializer
+  alias EWallet.Web.V1.AdminUserSerializer
+
+  def render("admin_user.json", %{admin_user: admin_user}) do
+    admin_user
+    |> AdminUserSerializer.serialize()
+    |> ResponseSerializer.serialize(success: true)
+  end
+
+  def render("admin_users.json", %{admin_users: admin_users}) do
+    admin_users
+    |> AdminUserSerializer.serialize()
+    |> ResponseSerializer.serialize(success: true)
+  end
+
+  def render("empty.json", %{success: success}) do
+    ResponseSerializer.serialize(%{}, success: success)
+  end
+end

--- a/apps/admin_api/lib/admin_api/v1/views/user_view.ex
+++ b/apps/admin_api/lib/admin_api/v1/views/user_view.ex
@@ -28,4 +28,8 @@ defmodule AdminAPI.V1.UserView do
     |> UserSerializer.serialize()
     |> ResponseSerializer.serialize(success: true)
   end
+
+  def render("empty.json", %{success: success}) do
+    ResponseSerializer.serialize(%{}, success: success)
+  end
 end

--- a/apps/admin_api/priv/spec.json
+++ b/apps/admin_api/priv/spec.json
@@ -17526,6 +17526,465 @@
         }
       }
     },
+    "/admin.create": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Create a new admin.",
+        "operationId": "admin_create",
+        "security": [
+          {
+            "ProviderAuth": []
+          },
+          {
+            "AdminAuth": []
+          }
+        ],
+        "requestBody": {
+          "description": "The parameters to send to create an admin user",
+          "required": true,
+          "content": {
+            "application/vnd.omisego.v1+json": {
+              "schema": {
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  },
+                  "redirect_url": {
+                    "type": "string"
+                  },
+                  "full_name": {
+                    "type": "string"
+                  },
+                  "calling_name": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "global_role": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "encrypted_metadata": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "email",
+                  "redirect_url"
+                ],
+                "example": {
+                  "email": "user@example.com",
+                  "redirect_url": "https://domain/redirect_path?email={email}&token={token}",
+                  "full_name": "John Doe",
+                  "calling_name": "John",
+                  "global_role": "admin"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns an empty response",
+            "content": {
+              "application/vnd.omisego.v1+json": {
+                "schema": {
+                  "description": "The response schema for a successful operation",
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "success",
+                    "data"
+                  ],
+                  "example": {
+                    "version": "1",
+                    "success": true,
+                    "data": {}
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Returns an internal server error",
+            "content": {
+              "application/vnd.omisego.v1+json": {
+                "schema": {
+                  "description": "The response schema for an error",
+                  "allOf": [
+                    {
+                      "description": "The response schema for a successful operation",
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "string"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        },
+                        "data": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "version",
+                        "success",
+                        "data"
+                      ],
+                      "example": {
+                        "version": "1",
+                        "success": true,
+                        "data": {}
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "description": "The object schema for an error",
+                          "type": "object",
+                          "properties": {
+                            "object": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "messages": {
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "object",
+                            "code",
+                            "description",
+                            "messages"
+                          ],
+                          "example": {
+                            "object": "error",
+                            "code": "server:internal_server_error",
+                            "description": "Something went wrong on the server",
+                            "messages": {
+                              "error_key": "error_reason"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ],
+                      "example": {
+                        "success": false,
+                        "data": {
+                          "object": "error",
+                          "code": "server:internal_server_error",
+                          "description": "Something went wrong on the server",
+                          "messages": {
+                            "error_key": "error_reason"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin.update": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Update an admin.",
+        "operationId": "admin_update",
+        "security": [
+          {
+            "ProviderAuth": []
+          },
+          {
+            "AdminAuth": []
+          }
+        ],
+        "requestBody": {
+          "description": "Parameters to update a user. A user can't update himself through this endpoint. If an email address is given, an email will be sent to the address, allowing the user to confirm the new email address.",
+          "required": true,
+          "content": {
+            "application/vnd.omisego.v1+json": {
+              "schema": {
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "full_name": {
+                    "type": "string"
+                  },
+                  "calling_name": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "global_role": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "encrypted_metadata": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "example": {
+                  "id": "usr_01ce83q2zw7zk1dqr79t22zr1v",
+                  "full_name": "John Doe",
+                  "calling_name": "John",
+                  "global_role": "admin"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns a single admin panel user",
+            "content": {
+              "application/vnd.omisego.v1+json": {
+                "schema": {
+                  "description": "The response schema for an admin user",
+                  "allOf": [
+                    {
+                      "description": "The response schema for a successful operation",
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "string"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        },
+                        "data": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "version",
+                        "success",
+                        "data"
+                      ],
+                      "example": {
+                        "version": "1",
+                        "success": true,
+                        "data": {}
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "description": "The object schema for a user",
+                          "properties": {
+                            "object": {
+                              "type": "string"
+                            },
+                            "id": {
+                              "type": "string"
+                            },
+                            "username": {
+                              "type": "string"
+                            },
+                            "full_name": {
+                              "type": "string"
+                            },
+                            "calling_name": {
+                              "type": "string"
+                            },
+                            "provider_user_id": {
+                              "type": "string"
+                            },
+                            "email": {
+                              "type": "string",
+                              "format": "email"
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "metadata": {
+                              "type": "object"
+                            },
+                            "encrypted_metadata": {
+                              "type": "object"
+                            },
+                            "avatar": {
+                              "type": "object"
+                            },
+                            "created_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "updated_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          },
+                          "required": [
+                            "object",
+                            "id",
+                            "created_at",
+                            "updated_at"
+                          ]
+                        }
+                      },
+                      "example": {
+                        "data": {
+                          "object": "user",
+                          "id": "usr_01ce83zf80j542z4q4zqd8qvfx",
+                          "provider_user_id": "wijf-fbancomw-dqwjudb",
+                          "username": "johndoe",
+                          "full_name": "John Doe",
+                          "calling_name": "John",
+                          "email": "johndoe@omise.co",
+                          "enabled": true,
+                          "metadata": {
+                            "first_name": "John",
+                            "last_name": "Doe"
+                          },
+                          "encrypted_metadata": {
+                            "something": "secret"
+                          },
+                          "avatar": {
+                            "original": "file_url"
+                          },
+                          "created_at": "2018-01-01T00:00:00Z",
+                          "updated_at": "2018-01-01T10:00:00Z"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Returns an internal server error",
+            "content": {
+              "application/vnd.omisego.v1+json": {
+                "schema": {
+                  "description": "The response schema for an error",
+                  "allOf": [
+                    {
+                      "description": "The response schema for a successful operation",
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "string"
+                        },
+                        "success": {
+                          "type": "boolean"
+                        },
+                        "data": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "version",
+                        "success",
+                        "data"
+                      ],
+                      "example": {
+                        "version": "1",
+                        "success": true,
+                        "data": {}
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "description": "The object schema for an error",
+                          "type": "object",
+                          "properties": {
+                            "object": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "messages": {
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "object",
+                            "code",
+                            "description",
+                            "messages"
+                          ],
+                          "example": {
+                            "object": "error",
+                            "code": "server:internal_server_error",
+                            "description": "Something went wrong on the server",
+                            "messages": {
+                              "error_key": "error_reason"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ],
+                      "example": {
+                        "success": false,
+                        "data": {
+                          "object": "error",
+                          "code": "server:internal_server_error",
+                          "description": "Something went wrong on the server",
+                          "messages": {
+                            "error_key": "error_reason"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/admin.enable_or_disable": {
       "post": {
         "tags": [
@@ -18276,12 +18735,27 @@
           }
         ],
         "requestBody": {
-          "description": "The parameters to use for updating a user",
+          "description": "Parameters to update a user. A user can't update himself through this endpoint. If an email address is given, an email will be sent to the address, allowing the user to confirm the new email address.",
           "required": true,
           "content": {
             "application/vnd.omisego.v1+json": {
               "schema": {
                 "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "full_name": {
+                    "type": "string"
+                  },
+                  "calling_name": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "global_role": {
+                    "type": "string"
+                  },
                   "metadata": {
                     "type": "object",
                     "additionalProperties": true
@@ -18291,9 +18765,14 @@
                     "additionalProperties": true
                   }
                 },
+                "required": [
+                  "id"
+                ],
                 "example": {
-                  "metadata": {},
-                  "encrypted_metadata": {}
+                  "id": "usr_01ce83q2zw7zk1dqr79t22zr1v",
+                  "full_name": "John Doe",
+                  "calling_name": "John",
+                  "global_role": "admin"
                 }
               }
             }

--- a/apps/admin_api/priv/spec.json
+++ b/apps/admin_api/priv/spec.json
@@ -17581,7 +17581,7 @@
                 ],
                 "example": {
                   "email": "user@example.com",
-                  "redirect_url": "https://domain/redirect_path?email={email}&token={token}",
+                  "redirect_url": "http://localhost:4000/admin/invite?email={email}&token={token}",
                   "full_name": "John Doe",
                   "calling_name": "John",
                   "global_role": "admin"

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -486,7 +486,7 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: &ref_40
+      requestBody: &ref_41
         description: >-
           The parameters to use for retrieving a specific user by its id or
           provider_user_id
@@ -1278,7 +1278,7 @@ paths:
                             properties:
                               data:
                                 type: array
-                                items: &ref_48
+                                items: &ref_49
                                   description: The object schema for an exchange pair
                                   type: object
                                   properties: &ref_18
@@ -2150,7 +2150,7 @@ paths:
                 id: acc_01ca2p8jqans5aty5gj5etmjcf
                 owned: true
       responses:
-        '200': &ref_37
+        '200': &ref_38
           description: Returns a list of users
           content:
             application/vnd.omisego.v1+json:
@@ -2257,7 +2257,7 @@ paths:
                                 items:
                                   description: The object schema for a wallet
                                   type: object
-                                  properties: &ref_44
+                                  properties: &ref_45
                                     object:
                                       type: string
                                     socket_topic:
@@ -2299,7 +2299,7 @@ paths:
                                           - object
                                           - token
                                           - amount
-                                  required: &ref_45
+                                  required: &ref_46
                                     - object
                                     - socket_topic
                                     - address
@@ -2362,7 +2362,7 @@ paths:
         - AdminAuth: []
       requestBody: *ref_33
       responses:
-        '200': &ref_41
+        '200': &ref_42
           description: Returns a list of transactions
           content:
             application/vnd.omisego.v1+json:
@@ -2440,7 +2440,7 @@ paths:
         - AdminAuth: []
       requestBody: *ref_33
       responses:
-        '200': &ref_49
+        '200': &ref_50
           description: Returns a list of transaction requests
           content:
             application/vnd.omisego.v1+json:
@@ -2462,7 +2462,7 @@ paths:
                                     The response schema for a transaction
                                     request
                                   type: object
-                                  properties: &ref_50
+                                  properties: &ref_51
                                     object:
                                       type: string
                                     id:
@@ -2527,7 +2527,7 @@ paths:
                                       type: string
                                     updated_at:
                                       type: string
-                                  required: &ref_51
+                                  required: &ref_52
                                     - object
                                     - id
                                     - formatted_id
@@ -2597,7 +2597,7 @@ paths:
         - AdminAuth: []
       requestBody: *ref_33
       responses:
-        '200': &ref_43
+        '200': &ref_44
           description: Returns a list of transaction consumptions
           content:
             application/vnd.omisego.v1+json:
@@ -2948,6 +2948,97 @@ paths:
       responses:
         '200': *ref_36
         '500': *ref_2
+  /admin.create:
+    post:
+      tags:
+        - Admin
+      summary: Create a new admin.
+      operationId: admin_create
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody:
+        description: The parameters to send to create an admin user
+        required: true
+        content:
+          application/vnd.omisego.v1+json:
+            schema:
+              properties:
+                email:
+                  type: string
+                redirect_url:
+                  type: string
+                full_name:
+                  type: string
+                calling_name:
+                  type: string
+                enabled:
+                  type: boolean
+                global_role:
+                  type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+                encrypted_metadata:
+                  type: object
+                  additionalProperties: true
+              required:
+                - email
+                - redirect_url
+              example:
+                email: user@example.com
+                redirect_url: 'https://domain/redirect_path?email={email}&token={token}'
+                full_name: John Doe
+                calling_name: John
+                global_role: admin
+      responses:
+        '200': *ref_7
+        '500': *ref_2
+  /admin.update:
+    post:
+      tags:
+        - Admin
+      summary: Update an admin.
+      operationId: admin_update
+      security:
+        - ProviderAuth: []
+        - AdminAuth: []
+      requestBody: &ref_37
+        description: >-
+          Parameters to update a user. A user can't update himself through this
+          endpoint. If an email address is given, an email will be sent to the
+          address, allowing the user to confirm the new email address.
+        required: true
+        content:
+          application/vnd.omisego.v1+json:
+            schema:
+              properties:
+                id:
+                  type: string
+                full_name:
+                  type: string
+                calling_name:
+                  type: string
+                enabled:
+                  type: boolean
+                global_role:
+                  type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+                encrypted_metadata:
+                  type: object
+                  additionalProperties: true
+              required:
+                - id
+              example:
+                id: usr_01ce83q2zw7zk1dqr79t22zr1v
+                full_name: John Doe
+                calling_name: John
+                global_role: admin
+      responses:
+        '200': *ref_36
+        '500': *ref_2
   /admin.enable_or_disable:
     post:
       tags:
@@ -3034,22 +3125,7 @@ paths:
       operationId: me_update
       security:
         - AdminAuth: []
-      requestBody:
-        description: The parameters to use for updating a user
-        required: true
-        content:
-          application/vnd.omisego.v1+json:
-            schema:
-              properties:
-                metadata:
-                  type: object
-                  additionalProperties: true
-                encrypted_metadata:
-                  type: object
-                  additionalProperties: true
-              example:
-                metadata: {}
-                encrypted_metadata: {}
+      requestBody: *ref_37
       responses:
         '200': *ref_36
         '500': *ref_2
@@ -3176,7 +3252,7 @@ paths:
         - AdminAuth: []
       requestBody: *ref_16
       responses:
-        '200': *ref_37
+        '200': *ref_38
         '500': *ref_2
   /user.create:
     post:
@@ -3187,7 +3263,7 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: &ref_38
+      requestBody: &ref_39
         description: The parameters to use for creating or updating a user
         required: true
         content:
@@ -3221,7 +3297,7 @@ paths:
                   last_name: Doe
                 encrypted_metadata: {}
       responses:
-        '200': &ref_39
+        '200': &ref_40
           description: Returns a single user
           content:
             application/vnd.omisego.v1+json:
@@ -3263,9 +3339,9 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: *ref_38
+      requestBody: *ref_39
       responses:
-        '200': *ref_39
+        '200': *ref_40
         '500': *ref_2
   /user.get:
     post:
@@ -3276,9 +3352,9 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: *ref_40
+      requestBody: *ref_41
       responses:
-        '200': *ref_39
+        '200': *ref_40
         '500': *ref_2
   /user.get_wallets:
     post:
@@ -3325,7 +3401,7 @@ paths:
         - User
       summary: Get the list of transactions for the given user
       operationId: get_all_transactions_for_user
-      requestBody: &ref_42
+      requestBody: &ref_43
         description: >-
           The parameters to use for retrieving a collection owned by user by its
           id or provider_user_id
@@ -3351,7 +3427,7 @@ paths:
         - ProviderAuth: []
         - AdminAuth: []
       responses:
-        '200': *ref_41
+        '200': *ref_42
         '500': *ref_2
   /user.get_transaction_consumptions:
     post:
@@ -3362,9 +3438,9 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: *ref_42
+      requestBody: *ref_43
       responses:
-        '200': *ref_43
+        '200': *ref_44
         '500': *ref_2
   /user.enable_or_disable:
     post:
@@ -3404,7 +3480,7 @@ paths:
                 id: usr_01ct2zjh20fj210bzz078948f6
                 enabled: false
       responses:
-        '200': *ref_39
+        '200': *ref_40
         '500': *ref_2
   /wallet.all:
     post:
@@ -3494,7 +3570,7 @@ paths:
                     - identifier
                     - account_id
       responses:
-        '200': &ref_46
+        '200': &ref_47
           description: Returns a single wallet
           content:
             application/vnd.omisego.v1+json:
@@ -3507,8 +3583,8 @@ paths:
                       data:
                         type: object
                         description: The object schema for a wallet
-                        properties: *ref_44
-                        required: *ref_45
+                        properties: *ref_45
+                        required: *ref_46
                     example:
                       data:
                         object: wallet
@@ -3555,7 +3631,7 @@ paths:
               example:
                 address: kxhk519271652215
       responses:
-        '200': *ref_46
+        '200': *ref_47
         '500': *ref_2
   /wallet.get_transaction_consumptions:
     post:
@@ -3582,7 +3658,7 @@ paths:
               example:
                 address: kxhk519271652215
       responses:
-        '200': *ref_43
+        '200': *ref_44
         '500': *ref_2
   /wallet.enable_or_disable:
     post:
@@ -3611,7 +3687,7 @@ paths:
                 address: kxhk519271652215
                 enabled: false
       responses:
-        '200': *ref_46
+        '200': *ref_47
         '500': *ref_2
   /transaction.all:
     post:
@@ -3624,7 +3700,7 @@ paths:
         - AdminAuth: []
       requestBody: *ref_16
       responses:
-        '200': *ref_41
+        '200': *ref_42
         '500': *ref_2
   /transaction.export:
     post:
@@ -3660,7 +3736,7 @@ paths:
                     sort_by: created_at
                     sort_dir: desc
       responses:
-        '200': &ref_61
+        '200': &ref_62
           description: Returns a single export
           content:
             application/vnd.omisego.v1+json:
@@ -3673,7 +3749,7 @@ paths:
                       data:
                         type: object
                         description: The object schema for an export
-                        properties: &ref_59
+                        properties: &ref_60
                           object:
                             type: string
                           id:
@@ -3704,7 +3780,7 @@ paths:
                           updated_at:
                             type: string
                             format: date-time
-                        required: &ref_60
+                        required: &ref_61
                           - object
                           - id
                           - filename
@@ -3754,7 +3830,7 @@ paths:
               example:
                 id: txn_01ce83x8w4db56f3fcjy4n4qpc
       responses:
-        '200': &ref_47
+        '200': &ref_48
           description: Returns a single transaction
           content:
             application/vnd.omisego.v1+json:
@@ -3884,7 +3960,7 @@ paths:
                 metadata: {}
                 encrypted_metadata: {}
       responses:
-        '200': *ref_47
+        '200': *ref_48
         '500': *ref_2
   /transaction.calculate:
     post:
@@ -3942,7 +4018,7 @@ paths:
                             type: integer
                           to_token_id:
                             type: string
-                          exchange_pair: *ref_48
+                          exchange_pair: *ref_49
                           calculated_at:
                             type: string
                             format: date-time
@@ -3999,7 +4075,7 @@ paths:
         - AdminAuth: []
       requestBody: *ref_16
       responses:
-        '200': *ref_49
+        '200': *ref_50
         '500': *ref_2
   /transaction_request.create:
     post:
@@ -4126,7 +4202,7 @@ paths:
                 correlation_id: some correlation id
                 address: 2ae52683-68d8-4af6-94d7-5ed4c34ecf1a
       responses:
-        '200': &ref_52
+        '200': &ref_53
           description: Transaction request response
           content:
             application/vnd.omisego.v1+json:
@@ -4139,8 +4215,8 @@ paths:
                       data:
                         type: object
                         description: The response schema for a transaction request
-                        properties: *ref_50
-                        required: *ref_51
+                        properties: *ref_51
+                        required: *ref_52
                     example:
                       data:
                         object: transaction_request
@@ -4190,7 +4266,7 @@ paths:
               example:
                 formatted_id: data|txr_01cbfgc8cmmyzy1cfzpqwme3ey
       responses:
-        '200': *ref_52
+        '200': *ref_53
         '500': *ref_2
   /transaction_request.consume:
     post:
@@ -4250,7 +4326,7 @@ paths:
                 metadata: {}
                 encrypted_metadata: {}
       responses:
-        '200': &ref_53
+        '200': &ref_54
           description: Transaction request consumption response
           content:
             application/vnd.omisego.v1+json:
@@ -4410,7 +4486,7 @@ paths:
               example:
                 formatted_transaction_request_id: txr_01cbfg8mafdnbthgb9e68nd9y9
       responses:
-        '200': *ref_43
+        '200': *ref_44
         '500': *ref_2
   /transaction_consumption.all:
     post:
@@ -4423,7 +4499,7 @@ paths:
         - AdminAuth: []
       requestBody: *ref_16
       responses:
-        '200': *ref_43
+        '200': *ref_44
         '500': *ref_2
   /transaction_consumption.get:
     post:
@@ -4449,7 +4525,7 @@ paths:
               example:
                 id: txc_01abfg5m2ee06kzm8tbysfmmw5
       responses:
-        '200': *ref_53
+        '200': *ref_54
         '500': *ref_2
   /transaction_consumption.approve:
     post:
@@ -4461,7 +4537,7 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: &ref_54
+      requestBody: &ref_55
         description: Approve or reject a consumption using the specified ID.
         required: true
         content:
@@ -4475,7 +4551,7 @@ paths:
               example:
                 id: txc_01cbfg5m2ee06kzm8tbysfmmw5
       responses:
-        '200': *ref_53
+        '200': *ref_54
         '500': *ref_2
   /transaction_consumption.reject:
     post:
@@ -4487,9 +4563,9 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: *ref_54
+      requestBody: *ref_55
       responses:
-        '200': *ref_53
+        '200': *ref_54
         '500': *ref_2
   /transaction_consumption.cancel:
     post:
@@ -4515,7 +4591,7 @@ paths:
               example:
                 id: txc_01cbfg5m2ee06kzm8tbysfmmw5
       responses:
-        '200': *ref_53
+        '200': *ref_54
         '500': *ref_2
   /access_key.all:
     post:
@@ -4545,7 +4621,7 @@ paths:
                             properties:
                               data:
                                 type: array
-                                items: &ref_55
+                                items: &ref_56
                                   description: The object schema for an access key
                                   type: object
                                   properties:
@@ -4619,7 +4695,7 @@ paths:
                 name: my_key
                 global_role: none
       responses:
-        '200': &ref_56
+        '200': &ref_57
           description: Returns a single access key
           content:
             application/vnd.omisego.v1+json:
@@ -4629,7 +4705,7 @@ paths:
                   - *ref_1
                   - type: object
                     properties:
-                      data: *ref_55
+                      data: *ref_56
                     example:
                       data:
                         object: key
@@ -4671,7 +4747,7 @@ paths:
                 name: my_key
                 global_role: none
       responses:
-        '200': *ref_56
+        '200': *ref_57
         '500': *ref_2
   /access_key.enable_or_disable:
     post:
@@ -4702,7 +4778,7 @@ paths:
                 id: key_01ce83yphmq6vt4qnmn3ykwcw6
                 enabled: false
       responses:
-        '200': *ref_56
+        '200': *ref_57
         '500': *ref_2
   /access_key.delete:
     post:
@@ -4767,7 +4843,7 @@ paths:
                             properties:
                               data:
                                 type: array
-                                items: &ref_57
+                                items: &ref_58
                                   description: The object schema for an API key
                                   type: object
                                   properties:
@@ -4839,7 +4915,7 @@ paths:
               example:
                 name: my_api_key
       responses:
-        '200': &ref_58
+        '200': &ref_59
           description: Returns a single API key
           content:
             application/vnd.omisego.v1+json:
@@ -4849,7 +4925,7 @@ paths:
                   - *ref_1
                   - type: object
                     properties:
-                      data: *ref_57
+                      data: *ref_58
                     example:
                       data:
                         object: api_key
@@ -4889,7 +4965,7 @@ paths:
                 id: api_01ce83yphmq6vt4qnmn3ykwcw6
                 name: my_api_key
       responses:
-        '200': *ref_58
+        '200': *ref_59
         '500': *ref_2
   /api_key.enable_or_disable:
     post:
@@ -4920,7 +4996,7 @@ paths:
                 id: api_01ce83yphmq6vt4qnmn3ykwcw6
                 enabled: false
       responses:
-        '200': *ref_58
+        '200': *ref_59
         '500': *ref_2
   /api_key.delete:
     post:
@@ -4978,8 +5054,8 @@ paths:
                                 items:
                                   description: The object schema for an export
                                   type: object
-                                  properties: *ref_59
-                                  required: *ref_60
+                                  properties: *ref_60
+                                  required: *ref_61
                     example:
                       data:
                         data:
@@ -5007,7 +5083,7 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: &ref_62
+      requestBody: &ref_63
         description: The parameters to use for retrieving a specific export by its id
         required: true
         content:
@@ -5021,7 +5097,7 @@ paths:
               example:
                 id: exp_01ca2p8jqans5aty5gj5etmjcf
       responses:
-        '200': *ref_61
+        '200': *ref_62
         '500': *ref_2
   /export.download:
     post:
@@ -5032,7 +5108,7 @@ paths:
       security:
         - ProviderAuth: []
         - AdminAuth: []
-      requestBody: *ref_62
+      requestBody: *ref_63
       responses:
         '200':
           description: A CSV file
@@ -5327,7 +5403,7 @@ paths:
         - ProviderAuth: []
         - AdminAuth: []
       responses:
-        '200': &ref_63
+        '200': &ref_64
           description: Returns unauthorized error
           content:
             application/vnd.omisego.v1+json:
@@ -5364,7 +5440,7 @@ paths:
         - ProviderAuth: []
         - AdminAuth: []
       responses:
-        '200': *ref_63
+        '200': *ref_64
         '500': *ref_2
   /role.create:
     post:
@@ -5377,7 +5453,7 @@ paths:
         - ProviderAuth: []
         - AdminAuth: []
       responses:
-        '200': *ref_63
+        '200': *ref_64
         '500': *ref_2
   /role.update:
     post:
@@ -5390,7 +5466,7 @@ paths:
         - ProviderAuth: []
         - AdminAuth: []
       responses:
-        '200': *ref_63
+        '200': *ref_64
         '500': *ref_2
   /role.delete:
     post:
@@ -5403,5 +5479,5 @@ paths:
         - ProviderAuth: []
         - AdminAuth: []
       responses:
-        '200': *ref_63
+        '200': *ref_64
         '500': *ref_2

--- a/apps/admin_api/priv/spec.yaml
+++ b/apps/admin_api/priv/spec.yaml
@@ -2987,7 +2987,7 @@ paths:
                 - redirect_url
               example:
                 email: user@example.com
-                redirect_url: 'https://domain/redirect_path?email={email}&token={token}'
+                redirect_url: 'http://localhost:4000/admin/invite?email={email}&token={token}'
                 full_name: John Doe
                 calling_name: John
                 global_role: admin

--- a/apps/admin_api/priv/swagger/admin/paths.yaml
+++ b/apps/admin_api/priv/swagger/admin/paths.yaml
@@ -79,6 +79,41 @@ admin.get:
         $ref: 'responses.yaml#/AdminResponse'
       '500':
         $ref: '../../../../ewallet/priv/swagger/shared/responses.yaml#/InternalServerError'
+
+admin.create:
+  post:
+    tags:
+      - Admin
+    summary: Create a new admin.
+    operationId: admin_create
+    security:
+      - ProviderAuth: []
+      - AdminAuth: []
+    requestBody:
+      $ref: 'request_bodies.yaml#/AdminCreateBody'
+    responses:
+      '200':
+        $ref: '../../../../ewallet/priv/swagger/shared/responses.yaml#/EmptyResponse'
+      '500':
+        $ref: '../../../../ewallet/priv/swagger/shared/responses.yaml#/InternalServerError'
+
+admin.update:
+  post:
+    tags:
+      - Admin
+    summary: Update an admin.
+    operationId: admin_update
+    security:
+      - ProviderAuth: []
+      - AdminAuth: []
+    requestBody:
+      $ref: 'request_bodies.yaml#/AdminUpdateBody'
+    responses:
+      '200':
+        $ref: 'responses.yaml#/AdminResponse'
+      '500':
+        $ref: '../../../../ewallet/priv/swagger/shared/responses.yaml#/InternalServerError'
+
 admin.enable_or_disable:
   post:
     tags:

--- a/apps/admin_api/priv/swagger/admin/request_bodies.yaml
+++ b/apps/admin_api/priv/swagger/admin/request_bodies.yaml
@@ -74,6 +74,73 @@ AdminGetBody:
           - id
         example:
           id: usr_01ce83q2zw7zk1dqr79t22zr1v
+
+AdminCreateBody:
+  description: The parameters to send to create an admin user
+  required: true
+  content:
+    application/vnd.omisego.v1+json:
+      schema:
+        properties:
+          email:
+            type: string
+          redirect_url:
+            type: string
+          full_name:
+            type: string
+          calling_name:
+            type: string
+          enabled: 
+            type: boolean
+          global_role: 
+            type: string
+          metadata:
+            type: object
+            additionalProperties: true
+          encrypted_metadata:
+            type: object
+            additionalProperties: true
+        required:
+          - email
+          - redirect_url
+        example:
+          email: user@example.com
+          redirect_url: 'https://domain/redirect_path?email={email}&token={token}'
+          full_name: John Doe
+          calling_name: John
+          global_role: admin
+
+AdminUpdateBody:
+  description: Parameters to update a user. A user can't update himself through this endpoint. If an email address is given, an email will be sent to the address, allowing the user to confirm the new email address.
+  required: true
+  content:
+    application/vnd.omisego.v1+json:
+      schema:
+        properties:
+          id:
+            type: string
+          full_name:
+            type: string
+          calling_name:
+            type: string
+          enabled: 
+            type: boolean
+          global_role: 
+            type: string
+          metadata:
+            type: object
+            additionalProperties: true
+          encrypted_metadata:
+            type: object
+            additionalProperties: true
+        required:
+          - id
+        example:
+          id: usr_01ce83q2zw7zk1dqr79t22zr1v  
+          full_name: John Doe
+          calling_name: John
+          global_role: admin
+
 InviteAcceptBody:
   description: The parameters to use for accepting an invite
   required: true
@@ -99,23 +166,6 @@ InviteAcceptBody:
           token: dmWEOiEvlPfEpb2XPEkNkNYR4xEqNuf25E9hqBYwvzg
           password: user_provided_password
           password_confirmation: user_provided_password
-
-AdminUpdateBody:
-  description: The parameters to use for updating a user
-  required: true
-  content:
-    application/vnd.omisego.v1+json:
-      schema:
-        properties:
-          metadata:
-            type: object
-            additionalProperties: true
-          encrypted_metadata:
-            type: object
-            additionalProperties: true
-        example:
-          metadata: {}
-          encrypted_metadata: {}
 
 AdminToggleStatusBody:
   description: The parameters to enable/disable an admin. Send enabled=true to enable, enabled=false to disable.

--- a/apps/admin_api/priv/swagger/admin/request_bodies.yaml
+++ b/apps/admin_api/priv/swagger/admin/request_bodies.yaml
@@ -105,7 +105,7 @@ AdminCreateBody:
           - redirect_url
         example:
           email: user@example.com
-          redirect_url: 'https://domain/redirect_path?email={email}&token={token}'
+          redirect_url: 'http://localhost:4000/admin/invite?email={email}&token={token}'
           full_name: John Doe
           calling_name: John
           global_role: admin

--- a/apps/admin_api/priv/swagger/swagger.yaml
+++ b/apps/admin_api/priv/swagger/swagger.yaml
@@ -192,6 +192,10 @@ paths:
     $ref: 'admin/paths.yaml#/admin.all'
   /admin.get:
     $ref: 'admin/paths.yaml#/admin.get'
+  /admin.create:
+    $ref: 'admin/paths.yaml#/admin.create'
+  /admin.update:
+    $ref: 'admin/paths.yaml#/admin.update'
   /admin.enable_or_disable:
     $ref: 'admin/paths.yaml#/admin.enable_or_disable'
   /invite.accept:

--- a/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_controller_test.exs
@@ -62,7 +62,7 @@ defmodule AdminAPI.V1.AccountControllerTest do
     test_supports_match_all("/account.all", :account, :name)
 
     test_with_auths "returns a list of accounts that the current user can access" do
-      set_admin_as_none()
+      set_admin_user_role("none")
       master = Account.get_master_account()
       admin = get_test_admin()
       key = insert(:key)
@@ -95,7 +95,7 @@ defmodule AdminAPI.V1.AccountControllerTest do
     end
 
     test_with_auths "returns only one account if the user only has one membership" do
-      set_admin_as_none()
+      set_admin_user_role("none")
       master = Account.get_master_account()
       admin = get_test_admin()
       {:ok, _m} = Membership.unassign(admin, master, %System{})
@@ -181,7 +181,7 @@ defmodule AdminAPI.V1.AccountControllerTest do
     end
 
     test_with_auths "returns unauthorized if the user doesn't have access" do
-      set_admin_as_none()
+      set_admin_user_role("none")
       master = Account.get_master_account()
       admin = get_test_admin()
       {:ok, _m} = Membership.unassign(admin, master, %System{})

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_auth_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_auth_controller_test.exs
@@ -76,7 +76,7 @@ defmodule AdminAPI.V1.AdminAuthControllerTest do
     end
 
     test "responds with a new auth token if credentials are valid and user is a viewer" do
-      set_admin_as_none()
+      set_admin_user_role("none")
       user = get_test_admin() |> Repo.preload([:accounts])
       {:ok, _} = Membership.unassign(user, Enum.at(user.accounts, 0), %System{})
       account = insert(:account)

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_user_controller_test.exs
@@ -14,12 +14,15 @@
 
 defmodule AdminAPI.V1.AdminUserControllerTest do
   use AdminAPI.ConnCase, async: true
+  use Bamboo.Test
   alias Ecto.UUID
-  alias EWalletDB.{User, Account, AuthToken, Membership}
+  alias AdminAPI.UpdateEmailAddressEmail
+  alias EWalletDB.{User, Repo, Account, AuthToken, Invite, UpdateEmailRequest, Membership}
   alias ActivityLogger.System
 
   @owner_app :some_app
   @redirect_url "http://localhost:4000/invite?email={email}&token={token}"
+  @update_email_url "http://localhost:4000/update_email?email={email}&token={token}"
 
   describe "/admin.all" do
     test_with_auths "returns a list of admins and pagination data" do
@@ -227,6 +230,7 @@ defmodule AdminAPI.V1.AdminUserControllerTest do
   describe "/admin.create" do
     test_with_auths "invites a new admin user with email" do
       email = "admin_user@example.com"
+
       attrs = %{
         email: email,
         global_role: "super_admin",
@@ -242,8 +246,9 @@ defmodule AdminAPI.V1.AdminUserControllerTest do
       assert user.global_role == "super_admin"
     end
 
-    test_with_auths "invites a new admin user who gets no global role" do
+    test_with_auths "invites a new admin user who gets no global role once confirmed" do
       email = "admin_user@example.com"
+
       attrs = %{
         email: email,
         redirect_url: @redirect_url
@@ -256,6 +261,263 @@ defmodule AdminAPI.V1.AdminUserControllerTest do
       assert User.get_status(user) == :pending_confirmation
       assert user.email == email
       assert user.global_role == nil
+
+      invite =
+        Invite
+        |> Repo.get_by(user_uuid: user.uuid)
+        |> Repo.preload(:user)
+
+      response =
+        unauthenticated_request("/invite.accept", %{
+          "email" => email,
+          "token" => invite.token,
+          "password" => "password",
+          "password_confirmation" => "password"
+        })
+
+      assert response["success"]
+
+      user = User.get(user.id)
+      assert user.email == email
+      assert user.global_role == nil
+      assert UpdateEmailRequest.all_active() |> length() == 0
+    end
+
+    test_with_auths "can't set the role for a user as super_admin when only admin" do
+      set_admin_user_role("admin")
+      set_key_role("admin")
+
+      email = "admin_user@example.com"
+
+      attrs = %{
+        email: email,
+        global_role: "super_admin",
+        redirect_url: @redirect_url
+      }
+
+      response = request("/admin.create", attrs)
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+    end
+
+    test_with_auths "can't set the role for a user as super_admin when only viewer" do
+      set_admin_user_role("viewer")
+      set_key_role("viewer")
+
+      email = "admin_user@example.com"
+
+      attrs = %{
+        email: email,
+        global_role: "super_admin",
+        redirect_url: @redirect_url
+      }
+
+      response = request("/admin.create", attrs)
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+    end
+
+    test_with_auths "can't set the role for a user as super_admin when only end_user" do
+      set_admin_user_role("end_user")
+      set_key_role("end_user")
+
+      email = "admin_user@example.com"
+
+      attrs = %{
+        email: email,
+        global_role: "super_admin",
+        redirect_url: @redirect_url
+      }
+
+      response = request("/admin.create", attrs)
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+    end
+
+    test_with_auths "can't set the role for a user as super_admin when only none" do
+      set_admin_user_role("none")
+      set_key_role("none")
+
+      email = "admin_user@example.com"
+
+      attrs = %{
+        email: email,
+        global_role: "super_admin",
+        redirect_url: @redirect_url
+      }
+
+      response = request("/admin.create", attrs)
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+    end
+  end
+
+  describe "/admin.update" do
+    test_with_auths "updates an admin's email" do
+      admin = insert(:admin)
+      email = "admin_user@example.com"
+
+      attrs = %{
+        id: admin.id,
+        email: email,
+        full_name: "John Doe",
+        redirect_url: @update_email_url,
+        global_role: "super_admin"
+      }
+
+      response = request("/admin.update", attrs)
+
+      assert response["success"] == true
+      user = User.get_by(id: admin.id)
+
+      assert user.email != email
+      assert user.is_admin == true
+      assert user.full_name == "John Doe"
+      assert user.global_role == "super_admin"
+
+      request =
+        UpdateEmailRequest
+        |> Repo.get_by(user_uuid: admin.uuid)
+        |> Repo.preload(:user)
+
+      assert_delivered_email(UpdateEmailAddressEmail.create(request, @update_email_url))
+    end
+
+    test_with_auths "updates an admin's details without changing the email" do
+      admin = insert(:admin)
+      email = "admin_user@example.com"
+
+      attrs = %{
+        id: admin.id,
+        full_name: "John Doe",
+        global_role: "super_admin"
+      }
+
+      response = request("/admin.update", attrs)
+
+      assert response["success"] == true
+      user = User.get_by(id: admin.id)
+
+      assert user.email != email
+      assert user.is_admin == true
+      assert user.full_name == "John Doe"
+      assert user.global_role == "super_admin"
+
+      request =
+        UpdateEmailRequest
+        |> Repo.get_by(user_uuid: admin.uuid)
+        |> Repo.preload(:user)
+
+      assert request == nil
+    end
+
+    test_with_auths "can't update the email without giving a redirect_url" do
+      admin = insert(:admin)
+      email = "admin_user@example.com"
+
+      attrs = %{
+        id: admin.id,
+        email: email
+      }
+
+      response = request("/admin.update", attrs)
+
+      refute response["success"]
+      assert response["data"]["code"] == "client:invalid_parameter"
+    end
+
+    test "can't update themselves" do
+      admin = get_test_admin()
+
+      attrs = %{
+        id: admin.id,
+        global_role: "admin"
+      }
+
+      response = admin_user_request("/admin.update", attrs)
+
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+    end
+
+    test_with_auths "can't change a user global role when only admin" do
+      set_admin_user_role("admin")
+      set_key_role("admin")
+
+      admin = insert(:admin, global_role: "super_admin")
+
+      attrs = %{
+        id: admin.id,
+        global_role: "admin"
+      }
+
+      response = request("/admin.update", attrs)
+
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+
+      user = User.get_by(id: admin.id)
+      assert user.global_role == "super_admin"
+    end
+
+    test_with_auths "can't change a user global role when only viewer" do
+      set_admin_user_role("viewer")
+      set_key_role("viewer")
+
+      admin = insert(:admin, global_role: "super_admin")
+
+      attrs = %{
+        id: admin.id,
+        global_role: "admin"
+      }
+
+      response = request("/admin.update", attrs)
+
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+
+      user = User.get_by(id: admin.id)
+      assert user.global_role == "super_admin"
+    end
+
+    test_with_auths "can't change a user global role when only end_user" do
+      set_admin_user_role("end_user")
+      set_key_role("end_user")
+
+      admin = insert(:admin, global_role: "super_admin")
+
+      attrs = %{
+        id: admin.id,
+        global_role: "admin"
+      }
+
+      response = request("/admin.update", attrs)
+
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+
+      user = User.get_by(id: admin.id)
+      assert user.global_role == "super_admin"
+    end
+
+    test_with_auths "can't change a user global role when only none" do
+      set_admin_user_role("none")
+      set_key_role("none")
+
+      admin = insert(:admin, global_role: "super_admin")
+
+      attrs = %{
+        id: admin.id,
+        global_role: "admin"
+      }
+
+      response = request("/admin.update", attrs)
+
+      refute response["success"]
+      assert response["data"]["code"] == "unauthorized"
+
+      user = User.get_by(id: admin.id)
+      assert user.global_role == "super_admin"
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/export_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/export_controller_test.exs
@@ -127,8 +127,8 @@ defmodule AdminAPI.V1.ExportControllerTest do
     end
 
     test_with_auths "returns 'unauthorized' if the export is not owned" do
-      set_admin_as_none()
-      set_key_role_to_none()
+      set_admin_user_role("none")
+      set_key_role("none")
 
       export = insert(:export)
       response = request("/export.get", %{"id" => export.id})

--- a/apps/admin_api/test/admin_api/v1/controllers/self_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/self_controller_test.exs
@@ -17,7 +17,6 @@ defmodule AdminAPI.V1.SelfControllerTest do
   use Bamboo.Test
   import Ecto.Query
   alias AdminAPI.UpdateEmailAddressEmail
-  alias EWalletDB.{Account, Membership, Repo, User}
   alias EWalletDB.{Account, Membership, Repo, UpdateEmailRequest, User}
   alias Utils.Helpers.{Crypto, Assoc, DateFormatter}
   alias ActivityLogger.System

--- a/apps/admin_api/test/admin_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/transaction_controller_test.exs
@@ -254,7 +254,7 @@ defmodule AdminAPI.V1.TransactionControllerTest do
     end
 
     test_with_auths "returns match_all filtered transactions with no permissions", context do
-      set_admin_as_none()
+      set_admin_user_role("none")
 
       response =
         request("/transaction.all", %{

--- a/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
@@ -336,7 +336,6 @@ defmodule AdminAPI.V1.UserControllerTest do
       data = response["data"]
       assert data["object"] == "user"
       assert data["provider_user_id"] == request_data.provider_user_id
-      assert data["global_role"] == "end_user"
       assert data["username"] == request_data.username
       assert data["metadata"] == %{"something" => "interesting"}
       assert data["encrypted_metadata"] == %{"something" => "secret"}

--- a/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
@@ -336,6 +336,7 @@ defmodule AdminAPI.V1.UserControllerTest do
       data = response["data"]
       assert data["object"] == "user"
       assert data["provider_user_id"] == request_data.provider_user_id
+      assert data["global_role"] == "end_user"
       assert data["username"] == request_data.username
       assert data["metadata"] == %{"something" => "interesting"}
       assert data["encrypted_metadata"] == %{"something" => "secret"}

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -215,29 +215,20 @@ defmodule AdminAPI.ConnCase do
     |> Repo.one()
   end
 
-  @spec set_admin_as_super_admin() :: {:ok, EWalletDB.User.t()}
-  def set_admin_as_super_admin(admin_user \\ nil) do
+  @spec set_admin_user_role(String.t()) :: {:ok, EWalletDB.User.t()}
+  def set_admin_user_role(role, admin_user \\ nil) do
     {:ok, _} =
       User.update(admin_user || get_test_admin(), %{
-        global_role: "super_admin",
+        global_role: role,
         originator: %System{}
       })
   end
 
-  @spec set_admin_as_none() :: {:ok, EWalletDB.User.t()}
-  def set_admin_as_none(admin_user \\ nil) do
-    {:ok, _} =
-      User.update(admin_user || get_test_admin(), %{
-        global_role: "none",
-        originator: %System{}
-      })
-  end
-
-  @spec set_key_role_to_none() :: {:ok, EWalletDB.Key.t()}
-  def set_key_role_to_none(key \\ nil) do
+  @spec set_key_role(String.t()) :: {:ok, EWalletDB.Key.t()}
+  def set_key_role(role, key \\ nil) do
     {:ok, _} =
       Key.update(key || get_test_key(), %{
-        global_role: "none",
+        global_role: role,
         originator: %System{}
       })
   end
@@ -410,7 +401,7 @@ defmodule AdminAPI.ConnCase do
         opts = unquote(opts)
         field_name = Atom.to_string(field)
 
-        set_admin_as_super_admin()
+        set_admin_user_role("super_admin")
 
         factory_attrs = Keyword.get(opts, :factory_attrs, %{})
 
@@ -484,7 +475,7 @@ defmodule AdminAPI.ConnCase do
         opts = unquote(opts)
         field_name = Atom.to_string(field)
 
-        set_admin_as_super_admin()
+        set_admin_user_role("super_admin")
 
         factory_attrs = Keyword.get(opts, :factory_attrs, %{})
 

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -224,7 +224,7 @@ defmodule AdminAPI.ConnCase do
       })
   end
 
-  @spec set_key_role(String.t()) :: {:ok, EWalletDB.Key.t()}
+  @spec set_key_role(String.t(), %Key{}) :: {:ok, EWalletDB.Key.t()} | no_return()
   def set_key_role(role, key \\ nil) do
     {:ok, _} =
       Key.update(key || get_test_key(), %{

--- a/apps/admin_api/test/support/conn_case.ex
+++ b/apps/admin_api/test/support/conn_case.ex
@@ -224,7 +224,7 @@ defmodule AdminAPI.ConnCase do
       })
   end
 
-  @spec set_key_role(String.t(), %Key{}) :: {:ok, EWalletDB.Key.t()} | no_return()
+  @spec set_key_role(String.t(), %Key{} | nil) :: {:ok, EWalletDB.Key.t()} | no_return()
   def set_key_role(role, key \\ nil) do
     {:ok, _} =
       Key.update(key || get_test_key(), %{

--- a/apps/ewallet/lib/ewallet/gates/user_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/user_gate.ex
@@ -1,0 +1,98 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.UserGate do
+  alias EWallet.{EmailValidator, InviteEmail}
+  alias EWallet.Web.{UrlValidator, Inviter}
+  alias EWalletDB.{User, Membership}
+
+  # Get user or email specifically for `assign_user/2` above.
+  #
+  # Returns:
+  # - `%User{}` if user_id is provided and found.
+  # - `:unauthorized` if `user_id` is provided but not found.
+  # - `%User{}` if email is provided and found.
+  # - `string` email if email provided but not found.
+  #
+  # If both `user_id` and `email` are provided, only `user_id` is attempted.
+  # Hence the pattern matching for `%{"user_id" => _}` comes first.
+  def get_user_or_email(%{"user_id" => user_id}) do
+    case User.get(user_id) do
+      %User{} = user -> {:ok, user}
+      _ -> {:error, :unauthorized}
+    end
+  end
+
+  def get_user_or_email(%{"email" => nil}) do
+    {:error, :invalid_email}
+  end
+
+  def get_user_or_email(%{"email" => email}) do
+    case User.get_by_email(email) do
+      %User{} = user -> {:ok, user}
+      nil -> {:ok, email}
+    end
+  end
+
+  def validate_redirect_url(url) do
+    if UrlValidator.allowed_redirect_url?(url) do
+      {:ok, url}
+    else
+      {:error, :prohibited_url, param_name: "redirect_url", url: url}
+    end
+  end
+
+  def invite_global_user(%{"email" => email} = attrs, redirect_url) when is_binary(email) do
+    case EmailValidator.validate(email) do
+      {:ok, email} ->
+        Inviter.invite_admin(
+          attrs,
+          redirect_url,
+          &InviteEmail.create/2
+        )
+
+      error ->
+        error
+    end
+  end
+
+  def assign_or_invite(email, account, role, redirect_url, originator) when is_binary(email) do
+    case EmailValidator.validate(email) do
+      {:ok, email} ->
+        Inviter.invite_admin(
+          email,
+          account,
+          role,
+          redirect_url,
+          originator,
+          &InviteEmail.create/2
+        )
+
+      error ->
+        error
+    end
+  end
+
+  def assign_or_invite(user, account, role, redirect_url, originator) do
+    case User.get_status(user) do
+      :pending_confirmation ->
+        user
+        |> User.get_invite()
+        |> Inviter.send_email(redirect_url, &InviteEmail.create/2)
+
+      :active ->
+        Membership.assign(user, account, role, originator)
+    end
+  end
+end

--- a/apps/ewallet/lib/ewallet/gates/user_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/user_gate.ex
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 defmodule EWallet.UserGate do
+  @moduledoc """
+  Business logic for shared functions related to user creation.
+  """
   alias EWallet.{EmailValidator, InviteEmail}
   alias EWallet.Web.{UrlValidator, Inviter}
   alias EWalletDB.{User, Membership}

--- a/apps/ewallet/lib/ewallet/gates/user_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/user_gate.ex
@@ -58,7 +58,7 @@ defmodule EWallet.UserGate do
 
   def invite_global_user(%{"email" => email} = attrs, redirect_url) when is_binary(email) do
     case EmailValidator.validate(email) do
-      {:ok, email} ->
+      {:ok, _email} ->
         Inviter.invite_admin(
           attrs,
           redirect_url,

--- a/apps/ewallet/lib/ewallet/web/inviter.ex
+++ b/apps/ewallet/lib/ewallet/web/inviter.ex
@@ -57,7 +57,7 @@ defmodule EWallet.Web.Inviter do
   end
 
   @spec invite_admin(String.t(), %Account{}, %Role{}, String.t(), map() | atom(), fun()) ::
-        {:ok, %Invite{}} | {:error, atom()}
+          {:ok, %Invite{}} | {:error, atom()}
   def invite_admin(email, account, role, redirect_url, originator, create_email_func) do
     with {:ok, user} <- get_or_insert_user(email, nil, originator),
          {:ok, invite} <- Invite.generate(user, originator, preload: :user),

--- a/apps/ewallet/lib/ewallet/web/inviter.ex
+++ b/apps/ewallet/lib/ewallet/web/inviter.ex
@@ -44,8 +44,20 @@ defmodule EWallet.Web.Inviter do
   Creates the admin along with the membership if the admin does not exist,
   then sends the invite email out.
   """
-  @spec invite_admin(String.t(), %Account{}, %Role{}, String.t(), map() | atom(), fun()) ::
+  @spec invite_admin(map(), String.t(), fun()) ::
           {:ok, %Invite{}} | {:error, atom()}
+  def invite_admin(%{"originator" => originator} = attrs, redirect_url, create_email_func) do
+    with {:ok, user} <- insert_user(attrs),
+         {:ok, invite} <- Invite.generate(user, originator, preload: :user) do
+      send_email(invite, redirect_url, create_email_func)
+    else
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @spec invite_admin(String.t(), %Account{}, %Role{}, String.t(), map() | atom(), fun()) ::
+        {:ok, %Invite{}} | {:error, atom()}
   def invite_admin(email, account, role, redirect_url, originator, create_email_func) do
     with {:ok, user} <- get_or_insert_user(email, nil, originator),
          {:ok, invite} <- Invite.generate(user, originator, preload: :user),
@@ -75,6 +87,12 @@ defmodule EWallet.Web.Inviter do
           originator: originator
         })
     end
+  end
+
+  defp insert_user(attrs) do
+    attrs
+    |> Map.put("password", Crypto.generate_base64_key(32))
+    |> User.insert()
   end
 
   @doc """

--- a/apps/ewallet/lib/ewallet/web/v1/serializers/admin_user_serializer.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/serializers/admin_user_serializer.ex
@@ -1,0 +1,66 @@
+# Copyright 2018-2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWallet.Web.V1.AdminUserSerializer do
+  @moduledoc """
+  Serializes user(s) into V1 JSON response format.
+  """
+  alias Ecto.Association.NotLoaded
+  alias EWallet.Web.{Paginator, V1.PaginatorSerializer}
+  alias EWalletDB.Uploaders.Avatar
+  alias EWalletDB.User
+  alias Utils.Helpers.DateFormatter
+
+  def serialize(%Paginator{} = paginator) do
+    PaginatorSerializer.serialize(paginator, &serialize/1)
+  end
+
+  def serialize(users) when is_list(users) do
+    %{
+      object: "list",
+      data: Enum.map(users, &serialize/1)
+    }
+  end
+
+  def serialize(%User{} = user) do
+    %{
+      object: "user",
+      id: user.id,
+      socket_topic: "user:#{user.id}",
+      username: user.username,
+      global_role: user.global_role,
+      full_name: user.full_name,
+      calling_name: user.calling_name,
+      provider_user_id: user.provider_user_id,
+      email: user.email,
+      metadata: user.metadata || %{},
+      encrypted_metadata: user.encrypted_metadata || %{},
+      avatar: Avatar.urls({user.avatar, user}),
+      enabled: user.enabled,
+      created_at: DateFormatter.to_iso8601(user.inserted_at),
+      updated_at: DateFormatter.to_iso8601(user.updated_at)
+    }
+  end
+
+  def serialize(%NotLoaded{}), do: nil
+  def serialize(nil), do: nil
+
+  def serialize(%NotLoaded{}, _), do: nil
+
+  def serialize(users, :id) when is_list(users) do
+    Enum.map(users, fn user -> user.id end)
+  end
+
+  def serialize(nil, _), do: nil
+end

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/signup_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/signup_controller_test.exs
@@ -34,6 +34,9 @@ defmodule EWalletAPI.V1.SignupControllerTest do
       assert response["version"] == @expected_version
       assert response["success"] == true
       assert response["data"] == %{}
+
+      user = User.get_by(email: "test_user_signup@example.com")
+      assert user.global_role == "end_user"
     end
 
     test "uses the default verification_url if not provided" do
@@ -155,7 +158,8 @@ defmodule EWalletAPI.V1.SignupControllerTest do
         target: user,
         changes: %{
           "email" => "test_user_signup@example.com",
-          "password_hash" => user.password_hash
+          "password_hash" => user.password_hash,
+          "global_role" => "end_user"
         },
         encrypted_changes: %{}
       )
@@ -225,6 +229,9 @@ defmodule EWalletAPI.V1.SignupControllerTest do
 
       assert response["data"]["object"] == "user"
       assert response["data"]["id"] == context.user.id
+
+      user = User.get_by(email: "verify_email@example.com")
+      assert user.global_role == "end_user"
     end
 
     test "returns an error when email is invalid", context do

--- a/apps/ewallet_db/config/test.exs
+++ b/apps/ewallet_db/config/test.exs
@@ -5,5 +5,5 @@ config :ewallet_db, EWalletDB.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   url: {:system, "DATABASE_URL", "postgres://localhost/ewallet_test"},
   migration_timestamps: [type: :naive_datetime_usec],
-  queue_target: 1_500,
+  queue_target: 2_500,
   queue_interval: 5_000

--- a/apps/ewallet_db/lib/ewallet_db/role.ex
+++ b/apps/ewallet_db/lib/ewallet_db/role.ex
@@ -36,7 +36,6 @@ defmodule EWalletDB.Role do
         all: :accounts,
         get: :accounts,
         create: :accounts,
-        update: :accounts,
         update_password: :self,
         update_email: :self,
         upload_avatar: :self,

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -202,6 +202,7 @@ defmodule EWalletDB.User do
       ]
     )
     |> assoc_constraint(:invite)
+    |> validate_inclusion(:global_role, GlobalRole.global_roles())
     |> validate_by_roles(attrs)
   end
 

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -259,7 +259,7 @@ defmodule EWalletDB.User do
     |> unique_constraint(:email)
   end
 
-  defp set_global_role(changeset, attrs) do
+  defp set_global_role(changeset, _attrs) do
     case {get_field(changeset, :is_admin), get_field(changeset, :global_role)} do
       {true, _} ->
         changeset

--- a/apps/ewallet_db/lib/ewallet_db/user.ex
+++ b/apps/ewallet_db/lib/ewallet_db/user.ex
@@ -158,6 +158,7 @@ defmodule EWalletDB.User do
     |> assoc_constraint(:invite)
     |> put_change(:password_hash, password_hash)
     |> validate_by_roles(attrs)
+    |> set_global_role(attrs)
   end
 
   defp update_user_changeset(user, attrs) do
@@ -258,6 +259,19 @@ defmodule EWalletDB.User do
     |> unique_constraint(:email)
   end
 
+  defp set_global_role(changeset, attrs) do
+    case {get_field(changeset, :is_admin), get_field(changeset, :global_role)} do
+      {true, _} ->
+        changeset
+
+      {false, "end_user"} ->
+        changeset
+
+      {false, _} ->
+        put_change(changeset, :global_role, GlobalRole.end_user())
+    end
+  end
+
   # Two cases to validate for loginable:
   #
   #   1. A new admin user has just been created. No membership assigned yet.
@@ -303,9 +317,7 @@ defmodule EWalletDB.User do
   end
 
   defp do_validate_provider_user(changeset, _attrs) do
-    changeset
-    |> validate_required([:username, :provider_user_id])
-    |> put_change(:global_role, GlobalRole.end_user())
+    validate_required(changeset, [:username, :provider_user_id])
   end
 
   @doc """


### PR DESCRIPTION
Issue/Task Number: #838 
closes #838

# Overview

This PR adds `/admin.create` and `/admin.update` to deal with global users.

# Changes

- Add `/admin.create`
- Add `/admin.update`
- Properly set `end_user` global role for end users