### PR TITLE
Update categories in account settings

### DIFF
--- a/apps/admin_panel/assets/src/omg-account/action.js
+++ b/apps/admin_panel/assets/src/omg-account/action.js
@@ -118,7 +118,7 @@ export const getUsersByAccountId = ({ accountId, page, perPage, cacheKey, matchA
     cacheKey
   })
 
-export const updateAccount = ({ accountId, name, description, avatar }) =>
+export const updateAccount = ({ accountId, name, description, avatar, categoryIds }) =>
   createActionCreator({
     actionName: 'ACCOUNT',
     action: 'UPDATE',
@@ -126,7 +126,8 @@ export const updateAccount = ({ accountId, name, description, avatar }) =>
       const updatedAccount = await accountService.updateAccountInfo({
         id: accountId,
         name,
-        description
+        description,
+        categoryIds
       })
       if (updatedAccount.data.success && avatar) {
         const result = await accountService.uploadAccountAvatar({

--- a/apps/admin_panel/assets/src/omg-page-account-setting/index.js
+++ b/apps/admin_panel/assets/src/omg-page-account-setting/index.js
@@ -121,9 +121,9 @@ class AccountSettingPage extends Component {
   componentDidMount () {
     this.setInitialAccountState()
   }
-  async setInitialAccountState () {
+  setInitialAccountState = async () => {
     const { currentAccount } = this.props;
-    if (currentAccount) {
+    if (!_.isEmpty(currentAccount)) {
       this.setState({
         name: currentAccount.name,
         description: currentAccount.description,

--- a/apps/admin_panel/assets/src/omg-page-account-setting/index.js
+++ b/apps/admin_panel/assets/src/omg-page-account-setting/index.js
@@ -90,6 +90,7 @@ class AccountSettingPage extends Component {
       submitStatus: 'DEFAULT',
       categorySearch: '',
       categorySelect: '',
+      categoryTouched: false
     }
   }
   componentDidMount () {
@@ -102,8 +103,8 @@ class AccountSettingPage extends Component {
         name: currentAccount.name,
         description: currentAccount.description,
         avatar: currentAccount.avatar.original,
-        categorySelect: currentAccount.categories.data[0],
-        categorySearch: currentAccount.categories.data[0].name
+        categorySelect: _.get(currentAccount, 'categories.data[0]'),
+        categorySearch: _.get(currentAccount, 'categories.data[0].name')
       })
     } else {
       const result = await this.props.getAccountById(this.props.match.params.accountId)
@@ -112,8 +113,8 @@ class AccountSettingPage extends Component {
           name: result.data.name,
           description: result.data.description || '',
           avatar: result.data.avatar.original || '',
-          categorySelect: result.data.categories.data[0] || '',
-          categorySearch: result.data.categories.data[0].name || ''
+          categorySelect: _.get(result, 'data.categories.data[0]') || '',
+          categorySearch: _.get(result, 'data.categories.data[0].name') || ''
         })
       }
     }
@@ -135,7 +136,8 @@ class AccountSettingPage extends Component {
         accountId: this.props.match.params.accountId,
         name: this.state.name,
         description: this.state.description,
-        avatar: this.state.image
+        avatar: this.state.image,
+        categoryIds: [_.get(this.state.categorySelect, 'id')]
       })
 
       if (result.data) {
@@ -185,13 +187,15 @@ class AccountSettingPage extends Component {
   onChangeCategory = e => {
     this.setState({
       categorySearch: e.target.value,
-      categorySelect: ''
+      categorySelect: '',
+      categoryTouched: true
     });
   }
   onSelectCategory = category => {
     this.setState({
       categorySearch: category.name,
-      categorySelect: category
+      categorySelect: category,
+      categoryTouched: true
     });
   }
   renderCategoriesPicker = ({ data: categories = [] }) => (
@@ -216,7 +220,7 @@ class AccountSettingPage extends Component {
       this.props.currentAccount.description === this.state.description &&
       !this.state.image &&
       !sameCategory &&
-      this.state.categorySelect
+      this.state.categoryTouched
   }
   renderAccountSettingTab = () => (
     <ProfileSection>

--- a/apps/admin_panel/assets/src/omg-page-account-setting/index.js
+++ b/apps/admin_panel/assets/src/omg-page-account-setting/index.js
@@ -60,8 +60,15 @@ const CategorySelect = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  button {
-    margin-top: 20px;
+  margin-top: 20px;
+
+  .category {
+    padding-right: 20px;
+  }
+
+  .button {
+    cursor: pointer;
+    color: ${props => props.theme.colors.BL400}
   }
 `
 
@@ -270,15 +277,12 @@ class AccountSettingPage extends Component {
               prefill
             />
             <CategorySelect>
-              <div>{this.state.categorySearch}</div>
-              <Button
-                size='small'
-                key={'openModal'}
-                onClick={this.toggleModal}
-                styleType='secondary'
-              >
-                <span>{this.state.categorySearch ? 'Edit Category' : 'Add Category'}</span>
-              </Button>
+              {this.state.categorySearch && this.state.categorySearch !== 'None' && (
+                <div className='category'>{this.state.categorySearch}</div>
+              )}
+              <div className='button' onClick={this.toggleModal}>
+                {this.state.categorySearch === 'None' || !this.state.categorySearch ? 'Add Category' : 'Edit Category'}
+              </div>
             </CategorySelect>
             <Button
               size='small'

--- a/apps/admin_panel/assets/src/omg-page-account-setting/index.js
+++ b/apps/admin_panel/assets/src/omg-page-account-setting/index.js
@@ -130,7 +130,7 @@ class AccountSettingPage extends Component {
   }
   onClickUpdateAccount = async e => {
     e.preventDefault()
-    this.setState({ submitStatus: 'SUBMITTING' })
+    this.setState({ submitStatus: 'SUBMITTING', categoryTouched: false })
     try {
       const result = await this.props.updateAccount({
         accountId: this.props.match.params.accountId,
@@ -211,7 +211,7 @@ class AccountSettingPage extends Component {
       }))}
     />
   )
-  get checkDiff() {
+  get shouldSave() {
     const propsCategoryId = _.get(this.props.currentAccount, 'categories.data[0].id')
     const stateCategoryId = _.get(this.state.categorySelect, 'id')
     const sameCategory = propsCategoryId && propsCategoryId === stateCategoryId
@@ -219,8 +219,9 @@ class AccountSettingPage extends Component {
     return this.props.currentAccount.name === this.state.name &&
       this.props.currentAccount.description === this.state.description &&
       !this.state.image &&
-      !sameCategory &&
-      this.state.categoryTouched
+      this.state.categoryTouched &&
+      !(!this.state.categorySelect && this.state.categorySearch.length)
+      !sameCategory
   }
   renderAccountSettingTab = () => (
     <ProfileSection>
@@ -254,7 +255,7 @@ class AccountSettingPage extends Component {
               size='small'
               type='submit'
               key={'save'}
-              disabled={!this.checkDiff}
+              disabled={!this.shouldSave}
               loading={this.state.submitStatus === 'SUBMITTING'}
             >
               <span>Save Changes</span>

--- a/apps/admin_panel/assets/src/services/accountService.js
+++ b/apps/admin_panel/assets/src/services/accountService.js
@@ -38,13 +38,14 @@ export function uploadAccountAvatar ({ accountId, avatar }) {
   })
 }
 
-export function updateAccountInfo ({ id, name, description }) {
+export function updateAccountInfo ({ id, name, description, categoryIds }) {
   return authenticatedRequest({
     path: '/account.update',
     data: {
       id,
       name,
-      description
+      description,
+      category_ids: categoryIds
     }
   })
 }


### PR DESCRIPTION
Issue/Task Number: [383](https://github.com/omisego/ewallet/issues/383)

# Overview

Adds a select category field to account settings

# Changes

send the selected category with the update account call

# Implementation Details

- "Create account" currently only supports selecting one category, so i did the same here
- Allows user to save no category by emptying field
- Dont allow user to click save unless category is selected from dropdown