### PR TITLE
Add auth token expiration

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/auth/admin_user_auth.ex
+++ b/apps/admin_api/lib/admin_api/v1/auth/admin_user_auth.ex
@@ -55,26 +55,26 @@ defmodule AdminAPI.V1.AdminUserAuth do
         |> Map.put(:authenticated, true)
         |> Map.put(:admin_user, admin_user)
 
-      false ->
+      %PreAuthToken{} = pre_auth_token ->
+        auth
+        |> Map.put(:authenticated, false)
+        # |> Map.put(:auth_error, :auth_token_not_found)
+        |> Map.put(:admin_user, pre_auth_token.user)
+
+      {:error, :token_not_found} ->
         auth
         |> Map.put(:authenticated, false)
         |> Map.put(:auth_error, :auth_token_not_found)
+
+      {:error, :token_expired} ->
+        auth
+        |> Map.put(:authenticated, false)
+        |> Map.put(:auth_error, :auth_token_expired)
 
       {:error, changeset} ->
         auth
         |> Map.put(:authenticated, false)
         |> Map.put(:auth_error, changeset)
-
-      %PreAuthToken{} = pre_auth_token ->
-        auth
-        |> Map.put(:authenticated, false)
-        |> Map.put(:auth_error, :auth_token_not_found)
-        |> Map.put(:admin_user, pre_auth_token.user)
-
-      :token_expired ->
-        auth
-        |> Map.put(:authenticated, false)
-        |> Map.put(:auth_error, :auth_token_expired)
     end
   end
 end

--- a/apps/admin_api/lib/admin_api/v1/auth/admin_user_auth.ex
+++ b/apps/admin_api/lib/admin_api/v1/auth/admin_user_auth.ex
@@ -60,6 +60,11 @@ defmodule AdminAPI.V1.AdminUserAuth do
         |> Map.put(:authenticated, false)
         |> Map.put(:auth_error, :auth_token_not_found)
 
+      {:error, changeset} ->
+        auth
+        |> Map.put(:authenticated, false)
+        |> Map.put(:auth_error, changeset)
+
       %PreAuthToken{} = pre_auth_token ->
         auth
         |> Map.put(:authenticated, false)

--- a/apps/admin_api/test/admin_api/v1/controllers/admin_user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/admin_user_controller_test.exs
@@ -540,7 +540,7 @@ defmodule AdminAPI.V1.AdminUserControllerTest do
 
       assert response["success"] == true
       assert response["data"]["enabled"] == false
-      assert AuthToken.authenticate(token_string, @owner_app) == :token_expired
+      assert AuthToken.authenticate(token_string, @owner_app) == {:error, :token_expired}
     end
 
     test_with_auths "disable an admin that doesn't exist raises an 'unauthorized' error" do

--- a/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/user_controller_test.exs
@@ -738,7 +738,7 @@ defmodule AdminAPI.V1.UserControllerTest do
 
       assert response["success"] == true
       assert response["data"]["enabled"] == false
-      assert AuthToken.authenticate(token_string, @owner_app) == :token_expired
+      assert AuthToken.authenticate(token_string, @owner_app) == {:error, :token_expired}
     end
 
     test_with_auths "disable a user succeed and disable his tokens given his provider user id" do
@@ -759,7 +759,7 @@ defmodule AdminAPI.V1.UserControllerTest do
 
       assert response["success"] == true
       assert response["data"]["enabled"] == false
-      assert AuthToken.authenticate(token_string, @owner_app) == :token_expired
+      assert AuthToken.authenticate(token_string, @owner_app) == {:error, :token_expired}
     end
 
     test_with_auths "disable a user that doesn't exist raises an 'unauthorized' error" do

--- a/apps/ewallet/lib/ewallet/auth/user_authenticator.ex
+++ b/apps/ewallet/lib/ewallet/auth/user_authenticator.ex
@@ -19,9 +19,9 @@ defmodule EWallet.UserAuthenticator do
 
   alias EWalletDB.{User, AuthToken, PreAuthToken}
 
-  def authenticate(nil, _, _), do: false
+  def authenticate(nil, _, _), do: {:error, :token_not_found}
 
-  def authenticate(_, nil, _), do: false
+  def authenticate(_, nil, _), do: {:error, :token_not_found}
 
   def authenticate(%User{} = user, auth_token, owner_app) do
     cond do

--- a/apps/ewallet/test/ewallet/auth/user_auth_token_test.exs
+++ b/apps/ewallet/test/ewallet/auth/user_auth_token_test.exs
@@ -45,23 +45,25 @@ defmodule EWallet.UserAuthTokenTest do
     test "return false if the given user has enabled 2FA but the given token doesn't exist" do
       user = insert(:user, %{enabled_2fa_at: ~N[2000-02-02 20:02:02], originator: nil})
 
-      assert UserAuthenticator.authenticate(user, "1234", :admin_api) == false
+      assert UserAuthenticator.authenticate(user, "1234", :admin_api) ==
+               {:error, :token_not_found}
     end
 
     test "return false if the given token doesn't exist" do
       user = insert(:user, %{originator: nil})
 
-      assert UserAuthenticator.authenticate(user, "1234", :admin_api) == false
+      assert UserAuthenticator.authenticate(user, "1234", :admin_api) ==
+               {:error, :token_not_found}
     end
 
     test "return false if the given user is nil" do
       user = insert(:user)
 
-      assert UserAuthenticator.authenticate(user, nil, :admin_api) == false
+      assert UserAuthenticator.authenticate(user, nil, :admin_api) == {:error, :token_not_found}
     end
 
     test "return false if the given token is nil" do
-      assert UserAuthenticator.authenticate(nil, "1234", :admin_api) == false
+      assert UserAuthenticator.authenticate(nil, "1234", :admin_api) == {:error, :token_not_found}
     end
   end
 

--- a/apps/ewallet_api/lib/ewallet_api/v1/auth/client_auth.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/auth/client_auth.ex
@@ -79,15 +79,20 @@ defmodule EWalletAPI.V1.ClientAuth do
         |> Map.put(:authenticated, true)
         |> Map.put(:end_user, user)
 
-      false ->
+      {:error, :token_not_found} ->
         auth
         |> Map.put(:authenticated, false)
         |> Map.put(:auth_error, :auth_token_not_found)
 
-      :token_expired ->
+      {:error, :token_expired} ->
         auth
         |> Map.put(:authenticated, false)
         |> Map.put(:auth_error, :auth_token_expired)
+
+      {:error, changeset} ->
+        auth
+        |> Map.put(:authenticated, false)
+        |> Map.put(:auth_error, changeset)
     end
   end
 end

--- a/apps/ewallet_api/test/ewallet_api/v1/auth/client_auth_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/auth/client_auth_test.exs
@@ -64,7 +64,7 @@ defmodule EWalletAPI.V1.ClientAuthTest do
       assert auth[:end_user] == nil
     end
 
-    test "halts with :auth_token_not_found if auth_token is missing", meta do
+    test "halts with {:error, :auth_token_not_found} if auth_token is missing", meta do
       auth = auth_header(meta.api_key.key, "")
 
       assert auth.authenticated == false
@@ -72,7 +72,7 @@ defmodule EWalletAPI.V1.ClientAuthTest do
       assert auth[:end_user] == nil
     end
 
-    test "halts with :auth_token_not_found if auth_token is incorrect", meta do
+    test "halts with {:error, :auth_token_not_found} if auth_token is incorrect", meta do
       auth = auth_header(meta.api_key.key, "abc")
 
       assert auth.authenticated == false

--- a/apps/ewallet_api/test/ewallet_api/v1/plugs/client_auth_plug_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/plugs/client_auth_plug_test.exs
@@ -89,7 +89,7 @@ defmodule EWalletAPI.V1.ClientAuthPlugTest do
       # the typical unauthenticated flow. Expiring a token should be treated
       # as a successful authenticated call but with all auth info invalidated.
       refute conn.halted
-      assert AuthToken.authenticate(@auth_token, :ewallet_api) == :token_expired
+      assert AuthToken.authenticate(@auth_token, :ewallet_api) == {:error, :token_expired}
       refute conn.assigns[:authenticated]
       refute conn.assigns[:end_user]
     end

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -64,15 +64,15 @@ config :ewallet_config,
       position: 105,
       description: "The duration (in minutes) that a forget password request will be valid for."
     },
