### PR TITLE
Handle client reset password

### DIFF
--- a/apps/admin_panel/assets/package-lock.json
+++ b/apps/admin_panel/assets/package-lock.json
@@ -11705,6 +11705,11 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
+    "password-validator": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/password-validator/-/password-validator-4.1.1.tgz",
+      "integrity": "sha1-gPNDV5g0tXSRMJeXP2ayNH7Yqvk="
+    },
     "path-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",

--- a/apps/admin_panel/assets/package.json
+++ b/apps/admin_panel/assets/package.json
@@ -64,6 +64,7 @@
     "mock-socket": "^7.1.0",
     "moment": "^2.22.1",
     "numeral": "^2.0.6",
+    "password-validator": "^4.1.1",
     "postcss-loader": "^1.2.2",
     "prop-types": "^15.6.1",
     "qrcode": "^1.3.3",

--- a/apps/admin_panel/assets/src/clientApp/index.js
+++ b/apps/admin_panel/assets/src/clientApp/index.js
@@ -1,13 +1,23 @@
 import React, { Component } from 'react'
 import { hot } from 'react-hot-loader/root'
 import 'reset-css'
+import { ThemeProvider } from 'styled-components'
+import theme from '../adminPanelApp/theme'
+import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
+import ResetPasswordForm from '../omg-forgetPassword-form'
 class App extends Component {
   componentDidCatch () {
     return 'Something very bad happened, please contact admin.'
   }
   render () {
     return (
-      <div>ClientApp</div>
+      <ThemeProvider theme={theme}>
+        <Router basename='/client'>
+          <Switch>
+            <Route path='/reset-password' exact component={ResetPasswordForm} />
+          </Switch>
+        </Router>
+      </ThemeProvider>
     )
   }
 }

