### PR TITLE
Fix exception raised when the given `start_by` field is not allowed

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/balance_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/balance_controller.ex
@@ -39,6 +39,7 @@ defmodule AdminAPI.V1.BalanceController do
       render(conn, :balances, %Paginator{pagination: pagination, data: data})
     else
       {:error, error} -> handle_error(conn, error)
+      {:error, error, description} -> handle_error(conn, error, description)
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/balance_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/balance_controller_test.exs
@@ -123,6 +123,29 @@ defmodule AdminAPI.V1.BalanceControllerTest do
       assert response["data"]["description"] ==
                "Invalid parameter provided. `address` is required."
     end
+
+    test_with_auths "returns :error when querying with a prohibited field" do
+      user_wallet = prepare_user_wallet()
+
+      [_omg, _btc, _eth] = prepare_balances(user_wallet, [100, 200, 300])
+
+      attrs = %{
+        "sort_by" => "inserted_at",
+        "sort_dir" => "asc",
+        "start_after" => nil,
+        "start_by" => "subunit_to_unit", # not allowed
+        "address" => user_wallet.address
+      }
+
+      response = request("/wallet.get_balances", attrs)
+
+      assert response["success"] == false
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "start_by: `subunit_to_unit` is not allowed. "
+               <> "The available fields are: [id, inserted_at, updated_at]"
+    end
   end
 
   # number of created tokens == number of given amounts

--- a/apps/admin_api/test/admin_api/v1/controllers/balance_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/balance_controller_test.exs
@@ -133,7 +133,7 @@ defmodule AdminAPI.V1.BalanceControllerTest do
         "sort_by" => "inserted_at",
         "sort_dir" => "asc",
         "start_after" => nil,
-        "start_by" => "subunit_to_unit", # not allowed
+        "start_by" => "subunit_to_unit",
         "address" => user_wallet.address
       }
 
@@ -143,8 +143,8 @@ defmodule AdminAPI.V1.BalanceControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "start_by: `subunit_to_unit` is not allowed. "
-               <> "The available fields are: [id, inserted_at, updated_at]"
+               "start_by: `subunit_to_unit` is not allowed. " <>
+                 "The available fields are: [id, inserted_at, updated_at]"
     end
 
     test_with_auths "returns :error when querying with a non-existing field" do
@@ -156,7 +156,7 @@ defmodule AdminAPI.V1.BalanceControllerTest do
         "sort_by" => "inserted_at",
         "sort_dir" => "asc",
         "start_after" => nil,
-        "start_by" => "not_exists", # not allowed
+        "start_by" => "not_exists",
         "address" => user_wallet.address
       }
 
@@ -166,8 +166,8 @@ defmodule AdminAPI.V1.BalanceControllerTest do
       assert response["data"]["code"] == "client:invalid_parameter"
 
       assert response["data"]["description"] ==
-               "start_by: `not_exists` is not allowed. "
-               <> "The available fields are: [id, inserted_at, updated_at]"
+               "start_by: `not_exists` is not allowed. " <>
+                 "The available fields are: [id, inserted_at, updated_at]"
     end
   end
 

--- a/apps/admin_api/test/admin_api/v1/controllers/balance_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/balance_controller_test.exs
@@ -146,6 +146,29 @@ defmodule AdminAPI.V1.BalanceControllerTest do
                "start_by: `subunit_to_unit` is not allowed. "
                <> "The available fields are: [id, inserted_at, updated_at]"
     end
+
+    test_with_auths "returns :error when querying with a non-existing field" do
+      user_wallet = prepare_user_wallet()
+
+      [_omg, _btc, _eth] = prepare_balances(user_wallet, [100, 200, 300])
+
+      attrs = %{
+        "sort_by" => "inserted_at",
+        "sort_dir" => "asc",
+        "start_after" => nil,
+        "start_by" => "not_exists", # not allowed
+        "address" => user_wallet.address
+      }
+
+      response = request("/wallet.get_balances", attrs)
+
+      assert response["success"] == false
+      assert response["data"]["code"] == "client:invalid_parameter"
+
+      assert response["data"]["description"] ==
+               "start_by: `not_exists` is not allowed. "
+               <> "The available fields are: [id, inserted_at, updated_at]"
+    end
   end
 
   # number of created tokens == number of given amounts

--- a/apps/ewallet/lib/ewallet/web/paginators/start_after_paginator.ex
+++ b/apps/ewallet/lib/ewallet/web/paginators/start_after_paginator.ex
@@ -86,7 +86,8 @@ defmodule EWallet.Web.StartAfterPaginator do
     default_field = Atom.to_string(hd(allowed_fields))
 
     with {:ok, sort_by} <- attr_to_field(attrs, "sort_by", default_field, default_mapped_fields),
