### PR TITLE
Fix cors config

### DIFF
--- a/apps/admin_api/lib/admin_api/application.ex
+++ b/apps/admin_api/lib/admin_api/application.ex
@@ -27,7 +27,6 @@ defmodule AdminAPI.Application do
     settings = Application.get_env(:admin_api, :settings)
     EWalletConfig.Config.register_and_load(:admin_api, settings)
 
-    Config.configure_cors_plug()
     EWallet.configure_socket_endpoints([AdminAPI.V1.Endpoint])
 
     # Always run AdminAPI.Endpoint and AdminAPI.V1.Endpoint in supervision tree

--- a/apps/admin_api/lib/admin_api/application.ex
+++ b/apps/admin_api/lib/admin_api/application.ex
@@ -18,14 +18,14 @@ defmodule AdminAPI.Application do
   """
   use Application
   alias AdminAPI.Endpoint
-  alias EWallet.Web.Config
+  alias EWalletConfig.Config
 
   def start(_type, _args) do
     import Supervisor.Spec
     DeferredConfig.populate(:admin_api)
 
     settings = Application.get_env(:admin_api, :settings)
-    EWalletConfig.Config.register_and_load(:admin_api, settings)
+    Config.register_and_load(:admin_api, settings)
 
     EWallet.configure_socket_endpoints([AdminAPI.V1.Endpoint])
 

--- a/apps/admin_api/lib/admin_api/endpoint.ex
+++ b/apps/admin_api/lib/admin_api/endpoint.ex
@@ -16,6 +16,7 @@ defmodule AdminAPI.Endpoint do
   use Phoenix.Endpoint, otp_app: :admin_api
   use Appsignal.Phoenix
   use Sentry.Phoenix.Endpoint
+  alias EWallet.Web.Config
 
   if code_reloading? do
     plug(Phoenix.CodeReloader)
@@ -33,7 +34,7 @@ defmodule AdminAPI.Endpoint do
 
   plug(Plug.MethodOverride)
   plug(Plug.Head)
-  plug(CORSPlug)
+  plug(CORSPlug, Config.cors_plug_config)
 
   plug(AdminAPI.Router)
 end

--- a/apps/admin_api/lib/admin_api/endpoint.ex
+++ b/apps/admin_api/lib/admin_api/endpoint.ex
@@ -34,7 +34,7 @@ defmodule AdminAPI.Endpoint do
 
   plug(Plug.MethodOverride)
   plug(Plug.Head)
-  plug(CORSPlug, Config.cors_plug_config)
+  plug(CORSPlug, Config.cors_plug_config())
 
   plug(AdminAPI.Router)
 end

--- a/apps/ewallet/config/config.exs
+++ b/apps/ewallet/config/config.exs
@@ -5,6 +5,8 @@ use Mix.Config
 config :ewallet,
   ecto_repos: [],
   version: "1.2.0-dev",
+  cors_max_page: {:system, "CORS_MAX_AGE", 600, {String, :to_integer}},
+  cors_origin: {:system, "CORS_ORIGIN", nil},
   settings: [
     :base_url,
     :sender_email,

--- a/apps/ewallet/config/config.exs
+++ b/apps/ewallet/config/config.exs
@@ -5,7 +5,6 @@ use Mix.Config
 config :ewallet,
   ecto_repos: [],
   version: "1.2.0-dev",
-  cors_max_page: {:system, "CORS_MAX_AGE", 600, {String, :to_integer}},
   cors_origin: {:system, "CORS_ORIGIN", nil},
   settings: [
     :base_url,

--- a/apps/ewallet/lib/ewallet/web/config.ex
+++ b/apps/ewallet/lib/ewallet/web/config.ex
@@ -33,21 +33,26 @@ defmodule EWallet.Web.Config do
     "OMGAdmin-Account-ID"
   ]
 
-  def configure_cors_plug do
-    max_age =
-      case System.get_env("CORS_MAX_AGE") do
-        nil -> 600
-        value -> String.to_integer(value)
-      end
+  @methods [
+    "POST",
+    "GET"
+  ]
 
-    cors_origin = System.get_env("CORS_ORIGIN")
+  def cors_plug_config do
+    [max_age: cors_max_age(), origin: cors_origin(), headers: @headers, methods: @methods]
+  end
 
-    Application.put_env(:cors_plug, :max_age, max_age)
-    Application.put_env(:cors_plug, :headers, @headers)
-    Application.put_env(:cors_plug, :methods, ["POST"])
-    Application.put_env(:cors_plug, :origin, cors_plug_origin(cors_origin))
+  defp cors_origin do
+    "CORS_ORIGIN"
+    |> System.get_env()
+    |> cors_plug_origin()
+  end
 
-    :ok
+  defp cors_max_age do
+    case System.get_env("CORS_MAX_AGE") do
+      nil -> 600
+      value -> String.to_integer(value)
+    end
   end
 
   defp cors_plug_origin(nil), do: []

--- a/apps/ewallet/lib/ewallet/web/config.ex
+++ b/apps/ewallet/lib/ewallet/web/config.ex
@@ -38,22 +38,33 @@ defmodule EWallet.Web.Config do
     "GET"
   ]
 
+  @doc """
+  Prepares the config that is accepted by CORSPlug.
+
+  Note that calling this function when setting up a plug,
+  e.g. `plug CORSPlug, Config.cors_plug_config()`, would call this function at compile-time.
+
+  The only value that can be dynamic is :origin, which CORSPlug allows passing
+  a function reference to be called at runtime. See: https://hexdocs.pm/cors_plug/
+  """
+  @spec cors_plug_config() :: Keyword.t()
   def cors_plug_config do
     [
-      max_age: &__MODULE__.cors_max_age/0,
+      max_age: 86400,
       origin: &__MODULE__.cors_origin/0,
       headers: @headers,
       methods: @methods
     ]
   end
 
+  # This should be a private function but required to be public as it's passed into CORSPLug.
+  @doc false
+  @spec cors_origin() :: [String.t()]
   def cors_origin do
     :ewallet
     |> Application.get_env(:cors_origin)
     |> cors_plug_origin()
   end
-
-  def cors_max_age, do: Application.get_env(:ewallet, :cors_max_age)
 
   defp cors_plug_origin(nil), do: []
 

--- a/apps/ewallet/lib/ewallet/web/config.ex
+++ b/apps/ewallet/lib/ewallet/web/config.ex
@@ -43,17 +43,12 @@ defmodule EWallet.Web.Config do
   end
 
   def cors_origin do
-    "CORS_ORIGIN"
-    |> System.get_env()
+    :ewallet
+    |> Application.get_env(:cors_origin)
     |> cors_plug_origin()
   end
 
-  def cors_max_age do
-    case System.get_env("CORS_MAX_AGE") do
-      nil -> 600
-      value -> String.to_integer(value)
-    end
-  end
+  def cors_max_age, do: Application.get_env(:ewallet, :cors_max_age)
 
   defp cors_plug_origin(nil), do: []
 

--- a/apps/ewallet/lib/ewallet/web/config.ex
+++ b/apps/ewallet/lib/ewallet/web/config.ex
@@ -39,7 +39,12 @@ defmodule EWallet.Web.Config do
   ]
 
   def cors_plug_config do
-    [max_age: &__MODULE__.cors_max_age/0, origin: &__MODULE__.cors_origin/0, headers: @headers, methods: @methods]
+    [
+      max_age: &__MODULE__.cors_max_age/0,
+      origin: &__MODULE__.cors_origin/0,
+      headers: @headers,
+      methods: @methods
+    ]
   end
 
   def cors_origin do

--- a/apps/ewallet/lib/ewallet/web/config.ex
+++ b/apps/ewallet/lib/ewallet/web/config.ex
@@ -50,7 +50,7 @@ defmodule EWallet.Web.Config do
   @spec cors_plug_config() :: Keyword.t()
   def cors_plug_config do
     [
-      max_age: 86400,
+      max_age: 86_400,
       origin: &__MODULE__.cors_origin/0,
       headers: @headers,
       methods: @methods

--- a/apps/ewallet/lib/ewallet/web/config.ex
+++ b/apps/ewallet/lib/ewallet/web/config.ex
@@ -39,16 +39,16 @@ defmodule EWallet.Web.Config do
   ]
 
   def cors_plug_config do
-    [max_age: cors_max_age(), origin: cors_origin(), headers: @headers, methods: @methods]
+    [max_age: &__MODULE__.cors_max_age/0, origin: &__MODULE__.cors_origin/0, headers: @headers, methods: @methods]
   end
 
-  defp cors_origin do
+  def cors_origin do
     "CORS_ORIGIN"
     |> System.get_env()
     |> cors_plug_origin()
   end
 
-  defp cors_max_age do
+  def cors_max_age do
     case System.get_env("CORS_MAX_AGE") do
       nil -> 600
       value -> String.to_integer(value)

--- a/apps/ewallet/test/ewallet/web/config_test.exs
+++ b/apps/ewallet/test/ewallet/web/config_test.exs
@@ -84,12 +84,12 @@ defmodule EWallet.Web.ConfigTest do
     end
 
     test "returns a correct origin value when CORS_ORIGIN is specified with multiple values" do
-      origin = "http://example.com, http://localhost.com"
+      origin = "https://example.com, https://second.example.com"
       {:ok, original_env} = set_system_env("CORS_ORIGIN", origin)
 
       config = Config.cors_plug_config()
 
-      assert config[:origin] == ["http://example.com", "http://localhost.com"]
+      assert config[:origin] == ["https://example.com", "https://second.example.com"]
 
       # Revert the env var to their original values.
       {:ok, _} = set_system_env("CORS_ORIGIN", original_env)

--- a/apps/ewallet/test/ewallet/web/config_test.exs
+++ b/apps/ewallet/test/ewallet/web/config_test.exs
@@ -51,7 +51,7 @@ defmodule EWallet.Web.ConfigTest do
       {:ok, original_env} = set_env(:cors_max_age, max_age)
       config = Config.cors_plug_config()
 
-      assert config[:max_age].() == max_age
+      assert config[:max_age] == 1234
 
       # Revert the env var to their original values.
       {:ok, _} = set_env(:cors_max_age, original_env)

--- a/apps/ewallet/test/ewallet/web/config_test.exs
+++ b/apps/ewallet/test/ewallet/web/config_test.exs
@@ -47,11 +47,9 @@ defmodule EWallet.Web.ConfigTest do
     end
 
     test "returns the correct :cors_max_age value" do
-      max_age = 1234
-      {:ok, original_env} = set_env(:cors_max_age, max_age)
       config = Config.cors_plug_config()
 
-      assert config[:max_age] == 1234
+      assert config[:max_age] == 86_400
 
       # Revert the env var to their original values.
       {:ok, _} = set_env(:cors_max_age, original_env)

--- a/apps/ewallet/test/ewallet/web/config_test.exs
+++ b/apps/ewallet/test/ewallet/web/config_test.exs
@@ -50,9 +50,6 @@ defmodule EWallet.Web.ConfigTest do
       config = Config.cors_plug_config()
 
       assert config[:max_age] == 86_400
-
-      # Revert the env var to their original values.
-      {:ok, _} = set_env(:cors_max_age, original_env)
     end
 
     test "returns the correct :cors_origin value when there is only one origin" do

--- a/apps/ewallet_api/lib/ewallet_api/application.ex
+++ b/apps/ewallet_api/lib/ewallet_api/application.ex
@@ -27,7 +27,6 @@ defmodule EWalletAPI.Application do
     settings = Application.get_env(:ewallet_api, :settings)
     EWalletConfig.Config.register_and_load(:ewallet_api, settings)
 
-    Config.configure_cors_plug()
     EWallet.configure_socket_endpoints([EWalletAPI.V1.Endpoint])
 
     # Always run EWalletAPI.Endpoint and EWalletAPI.V1.Endpoint in supervision tree

--- a/apps/ewallet_api/lib/ewallet_api/application.ex
+++ b/apps/ewallet_api/lib/ewallet_api/application.ex
@@ -17,15 +17,15 @@ defmodule EWalletAPI.Application do
   EWalletAPI's startup and shutdown functionalities
   """
   use Application