-    "auth_token_lifetime" => %{
-      key: "auth_token_lifetime",
+    "atk_lifetime" => %{
+      key: "atk_lifetime",
       value: 0,
       type: "unsigned_integer",
       position: 106,
       description: "The duration (in seconds) that an auth token will be valid for."
     },
-    "pre_auth_token_lifetime" => %{
-      key: "pre_auth_token_lifetime",
+    "ptk_lifetime" => %{
+      key: "ptk_lifetime",
       value: 0,
       type: "unsigned_integer",
       position: 107,

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -64,18 +64,32 @@ config :ewallet_config,
       position: 105,
       description: "The duration (in minutes) that a forget password request will be valid for."
     },
+    "auth_token_lifetime" => %{
+      key: "auth_token_lifetime",
+      value: 60 * 24,
+      type: "unsigned_integer",
+      position: 106,
+      description: "The duration (in minutes) that an auth token will be valid for."
+    },
+    "pre_auth_token_lifetime" => %{
+      key: "pre_auth_token_lifetime",
+      value: 60 * 24,
+      type: "unsigned_integer",
+      position: 107,
+      description: "The duration (in minutes) that a pre auth token will be valid for."
+    },
     "number_of_backup_codes" => %{
       key: "number_of_backup_codes",
       value: 10,
       type: "unsigned_integer",
-      position: 106,
+      position: 108,
       description: "The number of backup codes for the two-factor authentication."
     },
     "two_fa_issuer" => %{
       key: "two_fa_issuer",
       value: "OmiseGO",
       type: "string",
-      position: 107,
+      position: 109,
       description:
         "The issuer for the two-factor authentication, which will be displayed the OTP app."
     },

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -66,17 +66,17 @@ config :ewallet_config,
     },
     "auth_token_lifetime" => %{
       key: "auth_token_lifetime",
-      value: 60 * 24,
+      value: 60,
       type: "unsigned_integer",
       position: 106,
-      description: "The duration (in minutes) that an auth token will be valid for."
+      description: "The duration (in seconds) that an auth token will be valid for."
     },
     "pre_auth_token_lifetime" => %{
       key: "pre_auth_token_lifetime",
-      value: 60 * 24,
+      value: 60,
       type: "unsigned_integer",
       position: 107,
-      description: "The duration (in minutes) that a pre auth token will be valid for."
+      description: "The duration (in seconds) that a pre auth token will be valid for."
     },
     "number_of_backup_codes" => %{
       key: "number_of_backup_codes",

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -69,14 +69,16 @@ config :ewallet_config,
       value: 0,
       type: "unsigned_integer",
       position: 106,
-      description: "The duration (in seconds) that an auth token will be valid for. Set to 0 to never expire an auth token."
+      description:
+        "The duration (in seconds) that an auth token will be valid for. Set to 0 to never expire an auth token."
     },
     "pre_auth_token_lifetime" => %{
       key: "pre_auth_token_lifetime",
       value: 0,
       type: "unsigned_integer",
       position: 107,
-      description: "The duration (in seconds) that a pre auth token will be valid for. Set to 0 to never expire a pre auth token."
+      description:
+        "The duration (in seconds) that a pre auth token will be valid for. Set to 0 to never expire a pre auth token."
     },
     "number_of_backup_codes" => %{
       key: "number_of_backup_codes",

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -66,14 +66,14 @@ config :ewallet_config,
     },
     "auth_token_lifetime" => %{
       key: "auth_token_lifetime",
-      value: 60,
+      value: 0,
       type: "unsigned_integer",
       position: 106,
       description: "The duration (in seconds) that an auth token will be valid for."
     },
     "pre_auth_token_lifetime" => %{
       key: "pre_auth_token_lifetime",
-      value: 60,
+      value: 0,
       type: "unsigned_integer",
       position: 107,
       description: "The duration (in seconds) that a pre auth token will be valid for."

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -69,14 +69,14 @@ config :ewallet_config,
       value: 0,
       type: "unsigned_integer",
       position: 106,
-      description: "The duration (in seconds) that an auth token will be valid for."
+      description: "The duration (in seconds) that an auth token will be valid for. Set to 0 to never expire an auth token."
     },
     "pre_auth_token_lifetime" => %{
       key: "pre_auth_token_lifetime",
       value: 0,
       type: "unsigned_integer",
       position: 107,
-      description: "The duration (in seconds) that a pre auth token will be valid for."
+      description: "The duration (in seconds) that a pre auth token will be valid for. Set to 0 to never expire a pre auth token."
     },
     "number_of_backup_codes" => %{
       key: "number_of_backup_codes",

--- a/apps/ewallet_config/config/config.exs
+++ b/apps/ewallet_config/config/config.exs
@@ -64,15 +64,15 @@ config :ewallet_config,
       position: 105,
       description: "The duration (in minutes) that a forget password request will be valid for."
     },
-    "atk_lifetime" => %{
-      key: "atk_lifetime",
+    "auth_token_lifetime" => %{
+      key: "auth_token_lifetime",
       value: 0,
       type: "unsigned_integer",
       position: 106,
       description: "The duration (in seconds) that an auth token will be valid for."
     },
-    "ptk_lifetime" => %{
-      key: "ptk_lifetime",
+    "pre_auth_token_lifetime" => %{
+      key: "pre_auth_token_lifetime",
       value: 0,
       type: "unsigned_integer",
       position: 107,

--- a/apps/ewallet_db/config/config.exs
+++ b/apps/ewallet_db/config/config.exs
@@ -14,8 +14,8 @@ config :ewallet_db,
     :gcs_bucket,
     :gcs_credentials,
     :master_account,
-    :ptk_lifetime,
-    :atk_lifetime
+    :pre_auth_token_lifetime,
+    :auth_token_lifetime
   ]
 
 config :ewallet_db, EWalletDB.Repo,

--- a/apps/ewallet_db/config/config.exs
+++ b/apps/ewallet_db/config/config.exs
@@ -13,7 +13,9 @@ config :ewallet_db,
     :aws_secret_access_key,
     :gcs_bucket,
     :gcs_credentials,
-    :master_account
+    :master_account,
+    :ptk_lifetime,
+    :atk_lifetime
   ]
 
 config :ewallet_db, EWalletDB.Repo,

--- a/apps/ewallet_db/lib/ewallet_db/auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/auth_token.ex
@@ -123,7 +123,10 @@ defmodule EWalletDB.AuthToken do
   or false otherwise.
   """
   @spec authenticate(String.t(), atom()) ::
-          User.t() | false | {:error, Changeset.t()} | :token_expired
+          User.t()
+          | {:error, :token_not_found}
+          | {:error, :token_expired}
+          | {:error, Changeset.t()}
   def authenticate(token, owner_app) when is_atom(owner_app) do
     token
     |> get_by_token(owner_app)
@@ -132,8 +135,11 @@ defmodule EWalletDB.AuthToken do
   end
 
   @spec authenticate(String.t(), String.t(), atom()) ::
-          User.t() | false | {:error, Changeset.t()} | :token_expired
-  def authenticate(user_id, token, owner_app) when token != nil and is_atom(owner_app) do
+          User.t()
+          | {:error, :token_not_found}
+          | {:error, :token_expired}
+          | {:error, Changeset.t()}
+  def authenticate(user_id, token, owner_app) when is_atom(owner_app) do
     user_id
     |> get_by_user(owner_app)
     |> compare_multiple(token)
@@ -142,6 +148,8 @@ defmodule EWalletDB.AuthToken do
   end
 
   def authenticate(_, _, _), do: Crypto.fake_verify()
+
+  defp compare_multiple(_, nil), do: nil
 
   defp compare_multiple(token_records, token) when is_list(token_records) do
     Enum.find(token_records, fn record ->
@@ -152,13 +160,13 @@ defmodule EWalletDB.AuthToken do
   defp return_user(token) do
     case token do
       nil ->
-        false
+        {:error, :token_not_found}
 
       {:error, changeset} ->
         {:error, changeset}
 
       %{expired: true} ->
-        :token_expired
+        {:error, :token_expired}
 
       token ->
         token

--- a/apps/ewallet_db/lib/ewallet_db/auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/auth_token.ex
@@ -192,6 +192,7 @@ defmodule EWalletDB.AuthToken do
 
   defp get_by_user(_, _), do: nil
 
+  @spec get_lifetime() :: integer
   def get_lifetime, do: Application.get_env(:ewallet_db, :atk_lifetime, 0)
 
   # `insert/1` is private to prohibit direct auth token insertion,
@@ -203,6 +204,7 @@ defmodule EWalletDB.AuthToken do
   end
 
   # Expires the given token.
+  @spec expire(EWalletDB.AuthToken.t(), any(), any()) :: {:error, any()} | {:ok, any()}
   def expire(token, owner_app, originator) when is_binary(token) and is_atom(owner_app) do
     token
     |> get_by_token(owner_app)
@@ -232,6 +234,7 @@ defmodule EWalletDB.AuthToken do
     :ok
   end
 
+  @spec refresh(EWalletDB.AuthToken.t(), any) :: {:error, any} | {:ok, any}
   def refresh(%AuthToken{} = token, originator) do
     update(token, %{
       expired: false,
@@ -243,6 +246,7 @@ defmodule EWalletDB.AuthToken do
   @doc """
   Delete all AuthTokens associated with the user.
   """
+  @spec delete_for_user(User.t()) :: :ok
   def delete_for_user(user) do
     Repo.delete_all(
       from(

--- a/apps/ewallet_db/lib/ewallet_db/auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/auth_token.ex
@@ -109,7 +109,7 @@ defmodule EWalletDB.AuthToken do
       owner_app: Atom.to_string(owner_app),
       user_uuid: user.uuid,
       account_uuid: nil,
-      expire_at: get_lifetime() |> AuthExpirer.get_new_expire_at(),
+      expire_at: get_lifetime() |> AuthExpirer.postpone_expire_at(),
       token: Crypto.generate_base64_key(@key_length),
       originator: originator
     }
@@ -236,7 +236,7 @@ defmodule EWalletDB.AuthToken do
 
   def refresh(%AuthToken{} = token, originator) do
     update(token, %{
-      expire_at: get_lifetime() |> AuthExpirer.get_new_expire_at(),
+      expire_at: get_lifetime() |> AuthExpirer.postpone_expire_at(),
       originator: originator
     })
   end

--- a/apps/ewallet_db/lib/ewallet_db/auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/auth_token.ex
@@ -53,7 +53,7 @@ defmodule EWalletDB.AuthToken do
     )
 
     field(:expired, :boolean)
-    field(:expire_at, :naive_datetime_usec)
+    field(:expired_at, :naive_datetime_usec)
     timestamps()
     activity_logging()
   end
@@ -62,7 +62,7 @@ defmodule EWalletDB.AuthToken do
     token
     |> cast_and_validate_required_for_activity_log(
       attrs,
-      cast: [:token, :owner_app, :user_uuid, :account_uuid, :expired, :expire_at],
+      cast: [:token, :owner_app, :user_uuid, :account_uuid, :expired, :expired_at],
       required: [:token, :owner_app, :user_uuid]
     )
     |> unique_constraint(:token)
@@ -73,7 +73,7 @@ defmodule EWalletDB.AuthToken do
     token
     |> cast_and_validate_required_for_activity_log(
       attrs,
-      cast: [:expired, :expire_at],
+      cast: [:expired, :expired_at],
       required: [:expired]
     )
   end
@@ -108,7 +108,7 @@ defmodule EWalletDB.AuthToken do
       owner_app: Atom.to_string(owner_app),
       user_uuid: user.uuid,
       account_uuid: nil,
-      expire_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),
+      expired_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),
       token: Crypto.generate_base64_key(@key_length),
       originator: originator
     }
@@ -206,7 +206,7 @@ defmodule EWalletDB.AuthToken do
   defp get_by_user(_, _), do: nil
 
   @spec get_lifetime() :: integer
-  def get_lifetime, do: Application.get_env(:ewallet_db, :atk_lifetime, 0)
+  def get_lifetime, do: Application.get_env(:ewallet_db, :auth_token_lifetime, 0)
 
   # `insert/1` is private to prohibit direct auth token insertion,
   # please use `generate/2` instead.
@@ -250,7 +250,7 @@ defmodule EWalletDB.AuthToken do
   def refresh(%AuthToken{} = token, originator) do
     update(token, %{
       expired: false,
-      expire_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),
+      expired_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),
       originator: originator
     })
   end

--- a/apps/ewallet_db/lib/ewallet_db/auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/auth_token.ex
@@ -102,7 +102,7 @@ defmodule EWalletDB.AuthToken do
   Generate an auth token for the specified user,
   then returns the auth token string.
   """
-  @spec generate(User.t(), atom(), any()) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
+  @spec generate(%User{}, atom(), any()) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def generate(%User{} = user, owner_app, originator) when is_atom(owner_app) do
     %{
       owner_app: Atom.to_string(owner_app),
@@ -123,10 +123,10 @@ defmodule EWalletDB.AuthToken do
   or false otherwise.
   """
   @spec authenticate(String.t(), atom()) ::
-          User.t()
+          %User{}
           | {:error, :token_not_found}
           | {:error, :token_expired}
-          | {:error, Changeset.t()}
+          | {:error, Ecto.Changeset.t()}
   def authenticate(token, owner_app) when is_atom(owner_app) do
     token
     |> get_by_token(owner_app)
@@ -135,10 +135,10 @@ defmodule EWalletDB.AuthToken do
   end
 
   @spec authenticate(String.t(), String.t(), atom()) ::
-          User.t()
+          %User{}
           | {:error, :token_not_found}
           | {:error, :token_expired}
-          | {:error, Changeset.t()}
+          | {:error, Ecto.Changeset.t()}
   def authenticate(user_id, token, owner_app) when is_atom(owner_app) do
     user_id
     |> get_by_user(owner_app)
@@ -217,7 +217,7 @@ defmodule EWalletDB.AuthToken do
   end
 
   # Expires the given token.
-  @spec expire(String.t(), atom(), any()) :: {:ok, %__MODULE__{}} | {:error, Changeset.t()}
+  @spec expire(String.t(), atom(), any()) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   def expire(token, owner_app, originator) when is_binary(token) and is_atom(owner_app) do
     token
     |> get_by_token(owner_app)
@@ -231,7 +231,7 @@ defmodule EWalletDB.AuthToken do
     })
   end
 
-  @spec expire_for_user(atom() | User.t()) :: :ok
+  @spec expire_for_user(atom() | %User{}) :: :ok
   def expire_for_user(%{enabled: true}), do: :ok
 
   def expire_for_user(user) do
@@ -246,7 +246,7 @@ defmodule EWalletDB.AuthToken do
     :ok
   end
 
-  @spec refresh(%__MODULE__{}, any()) :: {:ok, %__MODULE__{}} | {:error, Changeset.t()}
+  @spec refresh(%__MODULE__{}, any()) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   def refresh(%AuthToken{} = token, originator) do
     update(:refresh, token, %{
       expired: false,
@@ -258,7 +258,7 @@ defmodule EWalletDB.AuthToken do
   @doc """
   Delete all AuthTokens associated with the user.
   """
-  @spec delete_for_user(User.t()) :: :ok
+  @spec delete_for_user(%User{}) :: :ok
   def delete_for_user(user) do
     Repo.delete_all(
       from(

--- a/apps/ewallet_db/lib/ewallet_db/auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/auth_token.ex
@@ -192,8 +192,7 @@ defmodule EWalletDB.AuthToken do
 
   defp get_by_user(_, _), do: nil
 
-  # def get_lifetime(), do: Setting.get(@key_atk_lifetime).value
-  def get_lifetime, do: Application.get_env(:ewallet, :atk_lifetime, 0)
+  def get_lifetime, do: Application.get_env(:ewallet_db, :atk_lifetime, 0)
 
   # `insert/1` is private to prohibit direct auth token insertion,
   # please use `generate/2` instead.

--- a/apps/ewallet_db/lib/ewallet_db/auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/auth_token.ex
@@ -125,7 +125,7 @@ defmodule EWalletDB.AuthToken do
     token
     |> get_by_token(owner_app)
     |> AuthExpirer.expire_or_refresh(get_lifetime())
-    |> return_token_if_valid()
+    |> return_user()
   end
 
   def authenticate(user_id, token, owner_app) when token != nil and is_atom(owner_app) do
@@ -133,7 +133,7 @@ defmodule EWalletDB.AuthToken do
     |> get_by_user(owner_app)
     |> compare_multiple(token)
     |> AuthExpirer.expire_or_refresh(get_lifetime())
-    |> return_token_if_valid()
+    |> return_user()
   end
 
   def authenticate(_, _, _), do: Crypto.fake_verify()
@@ -144,13 +144,13 @@ defmodule EWalletDB.AuthToken do
     end)
   end
 
-  defp return_token_if_valid(token) do
+  defp return_user(token) do
     case token do
       nil ->
         false
 
-      {:error, _} ->
-        false
+      {:error, err} ->
+        {:error, err}
 
       %{expired: true} ->
         :token_expired

--- a/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
@@ -1,0 +1,77 @@
+# Copyright 2018-2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWalletDB.Expirers.AuthExpirer do
+  @moduledoc """
+  Manages the expiration time of `AuthToken` or `PreAuthToken`.
+  """
+
+  alias EWalletDB.{AuthToken, PreAuthToken}
+
+  def get_new_expire_at(0), do: nil
+
+  def get_new_expire_at(lifetime) do
+    NaiveDateTime.add(NaiveDateTime.utc_now(), lifetime, :second)
+  end
+
+  def expire_or_refresh(nil, _), do: nil
+
+  def expire_or_refresh(token, lifetime) do
+    case lifetime do
+      0 ->
+        token
+      _ ->
+        expire_or_refresh(:ok, token, token.expire_at || get_new_expire_at(lifetime))
+    end
+  end
+
+  defp expire_or_refresh(:ok, token, expire_at) do
+    NaiveDateTime.utc_now()
+    |> NaiveDateTime.compare(expire_at)
+    |> do_expire_or_refresh(token)
+    |> handle_result()
+  end
+
+  defp do_expire_or_refresh(:lt, token) do
+    refresh(token)
+  end
+
+  defp do_expire_or_refresh(_, token) do
+    expire(token)
+  end
+
+  defp refresh(%AuthToken{} = token) do
+    AuthToken.refresh(token, token.user)
+  end
+
+  defp refresh(%PreAuthToken{} = token) do
+    PreAuthToken.refresh(token, token.user)
+  end
+
+  defp expire(%AuthToken{} = token) do
+    AuthToken.expire(token, token.user)
+  end
+
+  defp expire(%PreAuthToken{} = token) do
+    PreAuthToken.expire(token, token.user)
+  end
+
+  defp handle_result({:ok, updated_token}) do
+    updated_token
+  end
+
+  defp handle_result(error) do
+    error
+  end
+end

--- a/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
@@ -51,20 +51,20 @@ defmodule EWalletDB.Expirers.AuthExpirer do
     expire(token)
   end
 
-  defp refresh(%AuthToken{} = token) do
-    AuthToken.refresh(token, token.user)
-  end
-
-  defp refresh(%PreAuthToken{} = token) do
-    PreAuthToken.refresh(token, token.user)
-  end
-
   defp expire(%AuthToken{} = token) do
     AuthToken.expire(token, token.user)
   end
 
   defp expire(%PreAuthToken{} = token) do
     PreAuthToken.expire(token, token.user)
+  end
+
+  defp refresh(%AuthToken{} = token) do
+    AuthToken.refresh(token, token.user)
+  end
+
+  defp refresh(%PreAuthToken{} = token) do
+    PreAuthToken.refresh(token, token.user)
   end
 
   defp handle_result({:ok, updated_token}) do

--- a/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
@@ -19,12 +19,21 @@ defmodule EWalletDB.Expirers.AuthExpirer do
 
   alias EWalletDB.{AuthToken, PreAuthToken}
 
-  def postpone_expire_at(0), do: nil
+  @doc """
+  Adds a specified amount of time (in second) to a NaiveDateTime.utc_now().
 
-  def postpone_expire_at(configured_auth_token_lifetime) do
-    NaiveDateTime.add(NaiveDateTime.utc_now(), configured_auth_token_lifetime, :second)
+  If a specified amount of time is zero, then return nil.
+  """
+  def get_advanced_datetime(0), do: nil
+
+  def get_advanced_datetime(second) do
+    NaiveDateTime.add(NaiveDateTime.utc_now(), second, :second)
   end
 
+  @doc """
+  Expire a given AuthToken or PreAuthToken if the datetime from `expire_at` field has been lapse.
+  Otherwise, extend the `expire_at` by a given time in second.
+  """
   def expire_or_refresh(nil, _), do: nil
 
   def expire_or_refresh(token, configured_auth_token_lifetime) do
@@ -36,7 +45,7 @@ defmodule EWalletDB.Expirers.AuthExpirer do
         expire_or_refresh(
           :ok,
           token,
-          token.expire_at || postpone_expire_at(configured_auth_token_lifetime)
+          token.expire_at || get_advanced_datetime(configured_auth_token_lifetime)
         )
     end
   end

--- a/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
@@ -19,21 +19,25 @@ defmodule EWalletDB.Expirers.AuthExpirer do
 
   alias EWalletDB.{AuthToken, PreAuthToken}
 
-  def get_new_expire_at(0), do: nil
+  def postpone_expire_at(0), do: nil
 
-  def get_new_expire_at(lifetime) do
-    NaiveDateTime.add(NaiveDateTime.utc_now(), lifetime, :second)
+  def postpone_expire_at(configured_auth_token_lifetime) do
+    NaiveDateTime.add(NaiveDateTime.utc_now(), configured_auth_token_lifetime, :second)
   end
 
   def expire_or_refresh(nil, _), do: nil
 
-  def expire_or_refresh(token, lifetime) do
-    case lifetime do
+  def expire_or_refresh(token, configured_auth_token_lifetime) do
+    case configured_auth_token_lifetime do
       0 ->
         token
 
       _ ->
-        expire_or_refresh(:ok, token, token.expire_at || get_new_expire_at(lifetime))
+        expire_or_refresh(
+          :ok,
+          token,
+          token.expire_at || postpone_expire_at(configured_auth_token_lifetime)
+        )
     end
   end
 

--- a/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
@@ -24,6 +24,7 @@ defmodule EWalletDB.Expirers.AuthExpirer do
 
   If a specified amount of time is zero, then return nil.
   """
+  @spec get_advanced_datetime(integer) :: NaiveDateTime.t() | nil
   def get_advanced_datetime(0), do: nil
 
   def get_advanced_datetime(second) do
@@ -34,6 +35,8 @@ defmodule EWalletDB.Expirers.AuthExpirer do
   Expire a given AuthToken or PreAuthToken if the datetime from `expire_at` field has been lapse.
   Otherwise, extend the `expire_at` by a given time in second.
   """
+  @spec expire_or_refresh(AuthToken.t() | PreAuthToken.t(), integer) ::
+          AuthToken.t() | PreAuthToken.t()
   def expire_or_refresh(nil, _), do: nil
 
   def expire_or_refresh(token, configured_auth_token_lifetime) do

--- a/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
@@ -31,6 +31,7 @@ defmodule EWalletDB.Expirers.AuthExpirer do
     case lifetime do
       0 ->
         token
+
       _ ->
         expire_or_refresh(:ok, token, token.expire_at || get_new_expire_at(lifetime))
     end

--- a/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
+++ b/apps/ewallet_db/lib/ewallet_db/expirers/auth_expirer.ex
@@ -41,16 +41,15 @@ defmodule EWalletDB.Expirers.AuthExpirer do
 
   def expire_or_refresh(token, configured_auth_token_lifetime) do
     cond do
-      configured_auth_token_lifetime != 0 or not is_nil(token.expired_at)->
+      configured_auth_token_lifetime != 0 or not is_nil(token.expired_at) ->
         expire_or_refresh(
           :ok,
           token,
           token.expired_at || get_advanced_datetime(configured_auth_token_lifetime)
         )
 
-    true ->
+      true ->
         token
-
     end
   end
 

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -102,7 +102,8 @@ defmodule EWalletDB.PreAuthToken do
   Returns the associated user if authenticated, :token_expired if token exists but expired,
   or false otherwise.
   """
-  @spec authenticate(String.t(), any) :: false | nil | :token_expired | [%{optional(atom) => any}] | %{optional(atom) => any}
+  @spec authenticate(String.t(), any) ::
+          false | nil | :token_expired | [%{optional(atom) => any}] | %{optional(atom) => any}
   def authenticate(token, owner_app) when is_atom(owner_app) do
     token
     |> get_by_token(owner_app)

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -219,9 +219,6 @@ defmodule EWalletDB.PreAuthToken do
     })
   end
 
-<<<<<<< HEAD
-  # `update/2` is private to prohibit direct auth token updates,
-=======
   def delete_for_user(user) do
     Repo.delete_all(
       from(
@@ -233,8 +230,6 @@ defmodule EWalletDB.PreAuthToken do
     :ok
   end
 
-  # `update/2` is private to prohibit direct pre auth token updates,
->>>>>>> :white_check_mark: Add test for AuthExpirer
   # if expiring the token, please use `expire/2` instead.
   defp update(%PreAuthToken{} = token, attrs) do
     token

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -99,7 +99,7 @@ defmodule EWalletDB.PreAuthToken do
   def generate(_, _, _), do: {:error, :invalid_parameter}
 
   @doc """
-  Retrieves an auth token using the specified token.
+  Retrieves a pre auth token using the specified token.
   Returns the associated user if authenticated, :token_expired if token exists but expired,
   or false otherwise.
   """
@@ -154,7 +154,7 @@ defmodule EWalletDB.PreAuthToken do
 
   def get_by_token(_, _), do: nil
 
-  # `get_by_user/2` is private to prohibit direct auth token access,
+  # `get_by_user/2` is private to prohibit direct pre auth token access,
   # please use `authenticate/3` instead.
   defp get_by_user(user_id, owner_app) when is_binary(user_id) and is_atom(owner_app) do
     auth_tokens =
@@ -174,7 +174,7 @@ defmodule EWalletDB.PreAuthToken do
 
   def get_lifetime(), do: Setting.get(@key_ptk_lifetime).value
 
-  # `insert/1` is private to prohibit direct auth token insertion,
+  # `insert/1` is private to prohibit direct pre auth token insertion,
   # please use `generate/2` instead.
   defp insert(attrs) do
     %PreAuthToken{}
@@ -182,7 +182,6 @@ defmodule EWalletDB.PreAuthToken do
     |> Repo.insert_record_with_activity_log()
   end
 
-<<<<<<< HEAD
   @doc """
   Delete all PreAuthTokens associated with the user.
   """
@@ -197,35 +196,6 @@ defmodule EWalletDB.PreAuthToken do
     :ok
   end
 
-  defp expire_or_refresh(%PreAuthToken{expire_at: nil} = token), do: token
-
-  defp expire_or_refresh(%PreAuthToken{expire_at: expire_at} = token) do
-    result =
-      NaiveDateTime.utc_now()
-      |> NaiveDateTime.compare(expire_at)
-      |> do_expire_or_refresh(token)
-
-    case result do
-      {:ok, updated_token} ->
-        updated_token
-
-      error ->
-        error
-    end
-  end
-
-  defp expire_or_refresh(_), do: nil
-
-  defp do_expire_or_refresh(:lt, token) do
-    refresh(token, token.user)
-  end
-
-  defp do_expire_or_refresh(_, token) do
-    expire(token, token.user)
-  end
-
-=======
->>>>>>> :hammer: Extract expiration logic to AuthExpirer
   # Expires the given token.
   @spec expire(binary(), atom(), any()) :: {:error, any()} | {:ok, any()}
   def expire(token, owner_app, originator) when is_binary(token) and is_atom(owner_app) do
@@ -249,7 +219,22 @@ defmodule EWalletDB.PreAuthToken do
     })
   end
 
+<<<<<<< HEAD
   # `update/2` is private to prohibit direct auth token updates,
+=======
+  def delete_for_user(user) do
+    Repo.delete_all(
+      from(
+        a in PreAuthToken,
+        where: a.user_uuid == ^user.uuid
+      )
+    )
+
+    :ok
+  end
+
+  # `update/2` is private to prohibit direct pre auth token updates,
+>>>>>>> :white_check_mark: Add test for AuthExpirer
   # if expiring the token, please use `expire/2` instead.
   defp update(%PreAuthToken{} = token, attrs) do
     token

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -82,6 +82,7 @@ defmodule EWalletDB.PreAuthToken do
   Generate a pre auth token for the specified user to be used for verify two-factor auth,
   then returns the pre auth token string.
   """
+  @spec generate(User.t(), any(), any()) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def generate(%User{} = user, owner_app, originator) when is_atom(owner_app) do
     %{
       owner_app: Atom.to_string(owner_app),
@@ -101,6 +102,7 @@ defmodule EWalletDB.PreAuthToken do
   Returns the associated user if authenticated, :token_expired if token exists but expired,
   or false otherwise.
   """
+  @spec authenticate(String.t(), any) :: false | nil | :token_expired | [%{optional(atom) => any}] | %{optional(atom) => any}
   def authenticate(token, owner_app) when is_atom(owner_app) do
     token
     |> get_by_token(owner_app)
@@ -108,6 +110,8 @@ defmodule EWalletDB.PreAuthToken do
     |> return_token_if_valid()
   end
 
+  @spec authenticate(String.t(), String.t(), any) ::
+          false | nil | :token_expired | [%{optional(atom) => any}] | %{optional(atom) => any}
   def authenticate(user_id, token, owner_app) when token != nil and is_atom(owner_app) do
     user_id
     |> get_by_user(owner_app)
@@ -171,6 +175,7 @@ defmodule EWalletDB.PreAuthToken do
   defp get_by_user(_, _), do: nil
 
   # def get_lifetime(), do: Setting.get(@key_ptk_lifetime).value
+  @spec get_lifetime :: integer
   def get_lifetime, do: Application.get_env(:ewallet_db, :ptk_lifetime, 0)
 
   # `insert/1` is private to prohibit direct pre auth token insertion,
@@ -184,6 +189,7 @@ defmodule EWalletDB.PreAuthToken do
   @doc """
   Delete all PreAuthTokens associated with the user.
   """
+  @spec delete_for_user(User.t()) :: :ok
   def delete_for_user(user) do
     Repo.delete_all(
       from(
@@ -211,6 +217,7 @@ defmodule EWalletDB.PreAuthToken do
     })
   end
 
+  @spec refresh(EWalletDB.PreAuthToken.t(), any) :: {:error, any} | {:ok, any}
   def refresh(%PreAuthToken{} = token, originator) do
     update(token, %{
       expire_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -53,7 +53,7 @@ defmodule EWalletDB.PreAuthToken do
     )
 
     field(:expired, :boolean)
-    field(:expire_at, :naive_datetime_usec)
+    field(:expired_at, :naive_datetime_usec)
     timestamps()
     activity_logging()
   end
@@ -62,7 +62,7 @@ defmodule EWalletDB.PreAuthToken do
     token
     |> cast_and_validate_required_for_activity_log(
       attrs,
-      cast: [:token, :owner_app, :user_uuid, :account_uuid, :expired, :expire_at],
+      cast: [:token, :owner_app, :user_uuid, :account_uuid, :expired, :expired_at],
       required: [:token, :owner_app, :user_uuid]
     )
     |> unique_constraint(:token)
@@ -73,7 +73,7 @@ defmodule EWalletDB.PreAuthToken do
     token
     |> cast_and_validate_required_for_activity_log(
       attrs,
-      cast: [:expired, :expire_at],
+      cast: [:expired, :expired_at],
       required: [:expired]
     )
   end
@@ -88,7 +88,7 @@ defmodule EWalletDB.PreAuthToken do
       owner_app: Atom.to_string(owner_app),
       user_uuid: user.uuid,
       account_uuid: nil,
-      expire_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),
+      expired_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),
       token: Crypto.generate_base64_key(@key_length),
       originator: originator
     }