-         {:ok, start_by} <- attr_to_field(attrs, "start_by", default_field, default_mapped_fields),
+         {:ok, start_by} <-
+           attr_to_field(attrs, "start_by", default_field, default_mapped_fields),
          {:allowed, true, _} <- {:allowed, start_by in allowed_fields, start_by} do
       attrs =
         attrs
@@ -97,7 +98,12 @@ defmodule EWallet.Web.StartAfterPaginator do
     else
       {:error, :not_existing_atom, field_type, field_name} ->
         available_fields = fields_to_string(allowed_fields)
-        msg = "#{field_type}: `#{field_name}` is not allowed. The available fields are: [#{available_fields}]"
+
+        msg =
+          "#{field_type}: `#{field_name}` is not allowed. The available fields are: [#{
+            available_fields
+          }]"
+
         {:error, :invalid_parameter, msg}
 
       {:allowed, false, start_by} ->

--- a/apps/ewallet/lib/ewallet/web/paginators/start_after_paginator.ex
+++ b/apps/ewallet/lib/ewallet/web/paginators/start_after_paginator.ex
@@ -85,24 +85,23 @@ defmodule EWallet.Web.StartAfterPaginator do
       ) do
     default_field = Atom.to_string(hd(allowed_fields))
 
-    sort_by = map_atom_attr(attrs, "sort_by", default_field, default_mapped_fields)
-    start_by = map_atom_attr(attrs, "start_by", default_field, default_mapped_fields)
+    with {:ok, sort_by} <- attr_to_field(attrs, "sort_by", default_field, default_mapped_fields),
+         {:ok, start_by} <- attr_to_field(attrs, "start_by", default_field, default_mapped_fields),
+         {:allowed, true, _} <- {:allowed, start_by in allowed_fields, start_by} do
+      attrs =
+        attrs
+        |> Map.put("sort_by", sort_by)
+        |> Map.put("start_by", start_by)
 
-    case is_allowed_start_by(start_by, allowed_fields) do
-      true ->
-        attrs =
-          attrs
-          |> Map.put("sort_by", sort_by)
-          |> Map.put("start_by", start_by)
+      paginate(queryable, attrs, repo)
+    else
+      {:error, :not_existing_atom, field_type, field_name} ->
+        available_fields = fields_to_string(allowed_fields)
+        msg = "#{field_type}: `#{field_name}` is not allowed. The available fields are: [#{available_fields}]"
+        {:error, :invalid_parameter, msg}
 
-        paginate(queryable, attrs, repo)
-
-      _ ->
-        available_fields =
-          allowed_fields
-          |> Enum.map(&Atom.to_string/1)
-          |> Enum.join(", ")
-
+      {:allowed, false, start_by} ->
+        available_fields = fields_to_string(allowed_fields)
         start_by = Atom.to_string(start_by)
 
         msg =
@@ -112,31 +111,21 @@ defmodule EWallet.Web.StartAfterPaginator do
     end
   end
 
-  def map_atom_attr(attrs, key, default, mapping) do
-    attrs[key]
-    |> map_default(default)
-    |> map_field(mapping)
-    |> map_atom(default)
-  end
+  def attr_to_field(attrs, key, default, mapping) do
+    field_name = attrs[key] || default
+    mapped_name = mapping[field_name] || field_name
 
-  defp map_default(original, default) do
-    case original do
-      nil -> default
-      any -> any
+    try do
+      {:ok, String.to_existing_atom(mapped_name)}
+    rescue
+      ArgumentError -> {:error, :not_existing_atom, key, field_name}
     end
   end
 
