### PR TITLE
Frontend lint release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,7 @@ jobs:
     executor: metal
     steps:
       - checkout
+      - run: sh update-versions.sh -a
       - run: make docker IMAGE_NAME=$IMAGE_NAME
       - run: sh .circleci/ci_e2e.sh
       - run: sh .circleci/ci_publish.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ jobs:
       - setup_ewallet_workspace
       - run: make check-format
       - run: make check-credo
+      - run: make check-assets
       - notify_slack_failure
 
   dialyze:

--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,10 @@ build-assets: deps-assets
 # If we call mix phx.digest without mix compile, mix release will silently fail
 # for some reason. Always make sure to run mix compile first.
 build-prod: deps-ewallet build-assets
-	$(ENV_PROD) mix compile
-	$(ENV_PROD) mix phx.digest
-	$(ENV_PROD) mix release
+	$(ENV_PROD) mix do compile, phx.digest, release
 
 build-dev: deps-ewallet build-assets
-	$(ENV_DEV) mix compile
-	$(ENV_DEV) mix release dev
+	$(ENV_DEV) mix do compile, release dev
 
 build-test: deps-ewallet
 	$(ENV_TEST) mix compile

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ check-credo:
 check-dialyzer:
 	$(ENV_TEST) mix dialyzer --halt-exit-status 2>&1
 
+check-assets:
+	$(ASSETS) npm run lint 2>&1
+
 .PHONY: format check-format check-credo
 
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       LOCAL_LEDGER_DATABASE_URL: "postgresql://postgres:passw0rd@postgres:5432/local_ledger"
       EWALLET_SECRET_KEY: "CHANGE_ME"
       LOCAL_LEDGER_SECRET_KEY: "CHANGE_ME"
+      KEYCHAIN_SECRET_KEY: "CHANGE_ME"
     ports:
       - "4000:4000"
 

--- a/docker-gen.sh
+++ b/docker-gen.sh
@@ -40,6 +40,7 @@ POSTGRES_PASSWORD=""
 EXTERNAL_NETWORK=""
 EWALLET_SECRET_KEY=""
 LOCAL_LEDGER_SECRET_KEY=""
+KEYCHAIN_SECRET_KEY=""
 DEV_MODE=0
 
 while true; do
@@ -49,6 +50,7 @@ while true; do
         -p ) POSTGRES_PASSWORD=$2;       shift; shift;;
         -k ) EWALLET_SECRET_KEY=$2;      shift; shift;;
         -K ) LOCAL_LEDGER_SECRET_KEY=$2; shift; shift;;
+        -J ) KEYCHAIN_SECRET_KEY=$2;     shift; shift;;
         -f ) ENV_FILE=$2;                shift; shift;;
         -d ) DEV_MODE=1;  shift;;
         -h ) print_usage; exit 2;;
@@ -58,6 +60,7 @@ done
 
 [ -z "$EWALLET_SECRET_KEY" ]      && EWALLET_SECRET_KEY=$(openssl rand -base64 32)
 [ -z "$LOCAL_LEDGER_SECRET_KEY" ] && LOCAL_LEDGER_SECRET_KEY=$(openssl rand -base64 32)
+[ -z "$KEYCHAIN_SECRET_KEY" ]     && KEYCHAIN_SECRET_KEY=$(openssl rand -base64 32)
 [ -z "$POSTGRES_PASSWORD" ]       && POSTGRES_PASSWORD=$(openssl rand -base64 24 | tr '+/' '-_')
 
 if [ -z "$IMAGE_NAME" ]; then
@@ -81,7 +84,8 @@ YML_SERVICES="
       DATABASE_URL: postgresql://postgres:$POSTGRES_PASSWORD@postgres:5432/ewallet
       LOCAL_LEDGER_DATABASE_URL: postgresql://postgres:$POSTGRES_PASSWORD@postgres:5432/local_ledger
       EWALLET_SECRET_KEY: $EWALLET_SECRET_KEY
-      LOCAL_LEDGER_SECRET_KEY: $LOCAL_LEDGER_SECRET_KEY\
+      LOCAL_LEDGER_SECRET_KEY: $LOCAL_LEDGER_SECRET_KEY
+      KEYCHAIN_SECRET_KEY: $KEYCHAIN_SECRET_KEY\
 " # EOF
 
 if [ -n "$ENV_FILE" ]; then

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -64,7 +64,7 @@ while IFS= read -r file; do
     fi
 
     printf 2>&1 "* %-40s" "${file#$BASE_DIR/*}..."
-    NEW_VERSION=$1 awk '
+    NEW_VERSION=$VERSION awk '
         m = match($0, "^([\ ]+version:[\ ]+)") {
           print substr($0, RSTART, RLENGTH-1) " \"" ENVIRON["NEW_VERSION"] "\","
         } ! m { print }

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -35,12 +35,16 @@ fi
 VERSION=$1
 
 if [ "$AUTO" = 1 ]; then
-    VERSION=$(git describe --tags)
-
     if ! command -v git >/dev/null; then
         printf 2>&1 "Git is required to auto-generating version\\n"
         exit 1
     fi
+
+    # git describe --tags will generate a version of the TAG, if HEAD is a tag,
+    # or a TAG-NN-gSHA where NN is the number of commits since the last tag
+    # and SHA256 is an abbrev-rev of HEAD, e.g. v1.2.0-pre.0-17-gaceb325f
+    VERSION=$(git describe --tags)
+    VERSION=${VERSION#v*}
 
     printf 2>&1 "Using %s as the current version.\\n" "$VERSION"
 elif [ -z "$VERSION" ]; then
@@ -65,7 +69,7 @@ while IFS= read -r file; do
 
     printf 2>&1 "* %-40s" "${file#$BASE_DIR/*}..."
     NEW_VERSION=$VERSION awk '
-        m = match($0, "^([\ ]+version:[\ ]+)") {
+        m = match($0, "^([ ]+version:[ ]+)") {
           print substr($0, RSTART, RLENGTH-1) " \"" ENVIRON["NEW_VERSION"] "\","
         } ! m { print }
     ' < "$file" > "$file.tmp"


### PR DESCRIPTION
Issue/Task Number: #945, #972

Run frontend linting (`npm run lint`) as part of the build process, as well as automatically update versions in `mix.exs` during build process. The version number will be either:

* Just the tag, for tagged commit e.g. `1.2.0-pre.0` for `v1.2.0-pre.0` tag, prefix `v` truncated
* Latest tag plus number of commits since last tag, and a hash e.g. `1.2.0-pre.0-18-g343a6c80`

The latter is generated using `git describe --tags`. SHA hash for the commit is after the `g` letter.

This commit also fixes #971 where config command fails due to `KEYCHAIN_SECRET_KEY` not properly getting configured during E2E.