### PR TITLE
Fix internal server error when providing an association as the filter param

### DIFF
--- a/apps/ewallet/lib/ewallet/web/filters/match_parser.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_parser.ex
@@ -80,6 +80,9 @@ defmodule EWallet.Web.MatchParser do
       nil ->
         {:error, :not_allowed, field}
 
+      :missing_subfield ->
+        {:error, :missing_subfield, field}
+
       field_definition ->
         {field_definition, comparator, value}
     end
@@ -141,7 +144,10 @@ defmodule EWallet.Web.MatchParser do
   # Returns `{field, nil}` if the type is not given
   defp get_field_definition(field, field), do: {field, nil}
 
-  # Returns `{field, type}` if the type is given
+  # Returns `:missing_subfield` if the field is an association
+  defp get_field_definition(field, {field, type}) when is_list(type), do: :missing_subfield
+
+  # Returns `{field, type}` if the type is given.
   defp get_field_definition(field, {field, type}), do: {field, type}
 
   # Returns nil if the field does not match

--- a/apps/ewallet/lib/ewallet/web/orchestrator.ex
+++ b/apps/ewallet/lib/ewallet/web/orchestrator.ex
@@ -48,6 +48,9 @@ defmodule EWallet.Web.Orchestrator do
       {:error, :not_allowed, field} ->
         {:error, :query_field_not_allowed, field_name: field}
 
+      {:error, :missing_subfield, field} ->
+        {:error, :query_field_missing_subfield, field_name: field}
+
       {:error, _, _} = error ->
         error
     end

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -33,6 +33,12 @@ defmodule EWallet.Web.V1.ErrorHandler do
       template:
         "Invalid parameter provided. The queried field is not allowed. Given: '%{field_name}'."
     },
+    query_field_missing_subfield: %{
+      code: "client:invalid_parameter",
+      template:
+        "Invalid parameter provided. The queried field must refer to the object's field,"
+        <> " not the object. Given: '%{field_name}'."
+    },
     missing_id: %{
       code: "client:invalid_parameter",
       description: "Invalid parameter provided. `id` is required."

--- a/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/error_handler.ex
@@ -36,8 +36,8 @@ defmodule EWallet.Web.V1.ErrorHandler do
     query_field_missing_subfield: %{
       code: "client:invalid_parameter",
       template:
-        "Invalid parameter provided. The queried field must refer to the object's field,"
-        <> " not the object. Given: '%{field_name}'."
+        "Invalid parameter provided. The queried field must refer to the object's field," <>
+          " not the object. Given: '%{field_name}'."
     },
     missing_id: %{
       code: "client:invalid_parameter",

--- a/apps/ewallet/test/ewallet/web/filters/match_parser_test.exs
+++ b/apps/ewallet/test/ewallet/web/filters/match_parser_test.exs
@@ -156,6 +156,28 @@ defmodule EWallet.Web.MatchParserTest do
                MatchParser.build_query(Transaction, attrs, whitelist, true, MatchAllQuery)
     end
 
+    test "returns error if the given field is an association entity" do
+      whitelist = [from_token: [:id]]
+
+      txn_1 = insert(:transaction)
+      {:ok, txn_1} = Preloader.preload_one(txn_1, :from_token)
+
+      attrs = [
+        %{
+          "field" => "from_token",
+          "comparator" => "eq",
+          "value" => txn_1.from_token.id
+        }
+      ]
+
+      {res, code, params} =
+        MatchParser.build_query(Transaction, attrs, whitelist, true, MatchAllQuery)
+
+      assert res == :error
+      assert code == :missing_subfield
+      assert params == "from_token"
+    end
+
     test "returns error if filtering is not allowed on the field" do
       whitelist = [from_token: [:email]]
 

--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -28,8 +28,21 @@ defmodule EWallet.Web.OrchestratorTest do
     def default_preload_assocs, do: [:wallets]
     def sort_fields, do: [:id, :name]
     def search_fields, do: [:id, :name]
-    def self_filter_fields, do: [:id, :name, :description, :inserted_at]
-    def filter_fields, do: [:id, :name, :description, :inserted_at]
+
+    def self_filter_fields, do: [
+      :id,
+      :name,
+      :description,
+      :inserted_at
+    ]
+
+    def filter_fields, do: [
+      id: nil,
+      name: nil,
+      description: nil,
+      inserted_at: nil,
+      mock_assoc: [:id, :name]
+    ]
   end
 
   describe "query/3" do
@@ -66,6 +79,24 @@ defmodule EWallet.Web.OrchestratorTest do
       assert res == :error
       assert error == :query_field_not_allowed
       assert params == [field_name: "status"]
+    end
+
+    test "returns :query_field_missing_subfield error if the field is an association" do
+      attrs = %{
+        "match_all" => [
+          %{
+            "field" => "mock_assoc",
+            "comparator" => "eq",
+            "value" => "some_value"
+          }
+        ]
+      }
+
+      {res, error, params} = Orchestrator.query(Account, MockOverlay, attrs)
+
+      assert res == :error
+      assert error == :query_field_missing_subfield
+      assert params == [field_name: "mock_assoc"]
     end
 
     test "returns records with the given `start_after`, `start_by` and `sort_by` is `desc`" do

--- a/apps/ewallet/test/ewallet/web/orchestrator_test.exs
+++ b/apps/ewallet/test/ewallet/web/orchestrator_test.exs
@@ -29,20 +29,24 @@ defmodule EWallet.Web.OrchestratorTest do
     def sort_fields, do: [:id, :name]
     def search_fields, do: [:id, :name]
 
-    def self_filter_fields, do: [
-      :id,
-      :name,
-      :description,
-      :inserted_at
-    ]
+    def self_filter_fields do
+      [
+        :id,
+        :name,
+        :description,
+        :inserted_at
+      ]
+    end
 
-    def filter_fields, do: [
-      id: nil,
-      name: nil,
-      description: nil,
-      inserted_at: nil,
-      mock_assoc: [:id, :name]
-    ]
+    def filter_fields do
+      [
+        id: nil,
+        name: nil,
+        description: nil,
+        inserted_at: nil,
+        mock_assoc: [:id, :name]
+      ]
+    end
   end
 
   describe "query/3" do


### PR DESCRIPTION
Issue/Task Number: #1051

# Overview

This PR fixes a specific case of filtering when an association name is given as the filter param without specifying the association's field.

# Changes

- Add a guard so association filters do not get processed as a field.

# Implementation Details

Overlay filters could be in the form of:

```elixir
[
  some_field: nil,
  some_id: :uuid,
  some_assoc: [:id, :name]
]
```

So when an association is given as a filter param without its dot-notated subfield, e.g. `field: "some_assoc"` instead of `field: "some_assoc.id"`, it treats `[:id, :name]` as a field type like `:uuid` instead of a list of associated subfields, and hence the internal server error.

An `is_list(type)` guard is added to catch the association and return `: missing_subfield` for further processing by the parser and orchestrator.

# Usage

Try the request in #1051. Its return should be similar to:

```javascript
{
  "version": "1",
  "success": false,
  "data": {
    "object": "error",
    "messages": null,
    "description": "Invalid parameter provided. The queried field must refer to the object's field, not the object. Given: 'from_wallet'.",
    "code": "client:invalid_parameter"
  }
}
```

# Impact

No changes to the API specs or DB schema.
