### PR TITLE
Prevent admin users from logging in through the client API

### DIFF
--- a/apps/ewallet_api/lib/ewallet_api/v1/end_user_authenticator.ex
+++ b/apps/ewallet_api/lib/ewallet_api/v1/end_user_authenticator.ex
@@ -23,7 +23,8 @@ defmodule EWalletAPI.V1.EndUserAuthenticator do
 
   def authenticate(conn, email, password) when is_binary(email) do
     with %User{} = user <- User.get_by_email(email) || :user_email_not_found,
-         true <- User.enabled?(user) || :user_disabled do
+         true <- User.enabled?(user) || :user_disabled,
+         true <- !User.admin?(user) || :user_is_admin do
       authenticate(conn, user, password)
     else
       _ ->
@@ -32,7 +33,7 @@ defmodule EWalletAPI.V1.EndUserAuthenticator do
     end
   end
 
-  def authenticate(conn, %{password_hash: password_hash} = user, password)
+  def authenticate(conn, %{password_hash: password_hash, is_admin: false} = user, password)
       when is_binary(password) and is_binary(password_hash) do
     case Crypto.verify_password(password, password_hash) do
       true ->

--- a/apps/ewallet_api/test/ewallet_api/v1/controllers/auth_controller_test.exs
+++ b/apps/ewallet_api/test/ewallet_api/v1/controllers/auth_controller_test.exs
@@ -64,6 +64,26 @@ defmodule EWalletAPI.V1.AuthControllerTest do
                "Your user account has not been confirmed yet. Please check your emails."
     end
 
+    test "returns an error when trying to login an admin user" do
+      email = "test_admin_login@example.com"
+      password = "some_password"
+      password_hash = Crypto.hash_password(password)
+
+      _admin = insert(:admin, email: email, password_hash: password_hash)
+      request_data = %{email: email, password: password}
+
+      response = client_request("/user.login", request_data)
+
+      assert response["version"] == @expected_version
+      assert response["success"] == false
+
+      assert response["data"]["object"] == "error"
+      assert response["data"]["code"] == "user:invalid_login_credentials"
+
+      assert response["data"]["description"] ==
+               "There is no user corresponding to the provided login credentials."
+    end
+
     test "returns user:invalid_login_credentials when given an unknown email", context do
       request_data = %{context.request_data | email: "unknown@example.com"}
       response = client_request("/user.login", request_data)


### PR DESCRIPTION
Issue/Task Number: #1025 
closes #1025

# Overview

Check that the logged in user is not an admin in the `/user.login` client endpoint.

# Changes

- Add a test to reflect the bug
- Fix the issue by preventing admins from logging in