-  alias EWallet.Web.Config
   alias EWalletAPI.Endpoint
+  alias EWalletConfig.Config
 
   def start(_type, _args) do
     import Supervisor.Spec
     DeferredConfig.populate(:ewallet_api)
 
     settings = Application.get_env(:ewallet_api, :settings)
-    EWalletConfig.Config.register_and_load(:ewallet_api, settings)
+    Config.register_and_load(:ewallet_api, settings)
 
     EWallet.configure_socket_endpoints([EWalletAPI.V1.Endpoint])
 

--- a/apps/ewallet_api/lib/ewallet_api/endpoint.ex
+++ b/apps/ewallet_api/lib/ewallet_api/endpoint.ex
@@ -36,7 +36,7 @@ defmodule EWalletAPI.Endpoint do
 
   plug(Plug.MethodOverride)
   plug(Plug.Head)
-  plug(CORSPlug, Config.cors_plug_config)
+  plug(CORSPlug, Config.cors_plug_config())
 
   plug(EWalletAPI.Router)
 end

--- a/apps/ewallet_api/lib/ewallet_api/endpoint.ex
+++ b/apps/ewallet_api/lib/ewallet_api/endpoint.ex
@@ -16,6 +16,7 @@ defmodule EWalletAPI.Endpoint do
   use Phoenix.Endpoint, otp_app: :ewallet_api
   use Appsignal.Phoenix
   use Sentry.Phoenix.Endpoint
+  alias EWallet.Web.Config
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
@@ -35,7 +36,7 @@ defmodule EWalletAPI.Endpoint do
 
   plug(Plug.MethodOverride)
   plug(Plug.Head)
-  plug(CORSPlug)
+  plug(CORSPlug, Config.cors_plug_config)
 
   plug(EWalletAPI.Router)
 end


### PR DESCRIPTION
Issue/Task Number: 866
Closes #866 

# Overview

This PR is an attempt to fix the currently broken CORS plug.
The previous configuration was not working properly because the configuration was set in application variables after the plug was initialized.

This PR moves the plug configuration setup at the `endpoint` level.

# Changes

- Configure the plug at the `endpoint` level
- Refactor plug config

# Impact

As the plug was not properly working until now, it was accepting all origins by default.
After this PR gets merged a proper configuration will be required.