@@ -184,7 +184,7 @@ defmodule EWalletDB.PreAuthToken do
   defp get_by_user(_, _), do: nil
 
   @spec get_lifetime :: integer
-  def get_lifetime, do: Application.get_env(:ewallet_db, :ptk_lifetime, 0)
+  def get_lifetime, do: Application.get_env(:ewallet_db, :pre_auth_token_lifetime, 0)
 
   # `insert/1` is private to prohibit direct pre auth token insertion,
   # please use `generate/2` instead.
@@ -227,7 +227,7 @@ defmodule EWalletDB.PreAuthToken do
   @spec refresh(%__MODULE__{}, any()) :: {:ok, %__MODULE__{}} | {:error, Changeset.t()}
   def refresh(%PreAuthToken{} = token, originator) do
     update(token, %{
-      expire_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),
+      expired_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),
       originator: originator
     })
   end

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -106,7 +106,7 @@ defmodule EWalletDB.PreAuthToken do
           %__MODULE__{}
           | {:error, :token_not_found}
           | {:error, :token_expired}
-          | {:error, Changeset.t()}
+          | {:error, Ecto.Changeset.t()}
   def authenticate(token, owner_app) when is_atom(owner_app) do
     token
     |> get_by_token(owner_app)
@@ -118,7 +118,7 @@ defmodule EWalletDB.PreAuthToken do
           %__MODULE__{}
           | {:error, :token_not_found}
           | {:error, :token_expired}
