### PR TITLE
Admin users wallets wrongly generated

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/account_membership_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/account_membership_controller_test.exs
@@ -878,11 +878,11 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
 
   describe "/account.assign_user" do
     test_with_auths "returns empty success if assigned with user_id successfully" do
-      {:ok, user} = :user |> params_for() |> User.insert()
+      {:ok, admin} = :admin |> params_for() |> User.insert()
 
       response =
         request("/account.assign_user", %{
-          user_id: user.id,
+          user_id: admin.id,
           account_id: insert(:account).id,
           role_name: Role.get_by(name: "admin").name,
           redirect_url: @redirect_url
@@ -890,12 +890,15 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
 
       assert response["success"] == true
       assert response["data"] == %{}
+      assert User.get_primary_wallet(admin) == nil
     end
 
     test_with_auths "returns empty success if assigned with email successfully" do
+      admin = insert(:admin)
+
       response =
         request("/account.assign_user", %{
-          email: insert(:admin).email,
+          email: admin.email,
           account_id: insert(:account).id,
           role_name: Role.get_by(name: "admin").name,
           redirect_url: @redirect_url
@@ -903,6 +906,7 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
 
       assert response["success"] == true
       assert response["data"] == %{}
+      assert User.get_primary_wallet(admin) == nil
     end
 
     test_with_auths "returns empty success if the user has a pending confirmation" do
@@ -922,8 +926,9 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
 
       # Make sure that the first attemps created the user with pending_confirmation status
       assert response["success"] == true
-      user = User.get_by(email: email)
-      assert User.get_status(user) == :pending_confirmation
+      admin = User.get_by(email: email)
+      assert User.get_status(admin) == :pending_confirmation
+      assert User.get_primary_wallet(admin) == nil
 
       response =
         request("/account.assign_user", %{
@@ -936,6 +941,7 @@ defmodule AdminAPI.V1.AccountMembershipControllerTest do
       # The second attempt should also be successful
       assert response["success"] == true
       assert response["data"] == %{}
+      assert User.get_primary_wallet(admin) == nil
     end
 
     test_with_auths "returns an error if the email format is invalid" do

--- a/apps/ewallet/lib/ewallet/web/inviter.ex
+++ b/apps/ewallet/lib/ewallet/web/inviter.ex
@@ -47,7 +47,8 @@ defmodule EWallet.Web.Inviter do
   @spec invite_admin(map(), String.t(), fun()) ::
           {:ok, %Invite{}} | {:error, atom()}
   def invite_admin(%{"originator" => originator} = attrs, redirect_url, create_email_func) do
-    with {:ok, user} <- insert_user(attrs),
+    with attrs <- Map.put(attrs, "is_admin", true),
+         {:ok, user} <- insert_user(attrs),
          {:ok, invite} <- Invite.generate(user, originator, preload: :user) do
       send_email(invite, redirect_url, create_email_func)
     else
@@ -59,7 +60,7 @@ defmodule EWallet.Web.Inviter do
   @spec invite_admin(String.t(), %Account{}, %Role{}, String.t(), map() | atom(), fun()) ::
           {:ok, %Invite{}} | {:error, atom()}
   def invite_admin(email, account, role, redirect_url, originator, create_email_func) do
-    with {:ok, user} <- get_or_insert_user(email, nil, originator),
+    with {:ok, user} <- get_or_insert_user(email, nil, originator, true),
          {:ok, invite} <- Invite.generate(user, originator, preload: :user),
          {:ok, _membership} <- Membership.assign(invite.user, account, role, originator) do
       send_email(invite, redirect_url, create_email_func)
@@ -69,7 +70,7 @@ defmodule EWallet.Web.Inviter do
     end
   end
 
-  defp get_or_insert_user(email, password, originator) do
+  defp get_or_insert_user(email, password, originator, is_admin \\ false) do
     case User.get_by_email(email) do
       %User{} = user ->
         case User.get_status(user) do
@@ -82,6 +83,7 @@ defmodule EWallet.Web.Inviter do
 
       nil ->
         User.insert(%{
+          is_admin: is_admin,
           email: email,
           password: password || Crypto.generate_base64_key(32),
           originator: originator


### PR DESCRIPTION
Issue/Task Number: #925
#925

# Overview

This PR fixes a bug where wallets were generated when inviting admin users to the system.

# Changes

- Add tests showing the bug
- Ensure `is_admin` is properly set when inserted admin users
