### PR TITLE
Fix a random test error in WalletControllerTest

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/wallet_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/wallet_controller_test.exs
@@ -159,12 +159,14 @@ defmodule AdminAPI.V1.WalletControllerTest do
       balances = List.first(response["data"]["data"])["balances"]
 
       assert Enum.any?(balances, fn balance ->
-        balance["amount"] == 150_000 * btc.subunit_to_unit && balance["token"]["id"] == btc.id
-      end)
+               balance["amount"] == 150_000 * btc.subunit_to_unit &&
+                 balance["token"]["id"] == btc.id
+             end)
 
       assert Enum.any?(balances, fn balance ->
-        balance["amount"] == 12_000 * omg.subunit_to_unit && balance["token"]["id"] == omg.id
-      end)
+               balance["amount"] == 12_000 * omg.subunit_to_unit &&
+                 balance["token"]["id"] == omg.id
+             end)
     end
 
     test_with_auths "Get all user wallets with an invalid parameter should fail" do


### PR DESCRIPTION
Issue/Task Number: #831 
Closes #831

# Overview

This PR fixes a random test error in WalletControllerTest due to indeterministic wallet balance order.

# Changes

- Fixed a test in WalletControllerTest by asserting for specific values than the entire response.

# Implementation Details

N/A

# Usage

`mix test` should not randomly fail as in #831.

# Impact

No changes to API specs nor DB schema