### PR TITLE
Fix /user.get_transactions wrong parameters

### DIFF
--- a/apps/admin_api/lib/admin_api/v1/controllers/transaction_controller.ex
+++ b/apps/admin_api/lib/admin_api/v1/controllers/transaction_controller.ex
@@ -135,8 +135,6 @@ defmodule AdminAPI.V1.TransactionController do
     end
   end
 
-  def all_for_user(conn, _), do: handle_error(conn, :invalid_parameter)
-
   @doc """
   Retrieves a specific transaction by its id.
   """

--- a/apps/admin_api/test/admin_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/transaction_controller_test.exs
@@ -438,6 +438,21 @@ defmodule AdminAPI.V1.TransactionControllerTest do
   end
 
   describe "/user.get_transactions" do
+    test_with_auths "returns all the transactions for a specific id", context do
+      response =
+        request("/user.get_transactions", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "id" => context.user.id
+        })
+
+      assert response["data"]["data"] |> length() == 8
+
+      Enum.each(response["data"]["data"], fn tx ->
+        assert Enum.member?([tx["from"]["user_id"], tx["to"]["user_id"]], context.user.id)
+      end)
+    end
+
     test_with_auths "returns all the transactions for a specific user_id", context do
       response =
         request("/user.get_transactions", %{

--- a/apps/admin_api/test/admin_api/v1/controllers/transaction_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/transaction_controller_test.exs
@@ -539,6 +539,19 @@ defmodule AdminAPI.V1.TransactionControllerTest do
                context.transaction_2.id
              ]
     end
+
+    test_with_auths "returns an error when invalid params are provided" do
+      response =
+        request("/user.get_transactions", %{
+          "sort_by" => "created_at",
+          "sort_dir" => "asc",
+          "per_page" => 3,
+          "page" => 1
+        })
+
+      assert response["data"]["code"] == "client:invalid_parameter"
+      assert response["data"]["description"] == "Invalid parameter provided."
+    end
   end
 
   describe "/transaction.get" do

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,8 @@ defmodule EWallet.Umbrella.Mixfile do
       {:distillery, "~> 1.5", runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.8", only: :test, runtime: false},
-      {:junit_formatter, "~> 3.0", only: :test}
+      {:junit_formatter, "~> 3.0", only: :test},
+      {:httpoison, "~> 0.11.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -37,8 +37,7 @@ defmodule EWallet.Umbrella.Mixfile do
       {:distillery, "~> 1.5", runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.8", only: :test, runtime: false},
-      {:junit_formatter, "~> 3.0", only: :test},
-      {:httpoison, "~> 0.11.0"}
+      {:junit_formatter, "~> 3.0", only: :test}
     ]
   end
 


### PR DESCRIPTION
Issue/Task Number: #1022 
closes #1022 

# Overview

This PR adds the proper parameter for the endpoint: `id` (instead of `user_id` and `provider_user_id` - those are still supported but `user_id` shouldn't be used anymore and isn't documented.

# Changes

- Add a test
- Fix endpoint