### PR TITLE
Normalize ENV values before saving to settings

### DIFF
--- a/apps/ewallet/lib/ewallet/release_tasks/config.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config.ex
@@ -99,16 +99,17 @@ defmodule EWallet.ReleaseTasks.Config do
 
       %{value: existing, type: type} ->
         case cast_env(value, type) do
-          ^existing ->
-            {:unchanged, existing}
-
-          casted_value ->
-            # The GenServer will return {:ok, result}, where the result is the actual
-            # {:ok, _} | {:error, _} of the operation, so we need to return only the result.
-            {:ok, result} = Config.update(%{key => casted_value, :originator => %CLIUser{}})
-            Enum.find_value(result, fn {^key, v} -> v end)
+          ^existing -> {:unchanged, existing}
+          casted_value -> do_update(key, value)
         end
     end
+  end
+
+  defp do_update(key, value) do
+    # The GenServer will return {:ok, result}, where the result is the actual
+    # {:ok, _} | {:error, _} of the operation, so we need to return only the result.
+    {:ok, result} = Config.update(%{key => value, :originator => %CLIUser{}})
+    Enum.find_value(result, fn {^key, v} -> v end)
   end
 
   # These cast_env/2 are private to this module because the only other place that

--- a/apps/ewallet/lib/ewallet/release_tasks/config.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config.ex
@@ -100,7 +100,7 @@ defmodule EWallet.ReleaseTasks.Config do
       %{value: existing, type: type} ->
         case cast_env(value, type) do
           ^existing -> {:unchanged, existing}
-          casted_value -> do_update(key, value)
+          casted_value -> do_update(key, casted_value)
         end
     end
   end

--- a/apps/ewallet/lib/ewallet/release_tasks/config.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config.ex
@@ -71,8 +71,11 @@ defmodule EWallet.ReleaseTasks.Config do
         :init.stop()
 
       {:error, :setting_not_found} ->
-        CLI.error("Error: `#{key}` is not a valid settings." <>
-          " Please check that the given settings name is correct and settings have been seeded.")
+        CLI.error(
+          "Error: `#{key}` is not a valid settings." <>
+            " Please check that the given settings name is correct and settings have been seeded."
+        )
+
         :init.stop(1)
 
       {:error, changeset} ->