-  defp map_field(original, mapping) do
-    case mapping[original] do
-      nil -> original
-      mapped -> mapped
-    end
-  end
-
-  defp map_atom(original, default) do
-    String.to_existing_atom(original)
-  rescue
-    ArgumentError -> default
+  defp fields_to_string(fields) do
+    fields
+    |> Enum.map(&Atom.to_string/1)
+    |> Enum.join(", ")
   end
 
   @doc """
@@ -242,10 +231,6 @@ defmodule EWallet.Web.StartAfterPaginator do
       _ ->
         {records, false}
     end
-  end
-
-  def is_allowed_start_by(start_by, allowed_fields) do
-    start_by in allowed_fields
   end
 
   def build_start_after_condition(%{"start_by" => start_by, "start_after" => start_after}) do

--- a/apps/ewallet/test/ewallet/web/paginators/start_after_paginator_test.exs
+++ b/apps/ewallet/test/ewallet/web/paginators/start_after_paginator_test.exs
@@ -325,13 +325,15 @@ defmodule EWallet.Web.StartFromPaginatorTest do
       attrs = %{"sort_by" => nil}
 
       # Assert nil value
-      sort_by = StartAfterPaginator.map_atom_attr(attrs, "sort_by", "id", @default_mapped_fields)
+      {res, sort_by} = StartAfterPaginator.attr_to_field(attrs, "sort_by", "id", @default_mapped_fields)
+      assert res == :ok
       assert sort_by == :id
 
       # Assert non-existing value
-      start_by =
-        StartAfterPaginator.map_atom_attr(attrs, "start_by", "id", @default_mapped_fields)
+      {res, start_by} =
+        StartAfterPaginator.attr_to_field(attrs, "start_by", "id", @default_mapped_fields)
 
+      assert res == :ok
       assert start_by == :id
     end
 
@@ -339,23 +341,38 @@ defmodule EWallet.Web.StartFromPaginatorTest do
       attrs = %{"sort_by" => "created_at", "start_by" => nil}
 
       # Assert original value exists in the `@default_mapped_fields`
-      sort_by = StartAfterPaginator.map_atom_attr(attrs, "sort_by", "id", @default_mapped_fields)
+      {res, sort_by} = StartAfterPaginator.attr_to_field(attrs, "sort_by", "id", @default_mapped_fields)
+      assert res == :ok
       assert sort_by == :inserted_at
 
       # Assert default value exists in the `@default_mapped_fields`
-      start_by =
-        StartAfterPaginator.map_atom_attr(attrs, "start_by", "created_at", @default_mapped_fields)
+      {res, start_by} =
+        StartAfterPaginator.attr_to_field(attrs, "start_by", "created_at", @default_mapped_fields)
 
+      assert res == :ok
       assert start_by == :inserted_at
     end
 
     test "returns original value when the value is non-nil and non-exist in the mapping" do
       attrs = %{"sort_by" => "id"}
 
-      sort_by =
-        StartAfterPaginator.map_atom_attr(attrs, "sort_by", "name", @default_mapped_fields)
+      {res, sort_by} =
+        StartAfterPaginator.attr_to_field(attrs, "sort_by", "name", @default_mapped_fields)
 
+      assert res == :ok
       assert sort_by == :id
+    end
+
+    test "returns an error tuple when the value is not an existing atom" do
+      attrs = %{"sort_by" => "never_an_atom"}
+
+      {res, error, type, field} =
+        StartAfterPaginator.attr_to_field(attrs, "sort_by", "id", @default_mapped_fields)
+
+      assert res == :error
+      assert error == :not_existing_atom
+      assert type == "sort_by"
+      assert field == "never_an_atom"
     end
   end
 end

--- a/apps/ewallet/test/ewallet/web/paginators/start_after_paginator_test.exs
+++ b/apps/ewallet/test/ewallet/web/paginators/start_after_paginator_test.exs
@@ -325,7 +325,9 @@ defmodule EWallet.Web.StartFromPaginatorTest do
       attrs = %{"sort_by" => nil}
 
       # Assert nil value
-      {res, sort_by} = StartAfterPaginator.attr_to_field(attrs, "sort_by", "id", @default_mapped_fields)
+      {res, sort_by} =
+        StartAfterPaginator.attr_to_field(attrs, "sort_by", "id", @default_mapped_fields)
+
       assert res == :ok
       assert sort_by == :id
 
@@ -341,7 +343,9 @@ defmodule EWallet.Web.StartFromPaginatorTest do
       attrs = %{"sort_by" => "created_at", "start_by" => nil}
 
       # Assert original value exists in the `@default_mapped_fields`
-      {res, sort_by} = StartAfterPaginator.attr_to_field(attrs, "sort_by", "id", @default_mapped_fields)
+      {res, sort_by} =
+        StartAfterPaginator.attr_to_field(attrs, "sort_by", "id", @default_mapped_fields)
+
       assert res == :ok
       assert sort_by == :inserted_at
 


### PR DESCRIPTION
Issue/Task Number: #985
Closes #985

# Overview

This PR fixes the exception raised when a given `start_by` field is not in the allowed list in  `/api/admin/wallet.get_balances`.

# Changes

- Handles `{:error, code, description}` tuple in `BalanceController`
- Fix exception thrown when an unrecognized field is given.

# Implementation Details

This 3-element error tuple was introduced in #719 and unfortunately `BalanceController` is the only controller that handles only 2-element error tuple. Already checked the rest of the controllers.

# Usage

As described in #985

# Impact

No changes to the API specs or DB schemas.