--- a/apps/admin_panel/assets/src/clientApp/index.js
+++ b/apps/admin_panel/assets/src/clientApp/index.js
@@ -15,7 +15,7 @@ class App extends Component {
       <ThemeProvider theme={theme}>
         <Router basename='/client'>
           <Switch>
-            <Route path='/reset-password' exact component={ResetPasswordForm} />
+            <Route path='/reset_password' exact component={ResetPasswordForm} />
           </Switch>
         </Router>
       </ThemeProvider>

--- a/apps/admin_panel/assets/src/clientApp/index.js
+++ b/apps/admin_panel/assets/src/clientApp/index.js
@@ -4,7 +4,8 @@ import 'reset-css'
 import { ThemeProvider } from 'styled-components'
 import theme from '../adminPanelApp/theme'
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
-import ResetPasswordForm from '../omg-forgetPassword-form'
+import ResetPasswordForm from './omg-client-reset-password'
+import '../adminPanelApp/globalStyle.css'
 class App extends Component {
   componentDidCatch () {
     return 'Something very bad happened, please contact admin.'

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types'
 import AuthFormLayout from '../../omg-layout/authFormLayout'
 import { compose } from 'recompose'
 import { updateUserPassword } from '../../services/clientService'
-import { isMobile } from '../../utils/device'
 const Form = styled.form`
   text-align: left;
   input {
@@ -37,17 +36,6 @@ const Error = styled.div`
   opacity: ${props => (props.error ? 1 : 0)};
   transition: 0.5s ease max-height, 0.3s ease opacity;
 `
-const MobileRedirect = styled.div`
-  text-align: center;
-  padding: 20px;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 18px;
-  a {
-    cursor: pointer;
-  }
-`
 const enhance = compose(withRouter)
 class ForgetPasswordForm extends Component {
   static propTypes = {
@@ -63,11 +51,16 @@ class ForgetPasswordForm extends Component {
       reEnteredNewPassword: '',
       reEnteredNewPasswordError: false,
       submitStatus: null,
-      maybeAppExist: isMobile() ? !!forwardUrl : false
+      showForm: false
     }
     if (forwardUrl) {
       window.location = forwardUrl
     }
+  }
+  componentDidMount = () => {
+    setTimeout(() => {
+      this.setState({ showForm: true })
+    }, 1000)
   }
 
   validatePassword = password => {
@@ -120,47 +113,45 @@ class ForgetPasswordForm extends Component {
   }
   render () {
     const { email } = queryString.parse(this.props.location.search)
-    return this.state.maybeAppExist ? (
-      <MobileRedirect>
-        We are trying to open an app for you, if this does not work <a onClick={this.onClickShowForm}>Click here</a>
-      </MobileRedirect>
-    ) : (
-      <AuthFormLayout>
-        <Form onSubmit={this.onSubmit} noValidate>
-          {this.state.submitStatus !== 'SUCCESS' ? (
-            <div>
-              <h4>Create Password ({email})</h4>
-              <p>Create new password with at least 8 characters</p>
-              <Input
-                placeholder='New password'
-                error={this.state.newPasswordError}
-                errorText='Invalid password'
-                onChange={this.onNewPasswordInputChange}
-                value={this.state.newPassword}
-                disabled={this.state.submitStatus === 'SUBMITTED'}
-                type='password'
-              />
-              <Input
-                placeholder='Re-enter new password'
-                type='password'
-                error={this.state.reEnteredNewPasswordError}
-                errorText='Password does not match'
-                onChange={this.onReEnteredNewPasswordInputChange}
-                value={this.state.reEnteredNewPassword}
-                disabled={this.state.submitStatus === 'SUBMITTED'}
-              />
-              <Button size='large' type='submit' fluid loading={this.state.submitStatus === 'SUBMITTED'}>
-                Reset Password
-              </Button>
-            </div>
-          ) : (
-            <UpdateSuccessfulContainer>
-              <h4>Reset password successfully</h4>
-            </UpdateSuccessfulContainer>
-          )}
-          <Error error={this.state.submitStatus === 'FAILED'}>{this.state.submitErrorText}</Error>
-        </Form>
-      </AuthFormLayout>
+    return (
+      this.state.showForm && (
+        <AuthFormLayout>
+          <Form onSubmit={this.onSubmit} noValidate>
+            {this.state.submitStatus !== 'SUCCESS' ? (
+              <div>
+                <h4>Create Password ({email})</h4>
+                <p>Create new password with at least 8 characters</p>
+                <Input
+                  placeholder='New password'
+                  error={this.state.newPasswordError}
+                  errorText='Invalid password'
+                  onChange={this.onNewPasswordInputChange}
+                  value={this.state.newPassword}
+                  disabled={this.state.submitStatus === 'SUBMITTED'}
+                  type='password'
+                />
+                <Input
+                  placeholder='Re-enter new password'
+                  type='password'
+                  error={this.state.reEnteredNewPasswordError}
+                  errorText='Password does not match'
+                  onChange={this.onReEnteredNewPasswordInputChange}
+                  value={this.state.reEnteredNewPassword}
+                  disabled={this.state.submitStatus === 'SUBMITTED'}
+                />
+                <Button size='large' type='submit' fluid loading={this.state.submitStatus === 'SUBMITTED'}>
+                  Reset Password
+                </Button>
+              </div>
+            ) : (
+              <UpdateSuccessfulContainer>
+                <h4>Reset password successfully</h4>
+              </UpdateSuccessfulContainer>
+            )}
+            <Error error={this.state.submitStatus === 'FAILED'}>{this.state.submitErrorText}</Error>
+          </Form>
+        </AuthFormLayout>
+      )
     )
   }
 }

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -41,8 +41,12 @@ const MobileRedirect = styled.div`
   text-align: center;
   padding: 20px;
   position: absolute;
-  top:50%;
+  top: 50%;
   transform: translateY(-50%);
+  font-size: 18px;
+  a {
+    cursor: pointer;
+  }
 `
 const enhance = compose(withRouter)
 class ForgetPasswordForm extends Component {
@@ -110,11 +114,15 @@ class ForgetPasswordForm extends Component {
       reEnteredNewPasswordError: !this.validateReEnteredNewPassword(this.state.newPassword, value)
     })
   }
+  onClickShowForm = e => {
+    e.preventDefault()
+    this.setState({ maybeAppExist: false })
+  }
   render () {
     const { email } = queryString.parse(this.props.location.search)
     return this.state.maybeAppExist ? (
       <MobileRedirect>
-        We are trying to open an app for you, if it does not work, <a>Click here</a>
+        We are trying to open an app for you, if this does not work <a onClick={this.onClickShowForm}>Click here</a>
       </MobileRedirect>
     ) : (
       <AuthFormLayout>

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
 import AuthFormLayout from '../../omg-layout/authFormLayout'
 import { compose } from 'recompose'
 import { updateUserPassword } from '../../services/clientService'
+import { isMobile } from '../../utils/device'
 const Form = styled.form`
   text-align: left;
   input {
@@ -36,18 +37,33 @@ const Error = styled.div`
   opacity: ${props => (props.error ? 1 : 0)};
   transition: 0.5s ease max-height, 0.3s ease opacity;
 `
-
+const MobileRedirect = styled.div`
+  text-align: center;
+  padding: 20px;
+  position: absolute;
+  top:50%;
+  transform: translateY(-50%);
+`
 const enhance = compose(withRouter)
 class ForgetPasswordForm extends Component {
   static propTypes = {
     location: PropTypes.object.isRequired
   }
-  state = {
-    newPassword: '',
-    newPasswordError: false,
-    reEnteredNewPassword: '',
-    reEnteredNewPasswordError: false,
-    submitStatus: null
+
+  constructor (props) {
+    super(props)
+    const { forward_url: forwardUrl } = queryString.parse(this.props.location.search)
+    this.state = {
+      newPassword: '',
+      newPasswordError: false,
+      reEnteredNewPassword: '',
+      reEnteredNewPasswordError: false,
+      submitStatus: null,
+      maybeAppExist: isMobile() ? !!forwardUrl : false
+    }
+    if (forwardUrl) {
+      window.location = forwardUrl
+    }
   }
 
   validatePassword = password => {
@@ -96,7 +112,11 @@ class ForgetPasswordForm extends Component {
   }
   render () {
     const { email } = queryString.parse(this.props.location.search)
-    return (
+    return this.state.maybeAppExist ? (
+      <MobileRedirect>
+        We are trying to open an app for you, if it does not work, <a>Click here</a>
+      </MobileRedirect>
+    ) : (
       <AuthFormLayout>
         <Form onSubmit={this.onSubmit} noValidate>
           {this.state.submitStatus !== 'SUCCESS' ? (

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
 import AuthFormLayout from '../../omg-layout/authFormLayout'
 import { compose } from 'recompose'
 import { updateUserPassword } from '../../services/clientService'
+import { isMobile } from '../../utils/device'
 const Form = styled.form`
   text-align: left;
   input {
@@ -36,6 +37,17 @@ const Error = styled.div`
   opacity: ${props => (props.error ? 1 : 0)};
   transition: 0.5s ease max-height, 0.3s ease opacity;
 `
+const MobileRedirect = styled.div`
+  text-align: center;
+  padding: 20px;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 18px;
+  a {
+    cursor: pointer;
+  }
+`
 const enhance = compose(withRouter)
 class ForgetPasswordForm extends Component {
   static propTypes = {
@@ -45,22 +57,20 @@ class ForgetPasswordForm extends Component {
   constructor (props) {
     super(props)
     const { forward_url: forwardUrl } = queryString.parse(this.props.location.search)
+    const [protocol] = forwardUrl ? String(forwardUrl).split('://') : []
+    const isforwardUrlWebProtocol = ['http', 'https'].includes(protocol)
+    this.isforwardUrlWebProtocol = isforwardUrlWebProtocol
     this.state = {
       newPassword: '',
       newPasswordError: false,
       reEnteredNewPassword: '',
       reEnteredNewPasswordError: false,
       submitStatus: null,
-      showForm: false
+      maybeAppExist: isforwardUrlWebProtocol ? false : isMobile() ? !!forwardUrl : false
     }
     if (forwardUrl) {
       window.location = forwardUrl
     }
-  }
-  componentDidMount = () => {
-    setTimeout(() => {
-      this.setState({ showForm: true })
-    }, 1000)
   }
 
   validatePassword = password => {
@@ -113,45 +123,47 @@ class ForgetPasswordForm extends Component {
   }
   render () {
     const { email } = queryString.parse(this.props.location.search)
-    return (
-      this.state.showForm && (
-        <AuthFormLayout>
-          <Form onSubmit={this.onSubmit} noValidate>
-            {this.state.submitStatus !== 'SUCCESS' ? (
-              <div>
-                <h4>Create Password ({email})</h4>
-                <p>Create new password with at least 8 characters</p>
-                <Input
-                  placeholder='New password'
-                  error={this.state.newPasswordError}
-                  errorText='Invalid password'
-                  onChange={this.onNewPasswordInputChange}
-                  value={this.state.newPassword}
-                  disabled={this.state.submitStatus === 'SUBMITTED'}
-                  type='password'
-                />
-                <Input
-                  placeholder='Re-enter new password'
-                  type='password'
-                  error={this.state.reEnteredNewPasswordError}
-                  errorText='Password does not match'
-                  onChange={this.onReEnteredNewPasswordInputChange}
-                  value={this.state.reEnteredNewPassword}
-                  disabled={this.state.submitStatus === 'SUBMITTED'}
-                />
-                <Button size='large' type='submit' fluid loading={this.state.submitStatus === 'SUBMITTED'}>
-                  Reset Password
-                </Button>
-              </div>
-            ) : (
-              <UpdateSuccessfulContainer>
-                <h4>Reset password successfully</h4>
-              </UpdateSuccessfulContainer>
-            )}
-            <Error error={this.state.submitStatus === 'FAILED'}>{this.state.submitErrorText}</Error>
-          </Form>
-        </AuthFormLayout>
-      )
+    return this.state.maybeAppExist || this.isforwardUrlWebProtocol ? (
+      <MobileRedirect>
+        We are trying to open an app for forward url for you, if this does not work <a onClick={this.onClickShowForm}>Click here</a> to reset password
+      </MobileRedirect>
+    ) : (
+      <AuthFormLayout>
+        <Form onSubmit={this.onSubmit} noValidate>
+          {this.state.submitStatus !== 'SUCCESS' ? (
+            <div>
+              <h4>Create Password ({email})</h4>
+              <p>Create new password with at least 8 characters</p>
+              <Input
+                placeholder='New password'
+                error={this.state.newPasswordError}
+                errorText='Invalid password'
+                onChange={this.onNewPasswordInputChange}
+                value={this.state.newPassword}
+                disabled={this.state.submitStatus === 'SUBMITTED'}
+                type='password'
+              />
+              <Input
+                placeholder='Re-enter new password'
+                type='password'
+                error={this.state.reEnteredNewPasswordError}
+                errorText='Password does not match'
+                onChange={this.onReEnteredNewPasswordInputChange}
+                value={this.state.reEnteredNewPassword}
+                disabled={this.state.submitStatus === 'SUBMITTED'}
+              />
+              <Button size='large' type='submit' fluid loading={this.state.submitStatus === 'SUBMITTED'}>
+                Reset Password
+              </Button>
+            </div>
+          ) : (
+            <UpdateSuccessfulContainer>
+              <h4>Reset password successfully</h4>
+            </UpdateSuccessfulContainer>
+          )}
+          <Error error={this.state.submitStatus === 'FAILED'}>{this.state.submitErrorText}</Error>
+        </Form>
+      </AuthFormLayout>
     )
   }
 }

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -8,6 +8,11 @@ import AuthFormLayout from '../../omg-layout/authFormLayout'
 import { compose } from 'recompose'
 import { updateUserPassword } from '../../services/clientService'
 import { isMobile } from '../../utils/device'
+import PasswordValidator from 'password-validator'
+
+const schema = new PasswordValidator()
+schema.is().min(8).has().uppercase().has().lowercase().has().digits().has().symbols()
+
 const Form = styled.form`
   text-align: left;
   input {
@@ -74,7 +79,7 @@ class ForgetPasswordForm extends Component {
   }
 
   validatePassword = password => {
-    return password.length >= 8
+    return schema.validate(password)
   }
   validateReEnteredNewPassword = (newPassword, reEnteredNewPassword) => {
     return newPassword === reEnteredNewPassword && newPassword !== '' && reEnteredNewPassword !== ''
@@ -133,7 +138,7 @@ class ForgetPasswordForm extends Component {
           {this.state.submitStatus !== 'SUCCESS' ? (
             <div>
               <h4>Create Password ({email})</h4>
-              <p>Create new password with at least 8 characters</p>
+              <p>Create new password with at least 8 characters, symbol, number, uppercase and lowercase</p>
               <Input
                 placeholder='New password'
                 error={this.state.newPasswordError}

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -1,0 +1,122 @@
+import React, { Component } from 'react'
+import { Input, Button } from '../omg-uikit'
+import styled from 'styled-components'
+import { Link, withRouter } from 'react-router-dom'
+import { sendResetPasswordEmail } from '../omg-session/action'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import { compose } from 'recompose'
+const Form = styled.form`
+  text-align: left;
+  input {
+    margin-top: 35px;
+  }
+  h4 {
+    margin-top: 30px;
+  }
+  p {
+    margin-top: 10px;
+  }
+  .back-link {
+    margin-top: 20px;
+    display: block;
+    text-align: center;
+  }
+`
+const SendEmailSuccessfulContainer = styled.div`
+  text-align: center;
+`
+const Error = styled.div`
+  color: ${props => props.theme.colors.R400};
+  text-align: center;
+  padding: 10px 0;
+  overflow: hidden;
+  max-height: ${props => (props.error ? '100px' : 0)};
+  opacity: ${props => (props.error ? 1 : 0)};
+  transition: 0.5s ease max-height, 0.3s ease opacity;
+`
+class ForgetPasswordForm extends Component {
+  static propTypes = {
+    sendResetPasswordEmail: PropTypes.func,
+    location: PropTypes.func
+  }
+  state = {
+    email: '',
+    emailError: false,
+    submitStatus: null
+  }
+
+  validateEmail = email => {
+    return !/@/.test(email) || email.length === 0
+  }
+  validatePassword = password => {
+    return password.length === 0
+  }
+  onSubmit = async e => {
+    e.preventDefault()
+    const emailError = this.validateEmail(this.state.email)
+    this.setState({
+      emailError,
+      submitStatus: emailError ? 'ERROR' : 'SUBMITTED'
+    })
+    if (!emailError) {
+      const result = await this.props.sendResetPasswordEmail({
+        email: this.state.email,
+        redirectUrl: window.location.href.replace(
+          this.props.location.pathname,
+          '/create-new-password/'
+        )
+      })
+      if (result.data) {
+        this.setState({ submitStatus: 'SUCCESS' })
+      } else {
+        this.setState({ submitStatus: 'FAILED', submitErrorText: result.error.description })
+      }
+    }
+  }
+  onEmailInputChange = e => {
+    const value = e.target.value
+    this.setState({
+      email: value,
+      emailError: this.state.submitStatus === 'ERROR' && this.validateEmail(value)
+    })
+  }
+  render () {
+    return (
+      <Form onSubmit={this.onSubmit} noValidate>
+        {this.state.submitStatus === 'SUCCESS' ? (
+          <SendEmailSuccessfulContainer>
+            <h4>Email has been sent, please check your email</h4>
+          </SendEmailSuccessfulContainer>
+        ) : (
+          <div>
+            <h4>Reset Password</h4>
+            <p>Please enter your recovery email to reset password.</p>
+            <Input
+              placeholder='email@domain.com'
+              error={this.state.emailError}
+              errorText='Invalid email'
+              onChange={this.onEmailInputChange}
+              value={this.state.email}
+              disabled={this.state.submitted}
+            />
+            <Button
+              size='large'
+              type='submit'
+              fluid
+              loading={this.state.submitStatus === 'SUBMITTED'}
+            >
+              Send Request Email
+            </Button>
+          </div>
+        )}
+        <Link to='/login/' className='back-link'>
+          Go back to Login
+        </Link>
+        <Error error={this.state.submitStatus === 'FAILED'}>{this.state.submitErrorText}</Error>
+      </Form>
+    )
+  }
+}
+
+export default ForgetPasswordForm

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -40,8 +40,7 @@ const Error = styled.div`
 const enhance = compose(withRouter)
 class ForgetPasswordForm extends Component {
   static propTypes = {
-    location: PropTypes.object.isRequired,
-    updatePasswordWithResetToken: PropTypes.func.isRequired
+    location: PropTypes.object.isRequired
   }
   state = {
     newPassword: '',

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react'
 import { Input, Button } from '../../omg-uikit'
 import styled from 'styled-components'
-import { Link, withRouter } from 'react-router-dom'
+import { withRouter } from 'react-router-dom'
 import queryString from 'query-string'
 import PropTypes from 'prop-types'
 import AuthFormLayout from '../../omg-layout/authFormLayout'
 import { compose } from 'recompose'
+import { updateUserPassword } from '../../services/clientService'
 const Form = styled.form`
   text-align: left;
   input {
@@ -67,9 +68,9 @@ class ForgetPasswordForm extends Component {
       submitStatus: !newPasswordError && !reEnteredNewPasswordError ? 'SUBMITTED' : null
     })
     if (!newPasswordError && !reEnteredNewPasswordError) {
-      const result = await this.props.updatePasswordWithResetToken({
+      const result = await updateUserPassword({
         email,
-        resetToken: token,
+        token,
         password: this.state.newPassword,
         passwordConfirmation: this.state.reEnteredNewPassword
       })
@@ -122,7 +123,7 @@ class ForgetPasswordForm extends Component {
                 disabled={this.state.submitStatus === 'SUBMITTED'}
               />
               <Button size='large' type='submit' fluid loading={this.state.submitStatus === 'SUBMITTED'}>
-              Reset Password
+                Reset Password
               </Button>
             </div>
           ) : (

--- a/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
+++ b/apps/admin_panel/assets/src/clientApp/omg-client-reset-password/index.js
@@ -104,7 +104,7 @@ class ForgetPasswordForm extends Component {
       if (result.data.success) {
         this.setState({ submitStatus: 'SUCCESS' })
       } else {
-        this.setState({ submitStatus: 'FAILED', submitErrorText: result.data.data.code })
+        this.setState({ submitStatus: 'FAILED', submitErrorText: result.data.data.description })
       }
     }
   }

--- a/apps/admin_panel/assets/src/config/index.js
+++ b/apps/admin_panel/assets/src/config/index.js
@@ -1,2 +1,3 @@
-export const API_URL = CONFIG.BACKEND_API_URL || '/api/admin'
+export const ADMIN_API_URL = CONFIG.BACKEND_API_URL || '/api/admin'
+export const CLIENT_API_URL = CONFIG.CLIENT_API_URL || '/api/client'
 export const WEBSOCKET_URL = CONFIG.BACKEND_WEBSOCKET_URL || '/api/admin/socket'

--- a/apps/admin_panel/assets/src/index.js
+++ b/apps/admin_panel/assets/src/index.js
@@ -63,7 +63,7 @@ async function bootAdminPanelApp () {
   // HOT RELOADING FOR DEVELOPMENT MODE
   if (module.hot) {
     module.hot.accept('./adminPanelApp', () => {
-      render(<App />, document.getElementById('app'))
+      render(<LoadedApp />, document.getElementById('app'))
     })
     module.hot.accept('./reducer', () => {
       store.replaceReducer(require('./reducer').default)
@@ -81,7 +81,7 @@ async function bootClientApp () {
   // HOT RELOADING FOR DEVELOPMENT MODE
   if (module.hot) {
     module.hot.accept('./clientApp', () => {
-      render(<App />, document.getElementById('app'))
+      render(<LoadedApp />, document.getElementById('app'))
     })
   }
   console.log('Started client app.')

--- a/apps/admin_panel/assets/src/services/apiService.js
+++ b/apps/admin_panel/assets/src/services/apiService.js
@@ -1,23 +1,32 @@
 import axios from 'axios'
 import createHeader from '../utils/headerGenerator'
-import { API_URL } from '../config'
+import { ADMIN_API_URL, CLIENT_API_URL } from '../config'
 import urlJoin from 'url-join'
-export function request ({ path, data, headers }) {
-  const joinedPath = urlJoin(API_URL, path)
+export const request = url => ({ path, data, headers }) => {
+  const joinedPath = urlJoin(url, path)
   return axios.post(joinedPath, data, { headers })
 }
+
+export const adminRequest = request(ADMIN_API_URL)
+export const clientRequest = request(CLIENT_API_URL)
+
+export function unAuthenticatedClientRequest ({ path, data }) {
+  const headers = createHeader({ auth: false })
+  return clientRequest({ path, data, headers })
+}
+
 export function authenticatedRequest ({ path, data }) {
   const headers = createHeader({ auth: true })
-  return request({ path, data, headers })
+  return adminRequest({ path, data, headers })
 }
 export function unAuthenticatedRequest ({ path, data }) {
   const headers = createHeader({ auth: false })
-  return request({ path, data, headers })
+  return adminRequest({ path, data, headers })
 }
 export function authenticatedMultipartRequest ({ path, data }) {
   const headers = createHeader({
     auth: true,
     headerOption: { 'content-type': 'multipart/form-data' }
   })
-  return request({ path, data, headers })
+  return adminRequest({ path, data, headers })
 }

--- a/apps/admin_panel/assets/src/services/apiService.test.js
+++ b/apps/admin_panel/assets/src/services/apiService.test.js
@@ -1,17 +1,17 @@
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { request } from './apiService'
-import { API_URL } from '../config'
+import { adminRequest } from './apiService'
+import { ADMIN_API_URL } from '../config'
 const mock = new MockAdapter(axios)
 describe('apiService', () => {
   afterEach(() => {
     mock.reset()
   })
   test('request should be called successfully.', async () => {
-    mock.onPost(`${API_URL}/testPath`).reply(200, {
+    mock.onPost(`${ADMIN_API_URL}/testPath`).reply(200, {
       test: 'test'
     })
-    const result = await request({
+    const result = await adminRequest({
       path: '/testPath',
       data: { test: 'test' },
       headers: { duumyHeader: 'header' }

--- a/apps/admin_panel/assets/src/services/clientService.js
+++ b/apps/admin_panel/assets/src/services/clientService.js
@@ -1,0 +1,7 @@
+import { unAuthenticatedRequest } from './apiService'
+export function updateUserPassword () {
+  return unAuthenticatedRequest({
+    path: 'user.update_password',
+    data: {}
+  })
+}

--- a/apps/admin_panel/assets/src/services/clientService.js
+++ b/apps/admin_panel/assets/src/services/clientService.js
@@ -1,7 +1,12 @@
 import { unAuthenticatedRequest } from './apiService'
-export function updateUserPassword () {
+export function updateUserPassword ({ email, token, password, passwordConfirmation }) {
   return unAuthenticatedRequest({
     path: 'user.update_password',
-    data: {}
+    data: {
+      email,
+      token,
+      password,
+      password_confirmation: passwordConfirmation
+    }
   })
 }

--- a/apps/admin_panel/assets/src/services/clientService.js
+++ b/apps/admin_panel/assets/src/services/clientService.js
@@ -1,6 +1,6 @@
-import { unAuthenticatedRequest } from './apiService'
+import { unAuthenticatedClientRequest } from './apiService'
 export function updateUserPassword ({ email, token, password, passwordConfirmation }) {
-  return unAuthenticatedRequest({
+  return unAuthenticatedClientRequest({
     path: 'user.update_password',
     data: {
       email,

--- a/apps/admin_panel/assets/src/utils/device.js
+++ b/apps/admin_panel/assets/src/utils/device.js
@@ -1,0 +1,15 @@
+const mobileRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series[46]0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i
+
+const tabletRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series[46]0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino|android|ipad|playbook|silk/i
+
+export function isMobile (opts) {
+  if (!opts) opts = {}
+  var ua = opts.ua
+  if (!ua && typeof navigator !== 'undefined') ua = navigator.userAgent
+  if (ua && ua.headers && typeof ua.headers['user-agent'] === 'string') {
+    ua = ua.headers['user-agent']
+  }
+  if (typeof ua !== 'string') return false
+
+  return opts.tablet ? tabletRE.test(ua) : mobileRE.test(ua)
+}

--- a/apps/admin_panel/assets/src/utils/device.js
+++ b/apps/admin_panel/assets/src/utils/device.js
@@ -1,8 +1,7 @@
-const mobileRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series[46]0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i
-
-const tabletRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series[46]0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino|android|ipad|playbook|silk/i
-
 export function isMobile (opts) {
+  // https://github.com/juliangruber/is-mobile
+  const mobileRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series[46]0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i
+  const tabletRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series[46]0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino|android|ipad|playbook|silk/i
   if (!opts) opts = {}
   var ua = opts.ua
   if (!ua && typeof navigator !== 'undefined') ua = navigator.userAgent

--- a/apps/admin_panel/assets/src/utils/headerGenerator.js
+++ b/apps/admin_panel/assets/src/utils/headerGenerator.js
@@ -8,10 +8,6 @@ export function createAuthenticationHeader ({ auth, accessToken }) {
     : {}
 }
 
-function createAccountIdHeader (currentAccountId) {
-  return currentAccountId ? { 'OMGAdmin-Account-ID': currentAccountId } : {}
-}
-
 export default function createHeaders ({
   auth,
   headerOption,
@@ -21,7 +17,6 @@ export default function createHeaders ({
   return {
     Accept: 'application/vnd.omisego.v1+json',
     ...createAuthenticationHeader({ auth, accessToken }),
-    ...createAccountIdHeader(currentAccountId),
     ...headerOption
   }
 }

--- a/apps/admin_panel/assets/src/utils/headerGenerator.test.js
+++ b/apps/admin_panel/assets/src/utils/headerGenerator.test.js
@@ -12,8 +12,7 @@ describe('headerGenerator', () => {
     const AuthorizationEncoded = btoa(`${accessToken.user_id}:${accessToken.authentication_token}`)
     expect(header).toEqual({
       'Accept': 'application/vnd.omisego.v1+json',
-      'Authorization': `OMGAdmin ${AuthorizationEncoded}`,
-      'OMGAdmin-Account-ID': currentAccountId
+      'Authorization': `OMGAdmin ${AuthorizationEncoded}`
     })
   })
   test('function createHeaders should return correct header for [unauthenticated] request', () => {
@@ -23,8 +22,7 @@ describe('headerGenerator', () => {
       currentAccountId
     })
     expect(header).toEqual({
-      'Accept': 'application/vnd.omisego.v1+json',
-      'OMGAdmin-Account-ID': currentAccountId
+      'Accept': 'application/vnd.omisego.v1+json'
     })
   })
 })

--- a/apps/admin_panel/assets/webpack/webpack.dev.config.js
+++ b/apps/admin_panel/assets/webpack/webpack.dev.config.js
@@ -32,6 +32,7 @@ module.exports = {
     new DefinePlugin({
       CONFIG: {
         BACKEND_API_URL: JSON.stringify(process.env.BACKEND_API_URL),
+        CLIENT_API_URL: JSON.stringify(process.env.CLIENT_API_URL),
         BACKEND_WEBSOCKET_URL: JSON.stringify(process.env.BACKEND_WEBSOCKET_URL)
       }
     })

--- a/apps/admin_panel/assets/webpack/webpack.prod.config.js
+++ b/apps/admin_panel/assets/webpack/webpack.prod.config.js
@@ -25,6 +25,7 @@ module.exports = {
     new DefinePlugin({
       CONFIG: {
         BACKEND_API_URL: JSON.stringify(process.env.BACKEND_API_URL),
+        CLIENT_API_URL: JSON.stringify(process.env.CLIENT_API_URL),
         BACKEND_WEBSOCKET_URL: JSON.stringify(process.env.BACKEND_WEBSOCKET_URL)
       }
     })


### PR DESCRIPTION
Issue/Task Number: #908 

# Overview

Handle reset password on client.

# Changes

- Add reset password fallback to app waiting scene.

# Implementation Details

There are many possibility for this,
- if it is a mobile, and foward_url exist we try to open an app and give a scene to wait.
- if not show usual form.

# Usage

try on mobile, and also opening an app.

# Impact

Deploy as usual.