-          | {:error, Changeset.t()}
+          | {:error, Ecto.Changeset.t()}
   def authenticate(user_id, token, owner_app) when is_atom(owner_app) do
     user_id
     |> get_by_user(owner_app)
@@ -224,7 +224,7 @@ defmodule EWalletDB.PreAuthToken do
     })
   end
 
-  @spec refresh(%__MODULE__{}, any()) :: {:ok, %__MODULE__{}} | {:error, Changeset.t()}
+  @spec refresh(%__MODULE__{}, any()) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   def refresh(%PreAuthToken{} = token, originator) do
     update(:refresh, token, %{
       expired_at: get_lifetime() |> AuthExpirer.get_advanced_datetime(),

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -89,7 +89,7 @@ defmodule EWalletDB.PreAuthToken do
       owner_app: Atom.to_string(owner_app),
       user_uuid: user.uuid,
       account_uuid: nil,
-      expire_at: get_lifetime() |> AuthExpirer.get_new_expire_at(),
+      expire_at: get_lifetime() |> AuthExpirer.postpone_expire_at(),
       token: Crypto.generate_base64_key(@key_length),
       originator: originator
     }
@@ -214,7 +214,7 @@ defmodule EWalletDB.PreAuthToken do
 
   def refresh(%PreAuthToken{} = token, originator) do
     update(token, %{
-      expire_at: get_lifetime() |> AuthExpirer.get_new_expire_at(),
+      expire_at: get_lifetime() |> AuthExpirer.postpone_expire_at(),
       originator: originator
     })
   end

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -183,7 +183,6 @@ defmodule EWalletDB.PreAuthToken do
 
   defp get_by_user(_, _), do: nil
 
-  # def get_lifetime(), do: Setting.get(@key_ptk_lifetime).value
   @spec get_lifetime :: integer
   def get_lifetime, do: Application.get_env(:ewallet_db, :ptk_lifetime, 0)
 

--- a/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
+++ b/apps/ewallet_db/lib/ewallet_db/pre_auth_token.ex
@@ -171,7 +171,7 @@ defmodule EWalletDB.PreAuthToken do
   defp get_by_user(_, _), do: nil
 
   # def get_lifetime(), do: Setting.get(@key_ptk_lifetime).value
-  def get_lifetime, do: Application.get_env(:ewallet, :ptk_lifetime, 0)
+  def get_lifetime, do: Application.get_env(:ewallet_db, :ptk_lifetime, 0)
 
   # `insert/1` is private to prohibit direct pre auth token insertion,
   # please use `generate/2` instead.

--- a/apps/ewallet_db/priv/repo/migrations/20190426083108_add_expire_at_to_auth_tokens.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20190426083108_add_expire_at_to_auth_tokens.exs
@@ -1,0 +1,9 @@
+defmodule EWalletDB.Repo.Migrations.AddExpireAtToAuthTokens do
+  use Ecto.Migration
+
+  def change do
+    alter table(:auth_token) do
+      add :expire_at, :naive_datetime_usec, null: true
+    end
+  end
+end

--- a/apps/ewallet_db/priv/repo/migrations/20190426083108_add_expire_at_to_auth_tokens.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20190426083108_add_expire_at_to_auth_tokens.exs
@@ -3,7 +3,7 @@ defmodule EWalletDB.Repo.Migrations.AddExpireAtToAuthTokens do
 
   def change do
     alter table(:auth_token) do
-      add :expire_at, :naive_datetime_usec, null: true
+      add :expired_at, :naive_datetime_usec, null: true
     end
   end
 end

--- a/apps/ewallet_db/priv/repo/migrations/20190426083132_add_expire_at_to_pre_auth_tokens.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20190426083132_add_expire_at_to_pre_auth_tokens.exs
@@ -1,0 +1,9 @@
+defmodule EWalletDB.Repo.Migrations.AddExpireAtToPreAuthTokens do
+  use Ecto.Migration
+
+  def change do
+    alter table(:pre_auth_token) do
+      add :expire_at, :naive_datetime_usec, null: true
+    end
+  end
+end

--- a/apps/ewallet_db/priv/repo/migrations/20190426083132_add_expire_at_to_pre_auth_tokens.exs
+++ b/apps/ewallet_db/priv/repo/migrations/20190426083132_add_expire_at_to_pre_auth_tokens.exs
@@ -3,7 +3,7 @@ defmodule EWalletDB.Repo.Migrations.AddExpireAtToPreAuthTokens do
 
   def change do
     alter table(:pre_auth_token) do
-      add :expire_at, :naive_datetime_usec, null: true
+      add :expired_at, :naive_datetime_usec, null: true
     end
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
@@ -248,6 +248,7 @@ defmodule EWalletDB.AuthTokenTest do
 
     test "returns :token_expired if the current date time is after expire_at" do
       user = insert(:user)
+
       attrs = %{
         user: user,
         owner_app: Atom.to_string(@owner_app),

--- a/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
@@ -111,7 +111,7 @@ defmodule EWalletDB.AuthTokenTest do
     end
 
     @tag atk_lifetime: 3600
-    test "returns a user with expired auth_token if the expire_at has been lapsed", context do
+    test "returns a user with unexpired auth_token if the expire_at has been lapsed", context do
       # The user has the authentication token which will be expired in the next minute.
       user = insert(:user)
       {:ok, auth_token} = AuthToken.generate(user, @owner_app, %System{})
@@ -141,7 +141,7 @@ defmodule EWalletDB.AuthTokenTest do
     end
 
     @tag atk_lifetime: 3600
-    test "returns :token_expired if the expire_at has not been lapsed" do
+    test "returns :token_expired if the expire_at has been lapsed" do
       attrs = %{owner_app: Atom.to_string(@owner_app), expire_at: NaiveDateTime.utc_now()}
 
       auth_token = insert(:auth_token, attrs)

--- a/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
@@ -23,8 +23,8 @@ defmodule EWalletDB.AuthTokenTest do
   setup context do
     case context do
       %{atk_lifetime: second} when not is_nil(second) ->
-        Application.put_env(:ewallet, :atk_lifetime, second)
-        on_exit(fn -> Application.put_env(:ewallet, :atk_lifetime, 0) end)
+        Application.put_env(:ewallet_db, :atk_lifetime, second)
+        on_exit(fn -> Application.put_env(:ewallet_db, :atk_lifetime, 0) end)
         {:ok, second: second}
 
       _ ->

--- a/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
@@ -48,8 +48,6 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
       # To include preloaded user
       auth_token = AuthToken.get_by_token(token, @some_app)
 
-      IO.inspect(auth_token)
-
       assert auth_token == AuthExpirer.expire_or_refresh(auth_token, 30)
     end
 

--- a/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
@@ -13,23 +13,39 @@
 # limitations under the License.
 
 defmodule EWalletDB.Expirers.AuthExpirerTest do
-  use EWalletDB.SchemaCase, async: true
+  use EWalletDB.SchemaCase
   import EWalletDB.Factory
-  alias ActivityLogger.System
   alias EWalletDB.Expirers.AuthExpirer
-  alias EWalletDB.{AuthToken, PreAuthToken, Membership}
+  alias EWalletDB.{AuthToken, PreAuthToken}
 
   @owner_app :some_app
 
-  describe "get_new_expire_at/1" do
+  setup context do
+    case context do
+      %{atk_lifetime: lifetime} when not is_nil(lifetime) ->
+        Application.put_env(:ewallet, :atk_lifetime, lifetime)
+        on_exit(fn -> Application.put_env(:ewallet, :atk_lifetime, 0) end)
+        {:ok, lifetime: lifetime}
+
+      %{ptk_lifetime: lifetime} when not is_nil(lifetime) ->
+        Application.put_env(:ewallet, :ptk_lifetime, lifetime)
+        on_exit(fn -> Application.put_env(:ewallet, :ptk_lifetime, 0) end)
+        {:ok, lifetime: lifetime}
+
+      _ ->
+        :ok
+    end
+  end
+
+  describe "get_advanced_datetime/1" do
     test "returns nil when the lifetime is 0" do
-      assert AuthExpirer.get_new_expire_at(0) == nil
+      assert AuthExpirer.get_advanced_datetime(0) == nil
     end
 
-    test "returns NaiveDateTime with advanced by `lifetime` lifetime from the current date time" do
+    test "returns an advanced NaiveDateTime when given a lifetime" do
       lifetime = 60
 
-      expire_at = AuthExpirer.get_new_expire_at(lifetime)
+      expire_at = AuthExpirer.get_advanced_datetime(lifetime)
       expected_expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), lifetime, :second)
 
       assert NaiveDateTime.diff(expire_at, expected_expire_at, :second) == 0