--- a/apps/ewallet/lib/ewallet/release_tasks/config.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config.ex
@@ -17,9 +17,10 @@ defmodule EWallet.ReleaseTasks.Config do
   A release task that manages application configurations.
   """
   use EWallet.ReleaseTasks
-  alias ActivityLogger.System
   alias EWallet.CLI
+  alias EWallet.ReleaseTasks.CLIUser
   alias EWalletConfig.Config
+  alias Utils.Helpers.Normalize
 
   @start_apps [:crypto, :ssl, :postgrex, :ecto_sql, :telemetry, :cloak, :ewallet]
   @apps [:activity_logger, :ewallet_config]
@@ -60,17 +61,48 @@ defmodule EWallet.ReleaseTasks.Config do
     Enum.each(@start_apps, &Application.ensure_all_started/1)
     Enum.each(@apps, &ensure_app_started/1)
 
-    case Config.update(%{key => value, originator: %System{}}) do
-      {:ok, [{key, {:ok, _}}]} ->
-        CLI.success("Successfully updated \"#{key}\" to \"#{value}\"")
+    case do_set_config(key, value) do
+      {:ok, setting} ->
+        CLI.success("Updated: `#{key}` is now #{inspect(setting.value)}.")
         :init.stop()
 
-      {:ok, [{key, {:error, :setting_not_found}}]} ->
-        CLI.error("Error: \"#{key}\" is not a valid settings")
+      {:unchanged, value} ->
+        CLI.warn("Skipped: `#{key}` is already set to #{inspect(value)}.")
+        :init.stop()
+
+      {:error, :setting_not_found} ->
+        CLI.error("Error: `#{key}` is not a valid settings.")
+        :init.stop(1)
+
+      {:error, changeset} ->
+        error_message =
+          Enum.reduce(changeset.errors, "", fn {field, {message, _}}, acc ->
+            acc <> "`#{field}` #{message}. "
+          end)
+
+        CLI.error("Error: setting `#{key}` to #{inspect(value)} returned #{error_message}")
         :init.stop(1)
 
       _ ->
         give_up()
     end
   end
+
+  defp do_set_config(key, value) do
+    setting = Config.get_setting(key)
+    existing = setting.value
+
+    case cast_env(value, setting.type) do
+      ^existing -> {:unchanged, existing}
+      casted -> Config.update_one(key, %{value: casted, originator: %CLIUser{}})
+    end
+  end
+
+  # These cast_env/2 are private to this module because the only other place that
+  # needs to convert ENV strings by config type is its sibling `ConfigMigration` release task.
+  defp cast_env(value, "string"), do: value
+  defp cast_env(value, "integer"), do: Normalize.to_integer(value)
+  defp cast_env(value, "unsigned_integer"), do: Normalize.to_integer(value)
+  defp cast_env(value, "boolean"), do: Normalize.to_boolean(value)
+  defp cast_env(value, "array"), do: Normalize.to_strings(value)
 end

--- a/apps/ewallet/lib/ewallet/release_tasks/config.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config.ex
@@ -94,7 +94,7 @@ defmodule EWallet.ReleaseTasks.Config do
 
     case cast_env(value, setting.type) do
       ^existing -> {:unchanged, existing}
-      casted -> Config.update_one(key, %{value: casted, originator: %CLIUser{}})
+      casted_value -> Config.update(%{key: casted_value, originator: %CLIUser{}})
     end
   end
 

--- a/apps/ewallet/lib/ewallet/release_tasks/config.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config.ex
@@ -93,8 +93,14 @@ defmodule EWallet.ReleaseTasks.Config do
     existing = setting.value
 
     case cast_env(value, setting.type) do
-      ^existing -> {:unchanged, existing}
-      casted_value -> Config.update(%{key: casted_value, originator: %CLIUser{}})
+      ^existing ->
+        {:unchanged, existing}
+
+      casted_value ->
+        # The GenServer will return {:ok, result}, where the result is the actual
+        # {:ok, _} | {:error, _} of the operation, so we need to return only the result.
+        {:ok, result} = Config.update(%{key => casted_value, :originator => %CLIUser{}})
+        Enum.find_value(result, fn {^key, v} -> v end)
     end
   end
 

--- a/apps/ewallet/lib/ewallet/release_tasks/config_migration.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config_migration.ex
@@ -100,15 +100,17 @@ defmodule EWallet.ReleaseTasks.ConfigMigration do
   defp ask_confirmation({to_migrate, unchanged} = plan, true) do
     _ = CLI.info("The following settings will be populated into the database:\n")
 
-    _ =Enum.each(to_migrate, fn {setting_name, value} ->
-      CLI.info("  - #{setting_name}: \"#{value}\"")
-    end)
+    _ =
+      Enum.each(to_migrate, fn {setting_name, value} ->
+        CLI.info("  - #{setting_name}: \"#{value}\"")
+      end)
 
     _ = CLI.info("The following settings will be skipped:\n")
 
-    _ = Enum.each(unchanged, fn {setting_name, value} ->
-      CLI.info("  - #{setting_name}: \"#{value}\"")
-    end)
+    _ =
+      Enum.each(unchanged, fn {setting_name, value} ->
+        CLI.info("  - #{setting_name}: \"#{value}\"")
+      end)
 
     confirmed? = CLI.confirm?("\nAre you sure to migrate these settings to the database?")
 
@@ -127,38 +129,44 @@ defmodule EWallet.ReleaseTasks.ConfigMigration do
   defp migrate({to_migrate, unchanged}) do
     _ = CLI.info("\nMigrating the settings to the database...\n")
 
-    _ = Enum.each(unchanged, fn {setting_name, value} ->
-      CLI.warn("  - Skipped: `#{setting_name}` is already #{inspect(value)}.")
-    end)
+    _ =
+      Enum.each(unchanged, fn {setting_name, value} ->
+        CLI.warn("  - Skipped: `#{setting_name}` is already #{inspect(value)}.")
+      end)
 
     {:ok, results} =
       to_migrate
       |> build_update_attrs()
       |> Config.update()
 
-    _ = Enum.each(results, fn
-      {setting_name, {:ok, setting}} ->
-        _ = CLI.success("  - Migrated: `#{setting_name}` is now #{inspect(setting.value)}.")
+    _ =
+      Enum.each(results, fn
+        {setting_name, {:ok, setting}} ->
+          _ = CLI.success("  - Migrated: `#{setting_name}` is now #{inspect(setting.value)}.")
 
-      {setting_name, {:error, changeset}} ->
-        error_message =
-          Enum.reduce(changeset.errors, "", fn {field, {message, _}}, acc ->
-            acc <> "`#{field}` #{message}. "
-          end)
+        {setting_name, {:error, changeset}} ->
+          error_message =
+            Enum.reduce(changeset.errors, "", fn {field, {message, _}}, acc ->
+              acc <> "`#{field}` #{message}. "
+            end)
 
-        _ = CLI.error(
-          "  - Error: setting `#{setting_name}` to #{inspect(Changeset.get_field(changeset, :value))}"
-          <> " returned #{error_message}"
-        )
-    end)
+          _ =
+            CLI.error(
+              "  - Error: setting `#{setting_name}` to #{
+                inspect(Changeset.get_field(changeset, :value))
+              }" <>
+                " returned #{error_message}"
+            )
+      end)
 
     _ = CLI.info("\nSettings migration completed. Please remove the environment variables.")
   end
 
   defp build_update_attrs(to_migrate) do
-    _ = Enum.reduce(to_migrate, [{:originator, %CLIUser{}}], fn {setting_name, value}, attrs ->
-      [{String.to_existing_atom(setting_name), value} | attrs]
-    end)
+    _ =
+      Enum.reduce(to_migrate, [{:originator, %CLIUser{}}], fn {setting_name, value}, attrs ->
+        [{String.to_existing_atom(setting_name), value} | attrs]
+      end)
   end
 
   # These cast_env/2 are private to this module because the only other place that

--- a/apps/ewallet/lib/ewallet/release_tasks/config_migration.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config_migration.ex
@@ -125,7 +125,7 @@ defmodule EWallet.ReleaseTasks.ConfigMigration do
 
     case cast_env(value, setting.type) do
       ^existing -> {:unchanged, existing}
-      casted -> Config.update_one(setting_name, %{value: casted, originator: %CLIUser{}})
+      casted_value -> Config.update(%{setting_name: casted_value, originator: %CLIUser{}})
     end
   end
 

--- a/apps/ewallet_config/lib/ewallet_config/config.ex
+++ b/apps/ewallet_config/lib/ewallet_config/config.ex
@@ -124,7 +124,7 @@ defmodule EWalletConfig.Config do
           {:ok, %Setting{}} | {:error, Ecto.Changeset.t()} | {:error, atom()}
         ]
   def update(attrs, pid \\ __MODULE__) do
-    {config_pid, attrs} = get_config_pid(attrs)
+    {config_pid, attrs} = extract_config_pid(attrs)
 
     case Application.get_env(:ewallet, :env) == :test do
       true ->
@@ -135,13 +135,13 @@ defmodule EWalletConfig.Config do
     end
   end
 
-  defp get_config_pid(%{config_pid: config_pid} = attrs),
+  defp extract_config_pid(%{config_pid: config_pid} = attrs),
     do: {config_pid, Map.delete(attrs, :config_pid)}
 
-  defp get_config_pid(%{"config_pid" => config_pid} = attrs),
+  defp extract_config_pid(%{"config_pid" => config_pid} = attrs),
     do: {config_pid, Map.delete(attrs, "config_pid")}
 
-  defp get_config_pid(attrs) when is_list(attrs) do
+  defp extract_config_pid(attrs) when is_list(attrs) do
     case Keyword.fetch(attrs, :config_pid) do
       :error ->
         {nil, attrs}
@@ -151,7 +151,7 @@ defmodule EWalletConfig.Config do
     end
   end
 
-  defp get_config_pid(attrs), do: {nil, attrs}
+  defp extract_config_pid(attrs), do: {nil, attrs}
 
   @spec insert_all_defaults(map(), map(), atom()) :: :ok
   def insert_all_defaults(originator, opts \\ %{}, pid \\ __MODULE__) do

--- a/apps/utils/lib/helpers/normalize.ex
+++ b/apps/utils/lib/helpers/normalize.ex
@@ -72,4 +72,11 @@ defmodule Utils.Helpers.Normalize do
   def to_integer(s) when is_integer(s), do: s
   def to_integer(s) when is_float(s), do: :erlang.round(s)
   def to_integer(value), do: raise(ToIntegerError, message: ToIntegerError.error_message(value))
+
+  # Converts a comma-separated string to a list of strings
+  def to_strings(s) do
+    s
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+  end
 end

--- a/apps/utils/test/utils/helpers/normalize_test.exs
+++ b/apps/utils/test/utils/helpers/normalize_test.exs
@@ -119,4 +119,16 @@ defmodule Utils.Helpers.NormalizeTest do
       assert -2 == Normalize.to_integer(-1.5)
     end
   end
+
+  describe "to_strings/1" do
+    test "converts a comma-separated string to a list of strings" do
+      assert ["a", "b", "c"] == Normalize.to_strings("a,b,c")
+      assert ["1", "2", "3"] == Normalize.to_strings("1,2,3")
+      assert ["aaaaa"] == Normalize.to_strings("aaaaa")
+    end
+
+    test "trims whitespaces for each list element" do
+      assert ["a", "b", "c"] == Normalize.to_strings("\na,  b,c  \n")
+    end
+  end
 end


### PR DESCRIPTION
Issue/Task Number: #804
Closes #804

# Overview

This PR normalizes an ENV value to its respective settings' type before attempting to update into settings.

# Changes

- Add `Config.update_one/3` for convenience when wanting to update a single settings
- Add `Normalize.to_strings/1` to normalize a comma-separated string (as expected as ENV values) into a list of strings.
- Updated `EWallet.ReleaseTasks.Config` with ENV value normalization according to each setting's type
- Updated `EWallet.ReleaseTasks.ConfigMigration` with ENV value normalization according to each setting's type

# Implementation Details

Notice that there's duplicate normalization code in `ReleaseTasks.Config` and `ReleaseTasks.ConfigMigration`. I think this is very specific to normalizing ENV values, which is unlikely to be used anywhere else, so it's simpler to duplicate code here than having another shared module for this.

# Usage

```shell
$ REDIRECT_URL_PREFIXES=a,b,c ENABLE_STANDALONE=1 mix omg.config -m -y
...
  - Skipped: `redirect_url_prefixes` is already ["a", "b", "c", "d"].
  - Migrated: `enable_standalone` is now true.
...
```

```shell
$ mix omg.config redirect_url_prefixes a,b,c,d
...
Updated: `redirect_url_prefixes` is now ["a", "b", "c", "d"].
```

```shell
$ mix omg.config enable_standalone true
...
Updated: `enable_standalone` is now false.
```

```shell
$ mix omg.config enable_standalone true
...
Skipped: `enable_standalone` is already set to true.
```

# Impact

Some setups may not have all ENV values migrated to Settings yet due to this issue. We recommend running `bin/ewallet config --migrate` once more.

No changes to API specs nor DB schemas.
