### PR TITLE
Fix admin panel url in seeding output

### DIFF
--- a/apps/ewallet_db/priv/repo/reporters/seeds.exs
+++ b/apps/ewallet_db/priv/repo/reporters/seeds.exs
@@ -17,7 +17,8 @@ defmodule EWalletDB.Repo.Reporters.SeedsReporter do
 
   def run(writer, args) do
     base_url = Config.get("base_url", "https://example.com")
-    frontend_url = base_url <> "/admin"
+    admin_panel_url = base_url <> "/admin"
+
     admin_api_url = base_url <> "/api/admin"
     admin_api_swagger_ui_url = base_url <> "/api/admin/docs"
 
@@ -35,7 +36,7 @@ defmodule EWalletDB.Repo.Reporters.SeedsReporter do
 
     To start using the Admin Panel, login with the following credentials:
 
-      - Login URL : `#{frontend_url}/admin`
+      - Login URL : `#{admin_panel_url}`
       - Email     : `#{admin_email}`
       - Password  : `#{admin_password}`
 


### PR DESCRIPTION
Issue/Task Number: #1037 
Closes #1037

# Overview

Fixes admin panel's URL in seeding output

# Changes

- Removed the extra `/admin` from the admin url building logic

# Implementation Details

String replaced.

# Usage

`mix seed` should now inform the correct admin panel url

# Impact

No changes to DB or API.