@@ -41,24 +57,87 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
       assert AuthExpirer.expire_or_refresh(nil, 30) == nil
     end
 
-    test "returns an updated token with a correct expire_at if given AuthToken and non-zero lifetime" do
-      user = insert(:user)
-      %{token: token} = insert(:auth_token, user: user)
+    test "returns a given token if a given atk_lifetime is zero" do
+      auth_token = insert(:auth_token)
+      assert AuthExpirer.expire_or_refresh(auth_token, 0) == auth_token
+    end
+
+    @tag atk_lifetime: 30
+    test "returns an auth_token with a renewed `expire_at` if given non-zero integer and nil to `atk_lifetime` and `expire_at` respectively",
+         context do
+      auth_token = insert(:auth_token)
+      %{expire_at: expire_at} = AuthExpirer.expire_or_refresh(auth_token, context.lifetime)
+      expected_expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), context.lifetime)
+      assert NaiveDateTime.diff(expire_at, expected_expire_at) == 0
+    end
+
+    test "returns a pre_auth_token with a renewed expire_at if given non-zero integer and nil to `ptk_lifetime` and `expire_at` respectively" do
+      %{token: token} = insert(:pre_auth_token)
 
       # To include preloaded user
-      auth_token = AuthToken.get_by_token(token, @some_app)
+      auth_token = PreAuthToken.get_by_token(token, @owner_app)
 
       assert auth_token == AuthExpirer.expire_or_refresh(auth_token, 30)
     end
 
