### PR TITLE
Fix unhandled error when match_all/match_any format is incorrect

### DIFF
--- a/apps/ewallet/lib/ewallet/web/filters/match_parser.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_parser.ex
@@ -40,6 +40,15 @@ defmodule EWallet.Web.MatchParser do
     end
   end
 
+  # Rejects if the user didn't provided the filters as a list.
+  defp parse_rules(inputs, _whitelist, _mappings) when not is_list(inputs) do
+    # In other usual cases where only a param is missing, the 3rd tuple element returned would be
+    # a map of parameters that the code successfully detected, so the user could figure out
+    # what is missing. In this case, where the params are totally invalid, the 3rd tuple element
+    # is therefore an empty map.
+    {:error, :missing_filter_param, %{}}
+  end
+
   # Parses a list of arbitrary `%{"field" => _, "comparator" => _, "value" => _}`
   # into a list of `{field, subfield, type, comparator, value}`.
   defp parse_rules(inputs, whitelist, mappings) do

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -398,7 +398,7 @@ defmodule EWallet.Web.V1.ErrorHandler do
     },
     missing_filter_param: %{
       code: "client:invalid_parameter",
-      description: "Invalid parameter provided. Missing one or more filter parameters."
+      description: "Invalid parameter provided. Expecting an array of filter parameters."
     },
     comparator_not_supported: %{
       code: "client:invalid_parameter",

--- a/apps/ewallet/test/ewallet/web/filters/match_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/filters/match_parser_test.exs
@@ -90,6 +90,21 @@ defmodule EWallet.Web.MatchParserTest do
 
       assert result == {:error, :not_allowed, "from_amount"}
     end
+
+    test "returns error if not provided a list of filter params" do
+      # Provided filter params directly instead of a list of filter params
+      attrs = %{
+        "field" => "from_amount",
+        "comparator" => "eq",
+        "value" => 1000
+      }
+
+      {res, code, params} = MatchParser.build_query(Transaction, attrs, [], true, MatchAllQuery)
+
+      assert res == :error
+      assert code == :missing_filter_param
+      assert params == %{}
+    end
   end
 
   describe "build_query/3 with field definitions" do

--- a/apps/ewallet/test/ewallet/web/v1/error_handler_test.exs
+++ b/apps/ewallet/test/ewallet/web/v1/error_handler_test.exs
@@ -109,7 +109,7 @@ defmodule EWallet.Web.V1.ErrorHandlerTest do
       expected = %{
         object: "error",
         code: "client:invalid_parameter",
-        description: "Invalid parameter provided. Missing one or more filter parameters.",
+        description: "Invalid parameter provided. Expecting an array of filter parameters.",
         messages: filter_params
       }
 


### PR DESCRIPTION
Issue/Task Number: #975
Closes #975

# Overview

Fixes the internal server error returned when the provided with an invalid `match_all`/`match_any` filter attributes.

# Changes

- `MatchParser` rejects filter attributes that are invalid (i.e. not in a list).
- Updated `:missing_filter_param` error description to `"Invalid parameter provided. Expecting an array of filter parameters."` for clarity

# Implementation Details

Server was crashing because `Enum.reduce_while/3` could be enumerated both over a list or a map. Since the expected value is a list, but a map could easily be mistaken (using only 1 set of filter, passed that set without wrapping in a list), this will be caught now before being handled.

Did this instead of supporting a single filter without list to keep the API consistent.

# Usage

Request:

```shell
curl -X POST http://localhost:4000/api/admin/token.all \
-X POST \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGProvider <truncated>" \
-H "Content-Type: application/json" \
-d '{
  "match_all": {
    "comparator": "eq",
    "field": "symbol",
    "value": "ABC"
  }
}' \
-v -w "\n"
```

Response:

```shell
{
  "version": "1",
  "success": false,
  "data": {
    "object": "error",
    "messages": {},
    "description": "Invalid parameter provided. Expecting an array of filter parameters.",
    "code": "client:invalid_parameter"
  }
}
```

# Impact

No changes to DB schema or API specs.