### PR TITLE
Skip settings migration if the settings value has not been changed

### DIFF
--- a/apps/ewallet_config/lib/ewallet_config/setting.ex
+++ b/apps/ewallet_config/lib/ewallet_config/setting.ex
@@ -185,8 +185,8 @@ defmodule EWalletConfig.Setting do
     |> update(attrs)
   end
 
-  def update(key, attrs) when is_binary(key) do
-    case Repo.get_by(StoredSetting, %{key: key}) do
+  def update(key, attrs) do
+    case Repo.get_by(StoredSetting, key: key) do
       nil ->
         {:error, :setting_not_found}
 


### PR DESCRIPTION
Issue/Task Number: #798
Closes #798 

# Overview

This PR skips migration of a specific settings if the settings value has not been changed.
This helps remove unnecessary database writes and activity logs caused by unchanged settings updates.

# Changes

- Updated `EWallet.ReleaseTasks.ConfigMigration` to skip updating if a settings value is unchanged.

# Implementation Details

The `Settings` and `StoredSettings` is pretty complicated and adds a lot of changes to the changeset. Since this settings migration command mainly takes ENV values and saves to database, this PR skips unnecessary DB updates by checking whether the settings value changed. Only if it changed then it proceeds with the update.

# Usage

Running this command the first time:

```shell
BASE_URL=http://localhost mix omg.config -m -y
```

Would result in:

```shell
Migrating the settings to the database...
  - Setting `base_url` to "http://localhost"... Done.
```

However, running it with the same value again would result in:

```shell
Migrating the settings to the database...
  - Setting `base_url` is already "http://localhost"... Skipping.
```

# Impact

No changes to API specs or DB schemas.