-    test "returns an updated token with a correct expire_at if given PreAuthToken and non-zero lifetime" do
+    @tag atk_lifetime: 7200
+    test "returns an auth_token with a renewed `expire_at` if given non-zero `atk_lifetime` and `expire_at` has not been lapsed",
+         context do
       user = insert(:user)
-      %{token: token} = insert(:auth_token)
+      expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), 3600)
 
-      # To include preloaded user
-      auth_token = AuthToken.get_by_token(token, @some_app)
+      auth_token = insert(:auth_token, %{expire_at: expire_at, user: user, owner_app: "some_app"})
 
-      assert auth_token == AuthExpirer.expire_or_refresh(auth_token, 30)
+      refreshed_auth_token =
+        auth_token.token
+        |> AuthToken.get_by_token(@owner_app)
+        |> AuthExpirer.expire_or_refresh(context.lifetime)
+
+      expected_expire_at = AuthExpirer.get_advanced_datetime(context.lifetime)
+      assert NaiveDateTime.diff(refreshed_auth_token.expire_at, expected_expire_at) == 0
+    end
+
+    @tag ptk_lifetime: 7200
+    test "returns a pre_auth_token with a renewed `expire_at` if given non-zero `ptk_lifetime` and `expire_at` has not been lapsed",
+         context do
+      user = insert(:user)
+      expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), 3600)
+
+      pre_auth_token =
+        insert(:pre_auth_token, %{expire_at: expire_at, user: user, owner_app: "some_app"})
+
+      refreshed_pre_auth_token =
+        pre_auth_token.token
+        |> PreAuthToken.get_by_token(@owner_app)
+        |> AuthExpirer.expire_or_refresh(context.lifetime)
+
+      expected_expire_at = AuthExpirer.get_advanced_datetime(context.lifetime)
+      assert NaiveDateTime.diff(refreshed_pre_auth_token.expire_at, expected_expire_at) == 0
+    end
+
+    test "returns an expired auth_token if a given auth_token's expire_at has been lapsed " do
+      # Set expire_at to 1 hr ago.
+      expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -3600)
+
+      auth_token =
+        :auth_token
+        |> insert(%{expire_at: expire_at})
+        |> AuthExpirer.expire_or_refresh(30)
+
+      assert auth_token.expired == true
+    end
+
+    @tag atk_lifetime: 7200
+    test "returns an expired pre_auth_token if a given pre_auth_token's expire_at has been lapsed" do
+      # Set expire_at to 1 hr ago.
+      expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -3600)
+
+      pre_auth_token =
+        :pre_auth_token
+        |> insert(%{expire_at: expire_at})
+        |> AuthExpirer.expire_or_refresh(30)
+
+      assert pre_auth_token.expired == true
     end
   end
 end

