### PR TITLE
Remove erlang datetime -> NaiveDateTime conversion from role migration

### DIFF
--- a/apps/ewallet_db/priv/repo/migrations/20181113055250_add_id_and_deleted_at_to_role.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20181113055250_add_id_and_deleted_at_to_role.exs
@@ -46,10 +46,7 @@ defmodule EWalletDB.Repo.Migrations.AddIdAndDeletedAtToRole do
                  lock: "FOR UPDATE")
 
     for [uuid, inserted_at] <- Repo.all(query) do
-      {date, {hours, minutes, seconds, microseconds}} = inserted_at
-
-      {:ok, datetime} = NaiveDateTime.from_erl({date, {hours, minutes, seconds}}, {microseconds, 4})
-      {:ok, datetime} = DateTime.from_naive(datetime, "Etc/UTC")
+      {:ok, datetime} = DateTime.from_naive(inserted_at, "Etc/UTC")
 
       ulid =
         datetime


### PR DESCRIPTION
Issue/Task Number: #956 
Closes #956

# Overview

Remove erlang datetime to NaiveDateTime conversion since it's already converted in later Ecto versions used by eWallet v1.2

# Changes

- Remove erlang date time to NaiveDateTime conversion from role migrationn

# Implementation Details

See overview.

# Usage

After this PR is merged `mix ecto.migrate` should pass successfully.

# Impact

No changes to DB schema or API specs.