### PR TITLE
Fix internal server error on missing filter params

### DIFF
--- a/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_all_query.ex
@@ -35,7 +35,7 @@ defmodule EWallet.Web.MatchAllQuery do
         dynamic([q], ilike(fragment("?::text", field(q, ^field)), ^"#{value}%") and ^dynamic)
 
       _ ->
-        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+        not_supported(field, comparator, value)
     end
   end
 
@@ -43,7 +43,7 @@ defmodule EWallet.Web.MatchAllQuery do
     case comparator do
       "eq" -> dynamic([q], is_nil(field(q, ^field)) and ^dynamic)
       "neq" -> dynamic([q], not is_nil(field(q, ^field)) and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+      _ -> not_supported(field, comparator, value)
     end
   end
 
@@ -57,7 +57,7 @@ defmodule EWallet.Web.MatchAllQuery do
       "lte" -> dynamic([q], field(q, ^field) <= ^value and ^dynamic)
       "contains" -> dynamic([q], ilike(field(q, ^field), ^"%#{value}%") and ^dynamic)
       "starts_with" -> dynamic([q], ilike(field(q, ^field), ^"#{value}%") and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+      _ -> not_supported(field, comparator, value)
     end
   end
 
@@ -88,7 +88,7 @@ defmodule EWallet.Web.MatchAllQuery do
     case comparator do
       "eq" -> dynamic([{a, position}], is_nil(field(a, ^field)) and ^dynamic)
       "neq" -> dynamic([{a, position}], not is_nil(field(a, ^field)) and ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+      _ -> not_supported(field, comparator, value)
     end
   end
 
@@ -119,7 +119,12 @@ defmodule EWallet.Web.MatchAllQuery do
         dynamic([{a, position}], ilike(field(a, ^field), ^"#{value}%") and ^dynamic)
 
       _ ->
-        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+        not_supported(field, comparator, value)
     end
+  end
+
+  defp not_supported(field, comparator, value) do
+    {:error, :comparator_not_supported,
+     field: Atom.to_string(field), comparator: comparator, value: value}
   end
 end

--- a/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_any_query.ex
@@ -35,7 +35,7 @@ defmodule EWallet.Web.MatchAnyQuery do
         dynamic([q], ilike(fragment("?::text", field(q, ^field)), ^"#{value}%") or ^dynamic)
 
       _ ->
-        {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+        not_supported(field, comparator, value)
     end
   end
 
@@ -43,7 +43,7 @@ defmodule EWallet.Web.MatchAnyQuery do
     case comparator do
       "eq" -> dynamic([q], is_nil(field(q, ^field)) or ^dynamic)
       "neq" -> dynamic([q], not is_nil(field(q, ^field)) or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+      _ -> not_supported(field, comparator, value)
     end
   end
 
@@ -57,7 +57,7 @@ defmodule EWallet.Web.MatchAnyQuery do
       "lte" -> dynamic([q], field(q, ^field) <= ^value or ^dynamic)
       "contains" -> dynamic([q], ilike(field(q, ^field), ^"%#{value}%") or ^dynamic)
       "starts_with" -> dynamic([q], ilike(field(q, ^field), ^"#{value}%") or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+      _ -> not_supported(field, comparator, value)
     end
   end
 
@@ -88,7 +88,7 @@ defmodule EWallet.Web.MatchAnyQuery do
     case comparator do
       "eq" -> dynamic([{a, position}], is_nil(field(a, ^field)) or ^dynamic)
       "neq" -> dynamic([{a, position}], not is_nil(field(a, ^field)) or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+      _ -> not_supported(field, comparator, value)
     end
   end
 
@@ -102,7 +102,12 @@ defmodule EWallet.Web.MatchAnyQuery do
       "lte" -> dynamic([{a, position}], field(a, ^field) <= ^value or ^dynamic)
       "contains" -> dynamic([{a, position}], ilike(field(a, ^field), ^"%#{value}%") or ^dynamic)
       "starts_with" -> dynamic([{a, position}], ilike(field(a, ^field), ^"#{value}%") or ^dynamic)
-      _ -> {:error, :comparator_not_supported, field: field, comparator: comparator, value: value}
+      _ -> not_supported(field, comparator, value)
     end
+  end
+
+  defp not_supported(field, comparator, value) do
+    {:error, :comparator_not_supported,
+     field: Atom.to_string(field), comparator: comparator, value: value}
   end
 end

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -48,6 +48,9 @@ defmodule EWallet.Web.Orchestrator do
       {:error, :not_allowed, field} ->
         {:error, :query_field_not_allowed, field_name: field}
 
+      {:error, :missing_filter_param, params} ->
+        {:error, :missing_filter_param, filter_params: params}
+
       {:error, _, _} = error ->
         error
     end

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -48,8 +48,8 @@ defmodule EWallet.Web.Orchestrator do
       {:error, :not_allowed, field} ->
         {:error, :query_field_not_allowed, field_name: field}
 
-      {:error, :missing_filter_param, params} ->
-        {:error, :missing_filter_param, filter_params: params}
+      # {:error, :missing_filter_param, params} ->
+      #   {:error, :missing_filter_param, filter_params: params}
 
       {:error, _, _} = error ->
         error

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -48,9 +48,6 @@ defmodule EWallet.Web.Orchestrator do
       {:error, :not_allowed, field} ->
         {:error, :query_field_not_allowed, field_name: field}
 
-      # {:error, :missing_filter_param, params} ->
-      #   {:error, :missing_filter_param, filter_params: params}
-
       {:error, _, _} = error ->
         error
     end

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -33,10 +33,6 @@ defmodule EWallet.Web.V1.ErrorHandler do
       template:
         "Invalid parameter provided. The queried field is not allowed. Given: '%{field_name}'."
     },
-    missing_filter_param: %{
-      code: "client:invalid_parameter",
-      template: "Invalid parameter provided. Missing a filter parameter. Got: %{filter_params}."
-    },
     missing_id: %{
       code: "client:invalid_parameter",
       description: "Invalid parameter provided. `id` is required."
@@ -400,6 +396,10 @@ defmodule EWallet.Web.V1.ErrorHandler do
       code: "setting:not_found",
       description: "There is no setting corresponding to the provided key."
     },
+    missing_filter_param: %{
+      code: "client:invalid_parameter",
+      template: "Invalid parameter provided. Missing a filter parameter. Got: %{filter_params}."
+    },
     comparator_not_supported: %{
       code: "client:invalid_parameter",
       template:
@@ -583,7 +583,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
   end
 
   defp template_replace(template, pattern, nil) do
-    template_replace(template, "%{#{pattern}}", "nil")
+    template_replace(template, pattern, "nil")
   end
 
   defp template_replace(template, pattern, replacement) when not is_binary(replacement) do

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -33,6 +33,10 @@ defmodule EWallet.Web.V1.ErrorHandler do
       template:
         "Invalid parameter provided. The queried field is not allowed. Given: '%{field_name}'."
     },
+    missing_filter_param: %{
+      code: "client:invalid_parameter",
+      template: "Invalid parameter provided. Missing a filter parameter. Got: %{filter_params}."
+    },
     missing_id: %{
       code: "client:invalid_parameter",
       description: "Invalid parameter provided. `id` is required."
@@ -579,7 +583,11 @@ defmodule EWallet.Web.V1.ErrorHandler do
   end
 
   defp template_replace(template, pattern, nil) do
-    String.replace(template, "%{#{pattern}}", "nil")
+    template_replace(template, "%{#{pattern}}", "nil")
+  end
+
+  defp template_replace(template, pattern, replacement) when not is_binary(replacement) do
+    template_replace(template, pattern, inspect(replacement))
   end
 
   defp template_replace(template, pattern, replacement) do

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -398,7 +398,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     missing_filter_param: %{
       code: "client:invalid_parameter",
-      template: "Invalid parameter provided. Missing a filter parameter. Got: %{filter_params}."
+      description: "Invalid parameter provided. Missing one or more filter parameters."
     },
     comparator_not_supported: %{
       code: "client:invalid_parameter",
@@ -495,9 +495,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
   """
   def build_error(:missing_filter_param = code, params, supported_errors) do
     run_if_valid_error(code, supported_errors, fn error ->
-      # Convert the filter params to JSON for readability.
-      data = Map.update(params, :filter_params, %{}, &Jason.encode!/1)
-      build(code: error.code, desc: build_template(data, error.template))
+      build(code: error.code, desc: error.description, msgs: params)
     end)
   end
 

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -491,6 +491,17 @@ defmodule EWallet.Web.V1.ErrorHandler do
   end
 
   @doc """
+  Handles response of missing_filter_param.
+  """
+  def build_error(:missing_filter_param = code, params, supported_errors) do
+    run_if_valid_error(code, supported_errors, fn error ->
+      # Convert the filter params to JSON for readability.
+      data = Map.update(params, :filter_params, %{}, &Jason.encode!/1)
+      build(code: error.code, desc: build_template(data, error.template))
+    end)
+  end
+
+  @doc """
   Handles response with template description to build.
   """
   def build_error(code, data, supported_errors) when is_map(data) or is_list(data) do

--- a/apps/ewallet/test/ewallet/web/filters/match_all_query_test.exs
+++ b/apps/ewallet/test/ewallet/web/filters/match_all_query_test.exs
@@ -272,7 +272,7 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "gt", value: nil]
+      assert meta == [field: "username", comparator: "gt", value: nil]
     end
   end
 
@@ -321,7 +321,7 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "gte", value: nil]
+      assert meta == [field: "username", comparator: "gte", value: nil]
     end
   end
 
@@ -370,7 +370,7 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "lt", value: nil]
+      assert meta == [field: "username", comparator: "lt", value: nil]
     end
   end
 
@@ -419,7 +419,7 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "lte", value: nil]
+      assert meta == [field: "username", comparator: "lte", value: nil]
     end
   end
 
@@ -442,7 +442,7 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "contains", value: nil]
+      assert meta == [field: "username", comparator: "contains", value: nil]
     end
   end
 
@@ -465,7 +465,7 @@ defmodule EWallet.Web.MatchAllQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "starts_with", value: nil]
+      assert meta == [field: "username", comparator: "starts_with", value: nil]
     end
   end
 end

--- a/apps/ewallet/test/ewallet/web/filters/match_any_query_test.exs
+++ b/apps/ewallet/test/ewallet/web/filters/match_any_query_test.exs
@@ -291,7 +291,7 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "gt", value: nil]
+      assert meta == [field: "username", comparator: "gt", value: nil]
     end
   end
 
@@ -340,7 +340,7 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "gte", value: nil]
+      assert meta == [field: "username", comparator: "gte", value: nil]
     end
   end
 
@@ -389,7 +389,7 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "lt", value: nil]
+      assert meta == [field: "username", comparator: "lt", value: nil]
     end
   end
 
@@ -438,7 +438,7 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "lte", value: nil]
+      assert meta == [field: "username", comparator: "lte", value: nil]
     end
   end
 
@@ -461,7 +461,7 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "contains", value: nil]
+      assert meta == [field: "username", comparator: "contains", value: nil]
     end
   end
 
@@ -484,7 +484,7 @@ defmodule EWallet.Web.MatchAnyQueryTest do
 
       assert res == :error
       assert code == :comparator_not_supported
-      assert meta == [field: :username, comparator: "starts_with", value: nil]
+      assert meta == [field: "username", comparator: "starts_with", value: nil]
     end
   end
 end

--- a/apps/ewallet/test/ewallet/web/v1/error_handler_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/error_handler_test.exs
@@ -116,6 +116,26 @@ defmodule EWallet.Web.V1.ErrorHandlerTest do
 
       assert ErrorHandler.build_error(:error_code, %{"value" => "ABCD"}, errors) == expected
     end
+
+    test "stringifies the templating data before rendering the error" do
+      errors = %{
+        error_code: %{
+          code: "error:error_code",
+          template: "Error template. Stringified data is: '%{map_data}'."
+        }
+      }
+
+      expected = %{
+        object: "error",
+        code: errors[:error_code].code,
+        description: ~s/Error template. Stringified data is: '%{"foo" => "bar"}'./,
+        messages: nil
+      }
+
+      template_data = %{"map_data" => %{"foo" => "bar"}}
+
+      assert ErrorHandler.build_error(:error_code, template_data, errors) == expected
+    end
   end
 
   describe "build_error/2" do

--- a/apps/ewallet/test/ewallet/web/v1/error_handler_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/error_handler_test.exs
@@ -100,23 +100,20 @@ defmodule EWallet.Web.V1.ErrorHandlerTest do
     end
 
     test "handles :missing_filter_param error" do
-      data = %{
-        filter_params: %{
-          "field" => "field_name",
-          "comparator" => "eq"
-          # "value" => "the_value"
-        }
+      filter_params = %{
+        "field" => "field_name",
+        "comparator" => "eq"
+        # "value" => "the_value"
       }
 
       expected = %{
         object: "error",
         code: "client:invalid_parameter",
-        description:
-          ~s'Invalid parameter provided. Missing a filter parameter. Got: {"comparator":"eq","field":"field_name"}.',
-        messages: nil
+        description: "Invalid parameter provided. Missing one or more filter parameters.",
+        messages: filter_params
       }
 
-      assert ErrorHandler.build_error(:missing_filter_param, data, ErrorHandler.errors()) ==
+      assert ErrorHandler.build_error(:missing_filter_param, filter_params, ErrorHandler.errors()) ==
                expected
     end
 

--- a/apps/ewallet/test/ewallet/web/v1/error_handler_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/error_handler_test.exs
@@ -99,6 +99,27 @@ defmodule EWallet.Web.V1.ErrorHandlerTest do
       assert ErrorHandler.build_error(:error_code, data, errors) == expected
     end
 
+    test "handles :missing_filter_param error" do
+      data = %{
+        filter_params: %{
+          "field" => "field_name",
+          "comparator" => "eq"
+          # "value" => "the_value"
+        }
+      }
+
+      expected = %{
+        object: "error",
+        code: "client:invalid_parameter",
+        description:
+          ~s'Invalid parameter provided. Missing a filter parameter. Got: {"comparator":"eq","field":"field_name"}.',
+        messages: nil
+      }
+
+      assert ErrorHandler.build_error(:missing_filter_param, data, ErrorHandler.errors()) ==
+               expected
+    end
+
     test "returns an error object when given a valid code and templating data" do
       errors = %{
         error_code: %{


### PR DESCRIPTION
Issue/Task Number: #814
Closes #814

# Overview

This PR fixes the internal server error returned when providing a filter with a missing parameter.

# Changes

- Updated `EWallet.Web.V1.ErrorHandler.template_replace/3` to stringify non-strings before attempting to build the error response.

# Implementation Details

Changing `EWallet.Web.V1.ErrorHandler.template_replace/3` to support non-string template data should be generic enough that passing other kinds of non-string data to the template in the future should work (as long as [Kernel.inspect/2](https://hexdocs.pm/elixir/Kernel.html#inspect/2) can handle it).

# Usage

### Request

```shell
curl 'http://localhost:4000/api/admin/activity_log.all' \
  -H 'Accept: application/vnd.omisego.v1+json' \
  -H 'Authorization: OMGAdmin <redacted>' \
  -H 'Content-Type: application/json;charset=UTF-8' \
  --data-binary '
    {
      "page":1,
      "per_page":10,
      "sort_by":"created_at",
      "sort_dir":"desc",
      "match_any":[
        {
           "field":"action",
           "comparator":"contains"
        }
       ]
     }' | jq
```

Notice that the filter params do not have `"value"`.

### Response

```js
{
  "version": "1",
  "success": false,
  "data": {
    "object": "error",
    "messages": {
      "field": "action",
      "comparator": "contains"
    },
    "description": "Invalid parameter provided. Missing one or more filter parameters.",
    "code": "client:invalid_parameter"
  }
}
```

# Impact

No changes to API specs nor DB schemas.