--- a/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
@@ -1,0 +1,66 @@
+# Copyright 2018-2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EWalletDB.Expirers.AuthExpirerTest do
+  use EWalletDB.SchemaCase, async: true
+  import EWalletDB.Factory
+  alias ActivityLogger.System
+  alias EWalletDB.Expirers.AuthExpirer
+  alias EWalletDB.{AuthToken, PreAuthToken, Membership}
+
+  @owner_app :some_app
+
+  describe "get_new_expire_at/1" do
+    test "returns nil when the lifetime is 0" do
+      assert AuthExpirer.get_new_expire_at(0) == nil
+    end
+
+    test "returns NaiveDateTime with advanced by `lifetime` lifetime from the current date time" do
+      lifetime = 60
+
+      expire_at = AuthExpirer.get_new_expire_at(lifetime)
+      expected_expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), lifetime, :second)
+
+      assert NaiveDateTime.diff(expire_at, expected_expire_at, :second) == 0
+    end
+  end
+
+  describe "expire_or_refresh/2" do
+    test "returns nil if the given token is nil" do
+      assert AuthExpirer.expire_or_refresh(nil, 30) == nil
+    end
+
+    test "returns an updated token with a correct expire_at if given AuthToken and non-zero lifetime" do
+      user = insert(:user)
+      %{token: token} = insert(:auth_token, user: user)
+
+      # To include preloaded user
+      auth_token = AuthToken.get_by_token(token, @some_app)
+
+      IO.inspect(auth_token)
+
+      assert auth_token == AuthExpirer.expire_or_refresh(auth_token, 30)
+    end
+
+    test "returns an updated token with a correct expire_at if given PreAuthToken and non-zero lifetime" do
+      user = insert(:user)
+      %{token: token} = insert(:auth_token)
+
+      # To include preloaded user
+      auth_token = AuthToken.get_by_token(token, @some_app)
+
+      assert auth_token == AuthExpirer.expire_or_refresh(auth_token, 30)
+    end
+  end
+end

--- a/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
@@ -23,13 +23,13 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
   setup context do
     case context do
       %{atk_lifetime: lifetime} when not is_nil(lifetime) ->
-        Application.put_env(:ewallet, :atk_lifetime, lifetime)
-        on_exit(fn -> Application.put_env(:ewallet, :atk_lifetime, 0) end)
+        Application.put_env(:ewallet_db, :atk_lifetime, lifetime)
+        on_exit(fn -> Application.put_env(:ewallet_db, :atk_lifetime, 0) end)
         {:ok, lifetime: lifetime}
 
       %{ptk_lifetime: lifetime} when not is_nil(lifetime) ->
-        Application.put_env(:ewallet, :ptk_lifetime, lifetime)
-        on_exit(fn -> Application.put_env(:ewallet, :ptk_lifetime, 0) end)
+        Application.put_env(:ewallet_db, :ptk_lifetime, lifetime)
+        on_exit(fn -> Application.put_env(:ewallet_db, :ptk_lifetime, 0) end)
         {:ok, lifetime: lifetime}
 
       _ ->

--- a/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
@@ -86,7 +86,8 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
       user = insert(:user)
       expired_at = NaiveDateTime.add(NaiveDateTime.utc_now(), 3600)
 
-      auth_token = insert(:auth_token, %{expired_at: expired_at, user: user, owner_app: "some_app"})
+      auth_token =
+        insert(:auth_token, %{expired_at: expired_at, user: user, owner_app: "some_app"})
 
       refreshed_auth_token =
         auth_token.token

--- a/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
@@ -63,7 +63,7 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
     end
 
     @tag atk_lifetime: 30
-    test "returns an auth_token with a renewed `expire_at` if given non-zero integer and nil to `atk_lifetime` and `expire_at` respectively",
+    test "returns an auth_token with a renewed `expire_at` if given positive integer and nil to `atk_lifetime` and `expire_at` respectively",
          context do
       auth_token = insert(:auth_token)
       %{expire_at: expire_at} = AuthExpirer.expire_or_refresh(auth_token, context.lifetime)
@@ -71,7 +71,7 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
       assert NaiveDateTime.diff(expire_at, expected_expire_at) == 0
     end
 
-    test "returns a pre_auth_token with a renewed expire_at if given non-zero integer and nil to `ptk_lifetime` and `expire_at` respectively" do
+    test "returns a pre_auth_token with a renewed expire_at if given positive integer and nil to `ptk_lifetime` and `expire_at` respectively" do
       %{token: token} = insert(:pre_auth_token)
 
       # To include preloaded user
@@ -81,7 +81,7 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
     end
 
     @tag atk_lifetime: 7200
-    test "returns an auth_token with a renewed `expire_at` if given non-zero `atk_lifetime` and `expire_at` has not been lapsed",
+    test "returns an auth_token with a renewed `expire_at` if given positive `atk_lifetime` and `expire_at` has not been lapsed",
          context do
       user = insert(:user)
       expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), 3600)
@@ -98,7 +98,7 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
     end
 
     @tag ptk_lifetime: 7200
-    test "returns a pre_auth_token with a renewed `expire_at` if given non-zero `ptk_lifetime` and `expire_at` has not been lapsed",
+    test "returns a pre_auth_token with a renewed `expire_at` if given positive `ptk_lifetime` and `expire_at` has not been lapsed",
          context do
       user = insert(:user)
       expire_at = NaiveDateTime.add(NaiveDateTime.utc_now(), 3600)

--- a/apps/ewallet_db/test/ewallet_db/pre_auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/pre_auth_token_test.exs
@@ -23,8 +23,8 @@ defmodule EWalletDB.PreAuthTokenTest do
   setup context do
     case context do
       %{ptk_lifetime: second} when not is_nil(second) ->
-        Application.put_env(:ewallet, :ptk_lifetime, second)
-        on_exit(fn -> Application.put_env(:ewallet, :ptk_lifetime, 0) end)
+        Application.put_env(:ewallet_db, :ptk_lifetime, second)
+        on_exit(fn -> Application.put_env(:ewallet_db, :ptk_lifetime, 0) end)
         {:ok, second: second}
 
       _ ->

--- a/apps/ewallet_db/test/ewallet_db/pre_auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/pre_auth_token_test.exs
@@ -139,17 +139,17 @@ defmodule EWalletDB.PreAuthTokenTest do
 
     @tag ptk_lifetime: 0
     test "returns pre_auth_token with expire_nil when ptk_lifetime is 0" do
-      %{token: token, user: user_1} = insert_ptk(%{expire_at: nil})
+      %{token: token_1, user: user_1} = insert_ptk(%{expire_at: nil})
 
-      %{token: token2, user: user_2, expire_at: token_2_expire_at} =
+      %{token: token_2, user: user_2, expire_at: token_2_expire_at} =
         insert_ptk(%{expire_at: from_now_by_seconds(60)})
 
-      pre_auth_token = PreAuthToken.authenticate(token, @owner_app)
-      pre_auth_token_2 = PreAuthToken.authenticate(token2, @owner_app)
+      pre_auth_token_1 = PreAuthToken.authenticate(token_1, @owner_app)
+      pre_auth_token_2 = PreAuthToken.authenticate(token_2, @owner_app)
 
-      assert pre_auth_token.user.uuid == user_1.uuid
+      assert pre_auth_token_1.user.uuid == user_1.uuid
       assert pre_auth_token_2.user.uuid == user_2.uuid
-      assert pre_auth_token.expire_at == nil
+      assert pre_auth_token_1.expire_at == nil
       assert pre_auth_token_2.expire_at == token_2_expire_at
     end
 

--- a/apps/ewallet_db/test/ewallet_db/pre_auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/pre_auth_token_test.exs
@@ -159,21 +159,21 @@ defmodule EWalletDB.PreAuthTokenTest do
 
       token = insert(:pre_auth_token, attrs)
 
-      assert PreAuthToken.authenticate(token.token, @owner_app) == :token_expired
+      assert PreAuthToken.authenticate(token.token, @owner_app) == {:error, :token_expired}
     end
 
     test "returns false if pre_auth_token exists but for a different owner app" do
       token = insert(:pre_auth_token, %{owner_app: "wrong_app"})
 
-      assert PreAuthToken.authenticate(token.token, @owner_app) == false
+      assert PreAuthToken.authenticate(token.token, @owner_app) == {:error, :token_not_found}
     end
 
     test "returns false if token does not exists" do
-      assert PreAuthToken.authenticate("unmatched", @owner_app) == false
+      assert PreAuthToken.authenticate("unmatched", @owner_app) == {:error, :token_not_found}
     end
 
     test "returns false if pre_auth_token is nil" do
-      assert PreAuthToken.authenticate(nil, @owner_app) == false
+      assert PreAuthToken.authenticate(nil, @owner_app) == {:error, :token_not_found}
     end
   end
 
@@ -253,7 +253,7 @@ defmodule EWalletDB.PreAuthTokenTest do
       pre_auth_token = insert(:pre_auth_token, attrs)
 
       assert PreAuthToken.authenticate(user.id, pre_auth_token.token, @owner_app) ==
-               :token_expired
+               {:error, :token_expired}
     end
 
     test "returns false if pre_auth_token belongs to a different user" do
@@ -264,7 +264,9 @@ defmodule EWalletDB.PreAuthTokenTest do
       {:ok, pre_auth_token} = PreAuthToken.generate(user, @owner_app, %System{})
 
       another_user = insert(:admin)
-      assert PreAuthToken.authenticate(another_user.id, pre_auth_token.token, @owner_app) == false
+
+      assert PreAuthToken.authenticate(another_user.id, pre_auth_token.token, @owner_app) ==
+               {:error, :token_not_found}
     end
 
     test "returns false if pre_auth_token exists but for a different owner app" do
@@ -275,7 +277,8 @@ defmodule EWalletDB.PreAuthTokenTest do
 
       {:ok, pre_auth_token} = PreAuthToken.generate(user, :different_app, %System{})
 
-      assert PreAuthToken.authenticate(user.id, pre_auth_token.token, @owner_app) == false
+      assert PreAuthToken.authenticate(user.id, pre_auth_token.token, @owner_app) ==
+               {:error, :token_not_found}
     end
 
     test "returns false if pre_auth_token does not exists" do
@@ -285,7 +288,8 @@ defmodule EWalletDB.PreAuthTokenTest do
       {:ok, _} = Membership.assign(user, account, role, %System{})
       {:ok, _} = PreAuthToken.generate(user, @owner_app, %System{})
 
-      assert PreAuthToken.authenticate(user.id, "unmatched", @owner_app) == false
+      assert PreAuthToken.authenticate(user.id, "unmatched", @owner_app) ==
+               {:error, :token_not_found}
     end
 
     test "returns false if pre_auth_token is nil" do
@@ -295,7 +299,7 @@ defmodule EWalletDB.PreAuthTokenTest do
       {:ok, _} = Membership.assign(user, account, role, %System{})
       {:ok, _} = PreAuthToken.generate(user, @owner_app, %System{})
 
-      assert PreAuthToken.authenticate(user.id, nil, @owner_app) == false
+      assert PreAuthToken.authenticate(user.id, nil, @owner_app) == {:error, :token_not_found}
     end
   end
 

--- a/apps/frontend/assets/src/adminPanelApp/routes/index.js
+++ b/apps/frontend/assets/src/adminPanelApp/routes/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { BrowserRouter as Router, Redirect, Switch, Route } from 'react-router-dom'
-import PropTypes from 'prop-types'
 
 import AuthenticatedRoute from './authenticatedRoute'
 import LoginRoute from './loginRoute'

--- a/apps/frontend/assets/src/omg-session/reducer.js
+++ b/apps/frontend/assets/src/omg-session/reducer.js
@@ -1,5 +1,4 @@
 import createReducer from '../reducer/createReducer'
-import _ from 'lodash'
 export const sessionReducer = createReducer(
   {},
   {


### PR DESCRIPTION
Issue/Task Number: #953 

Closes #953

# Overview

This PR implements the authentication token expiration.

The default behavior of this feature is: the authentication token will never be expired unless the settings (:pre_auth_token_lifetime and :auth_token_lifetime) are set to the integer which more than zero.

# Changes
 
  - Added `expire_at` to `AuthToken` and `PreAuthToken`
  - Added `:pre_auth_token_lifetime` in the setting to specify how long the `PreAuthToken` can be used.
  - Added `:auth_token_lifetime` in the setting to specify how long the `AuthToken` can be used.
  - Added an ability to expire either `PreAuthToken` or `AuthToken` or both.

> Note: `:pre_auth_token_lifetime` and `:auth_token_lifetime` can be positive integer or `0`. By set it to `0`, meaning that the `auth_token` or `pre_auth_token` will never be expired.

# Implementation Details

Every authenticated apis call `AuthToken.authenticate`. This PR adds some logic around there to check whether the authentication token's `expire_at` has lapsed. 

So the main logic was implemented pretty much like this:

```elixir
if lapsed do
  expire()
else
  refresh() 
end
```

That means If it has lapsed, then set `expire: true`, otherwise refresh the authentication token by advance an `expire_at` to the next `pre_auth_token_lifetime` or `auth_token_lifetime` seconds.

# How to test?

1.`mix do ecto.migrate, omg.server`

2. Set the :auth_token_lifetime (seconds) with the second you want to wait for expire.
```bash
curl http://localhost:4000/api/admin/configuration.update \
-H "Accept: application/vnd.omisego.v1+json" \
-H "Authorization: OMGAdmin `echo -n "user_id:authentication_token" | base64`" \
-H "Content-Type: application/json" \
-d '{
  "auth_token_lifetime": 20
}' \
-w "\n" | jq
``` 

3. Open the admin panel and login

4. Try to wait for `x` seconds (the value you've set at the previous step) to see if the auth token is expired or keep refreshing the webpage within `x` seconds to see if auth token is refreshed. 

> Note: You can also test the `PreAuthToken` but it will be applied only to the`/admin.login_2fa` which you've to enable two-factor authentication of the user first. 

# Impact

This PR requires a re-seeding of the settings using `mix seed --settings`. The steps after a deploy are therefore:

1. `mix ecto.migrate`
2. `mix seed --settings`