### PR TITLE
Minor fix transaction consumption confirmation

### DIFF
--- a/apps/admin_api/test/admin_api/v1/controllers/transaction_consumption_controller_test.exs
+++ b/apps/admin_api/test/admin_api/v1/controllers/transaction_consumption_controller_test.exs
@@ -2097,7 +2097,8 @@ defmodule AdminAPI.V1.TransactionConsumptionControllerTest do
       Endpoint.unsubscribe("transaction_consumption:#{consumption_id}")
     end
 
-    test_with_auths "successful approve when the transaction request was expired after consumption", context do
+    test_with_auths "successful approve when the transaction request was expired after consumption",
+                    context do
       mint!(context.token)
 
       # Create a require_confirmation transaction request that will be consumed soon
@@ -2150,7 +2151,8 @@ defmodule AdminAPI.V1.TransactionConsumptionControllerTest do
       }
 
       # Expire the transaction request
-      assert {:ok, expired_transaction_request} = TransactionRequest.expire(transaction_request, %System{})
+      assert {:ok, expired_transaction_request} =
+               TransactionRequest.expire(transaction_request, %System{})
 
       assert expired_transaction_request.id == transaction_request.id
       assert expired_transaction_request.status == TransactionRequest.expired()
@@ -2196,7 +2198,97 @@ defmodule AdminAPI.V1.TransactionConsumptionControllerTest do
       Endpoint.unsubscribe("transaction_consumption:#{consumption_id}")
     end
 
-    test_with_auths "successful approve when the transaction request's max_consumptions was reached after consumption", context do
+    test_with_auths "failed to approve when the transaction request's max_consumptions was reached",
+                    context do
+      mint!(context.token)
+
+      # Create a require_confirmation transaction request that will be consumed soon
+      transaction_request =
+        insert(
+          :transaction_request,
+          type: "send",
+          token_uuid: context.token.uuid,
+          account_uuid: context.account.uuid,
+          wallet: context.account_wallet,
+          amount: nil,
+          require_confirmation: true
+        )
+
+      request_topic = "transaction_request:#{transaction_request.id}"
+
+      # Start listening to the channels for the transaction request created above
+      Endpoint.subscribe(request_topic)
+
+      # Making the consumption, since we made the request require_confirmation, it will
+      # create a pending consumption that will need to be confirmed
+      response =
+        request("/transaction_request.consume", %{
+          idempotency_token: "123",
+          formatted_transaction_request_id: transaction_request.id,
+          correlation_id: nil,
+          amount: 100_000 * context.token.subunit_to_unit,
+          metadata: nil,
+          token_id: nil,
+          provider_user_id: context.bob.provider_user_id
+        })
+
+      consumption_id = response["data"]["id"]
+      assert response["success"]
+      assert response["data"]["status"] == TransactionConsumption.pending()
+      assert response["data"]["transaction_id"] == nil
+
+      # We check that we receive the confirmation request above in the
+      # transaction request channel
+      assert_receive %Phoenix.Socket.Broadcast{
+        event: "transaction_consumption_request",
+        topic: "transaction_request:" <> _,
+        payload:
+          %{
+            # Ignore content
+          }
+      }
+
+      # Expire the transaction request
+      assert {:ok, expired_transaction_request} =
+               TransactionRequest.expire(
+                 transaction_request,
+                 %System{},
+                 "max_consumptions_reached"
+               )
+
+      assert expired_transaction_request.id == transaction_request.id
+      assert expired_transaction_request.status == TransactionRequest.expired()
+      assert expired_transaction_request.expiration_reason == "max_consumptions_reached"
+
+      # We need to know once the consumption has been approved, so let's
+      # listen to the channel for it
+      Endpoint.subscribe("transaction_consumption:#{consumption_id}")
+
+      # Confirm the consumption
+      response =
+        request("/transaction_consumption.approve", %{
+          id: consumption_id
+        })
+
+      assert response == %{
+               "data" => %{
+                 "code" => "transaction_request:max_consumptions_reached",
+                 "description" =>
+                   "The specified transaction request has reached the allowed amount of consumptions.",
+                 "messages" => nil,
+                 "object" => "error"
+               },
+               "success" => false,
+               "version" => "1"
+             }
+
+      # Unsubscribe from all channels
+      Endpoint.unsubscribe("transaction_request:#{transaction_request.id}")
+      Endpoint.unsubscribe("transaction_consumption:#{consumption_id}")
+    end
+
+    test_with_auths "successful approve when the transaction request was cancelled after consumption",
+                    context do
       mint!(context.token)
 
       # Create a require_confirmation transaction request that will be consumed soon
@@ -2249,11 +2341,18 @@ defmodule AdminAPI.V1.TransactionConsumptionControllerTest do
       }
 
       # Expire the transaction request
-      assert {:ok, expired_transaction_request} = TransactionRequest.expire(transaction_request, %System{}, "max_consumptions_reached")
+      assert {:ok, expired_transaction_request} =
+               TransactionRequest.expire(
+                 transaction_request,
+                 %System{},
+                 TransactionRequest.cancelled_transaction_request()
+               )
 
       assert expired_transaction_request.id == transaction_request.id
       assert expired_transaction_request.status == TransactionRequest.expired()
-      assert expired_transaction_request.expiration_reason == "max_consumptions_reached"
+
+      assert expired_transaction_request.expiration_reason ==
+               TransactionRequest.cancelled_transaction_request()
 
       # We need to know once the consumption has been approved, so let's
       # listen to the channel for it
@@ -2294,7 +2393,6 @@ defmodule AdminAPI.V1.TransactionConsumptionControllerTest do
       Endpoint.unsubscribe("transaction_request:#{transaction_request.id}")
       Endpoint.unsubscribe("transaction_consumption:#{consumption_id}")
     end
-
 
     test_with_auths "sends socket confirmation when require_confirmation and approved between users",
                     context do

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -118,6 +118,13 @@ defmodule EWallet.TransactionConsumptionValidator do
   end
 
   defp validate_transaction_request(request, operation) do
+<<<<<<< HEAD
+=======
+    expiration_reason =
+      request.expiration_reason &&
+        String.to_existing_atom(request.expiration_reason)
+
+>>>>>>> f0844ca37... :hammer: Refactor handling `expiration_reason`
     request
     |> TransactionRequest.valid?()
     |> Kernel.||(TransactionRequest.get_expiration_reason(request))

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -146,11 +146,11 @@ defmodule EWallet.TransactionConsumptionValidator do
       true ->
         :ok
 
-      :cancelled_transaction_request ->
-        :ok
+      :max_consumptions_reached ->
+        {:error, :max_consumptions_reached}
 
       expiration_reason when not is_nil(expiration_reason) and is_atom(expiration_reason) ->
-        {:error, expiration_reason}
+        :ok
 
       _ ->
         {:error, :unknown_error}

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -118,9 +118,7 @@ defmodule EWallet.TransactionConsumptionValidator do
   end
 
   defp validate_transaction_request(request, operation) do
-    expiration_reason =
-      request.expiration_reason &&
-        String.to_existing_atom(request.expiration_reason)
+    expiration_reason = TransactionRequest.get_expiration_reason(request)
 
     request
     |> TransactionRequest.valid?()

--- a/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
+++ b/apps/ewallet/lib/ewallet/validators/transaction_consumption_validator.ex
@@ -118,13 +118,10 @@ defmodule EWallet.TransactionConsumptionValidator do
   end
 
   defp validate_transaction_request(request, operation) do
-<<<<<<< HEAD
-=======
     expiration_reason =
       request.expiration_reason &&
         String.to_existing_atom(request.expiration_reason)
 
->>>>>>> f0844ca37... :hammer: Refactor handling `expiration_reason`
     request
     |> TransactionRequest.valid?()
     |> Kernel.||(TransactionRequest.get_expiration_reason(request))

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
@@ -369,7 +369,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
       {:ok, transaction_request} = TransactionRequest.expire(transaction_request, %System{})
       assert transaction_request.expired_at != nil
 
-      res =
+      {status, res} =
         TransactionConsumptionConfirmerGate.confirm(
           consumption.id,
           true,
@@ -379,7 +379,8 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
           %System{}
         )
 
-      assert res == {:error, :expired_transaction_request}
+      assert status == :ok
+      assert %TransactionConsumption{} = res
     end
 
     test "rejects the consumption if not confirmed as admin user with rights", meta do
@@ -698,7 +699,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
       {:ok, transaction_request} = TransactionRequest.expire(transaction_request, %System{})
       assert transaction_request.expired_at != nil
 
-      res =
+      {status, res} =
         TransactionConsumptionConfirmerGate.confirm(
           consumption.id,
           true,
@@ -708,7 +709,8 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
           %System{}
         )
 
-      assert res == {:error, :expired_transaction_request}
+      assert status == :ok
+      assert %TransactionConsumption{} = res
     end
   end
 end

--- a/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transaction_consumption_confirmer_gate_test.exs
@@ -329,7 +329,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
       assert {:error, %{authorized: false}} = res
     end
 
-    test "fails to confirm the consumption if expired", meta do
+    test "confirms the consumption regardless the request has been expired", meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
       {:ok, _} = AccountUser.link(meta.account.uuid, meta.receiver.uuid, %System{})
 
@@ -663,7 +663,7 @@ defmodule EWallet.TransactionConsumptionConfirmerGateTest do
       assert {:error, %{authorized: false}} = res
     end
 
-    test "fails to confirm the consumption if expired", meta do
+    test "confirms the consumption regardless the request has been expired", meta do
       initialize_wallet(meta.sender_wallet, 200_000, meta.token)
 
       transaction_request =

--- a/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
+++ b/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
@@ -212,7 +212,7 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
       assert res.status == "pending"
     end
 
-    test "returns an expired error when the expiration reason is `max_consumptions_reached`" do
+    test "returns error when the expiration reason is `max_consumptions_reached`" do
       {:ok, user} = :user |> params_for() |> User.insert()
       wallet = User.get_primary_wallet(user)
 

--- a/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
+++ b/apps/ewallet/test/ewallet/validators/transaction_consumption_validator_test.exs
@@ -155,7 +155,7 @@ defmodule EWallet.TransactionConsumptionValidatorTest do
       assert %{authorized: false} = res
     end
 
-    test "expires request if past expiration date" do
+    test "confirms regardless the transaction request past expiration date" do
       now = NaiveDateTime.utc_now()
       {:ok, user} = :user |> params_for() |> User.insert()
       wallet = User.get_primary_wallet(user)

--- a/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
+++ b/apps/ewallet_db/lib/ewallet_db/transaction_request.ex
@@ -429,6 +429,14 @@ defmodule EWalletDB.TransactionRequest do
     end
   end
 
+  @spec get_expiration_reason(%TransactionRequest{}) :: atom() | nil
+  def get_expiration_reason(request) do
+    case request.expiration_reason do
+      nil -> nil
+      reason -> String.to_existing_atom(reason)
+    end
+  end
+
   @spec cancel(%TransactionRequest{}, map()) ::
           {:ok, %TransactionRequest{}}
           | {:error, map()}

--- a/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
@@ -362,6 +362,24 @@ defmodule EWalletDB.TransactionRequestTest do
     end
   end
 
+  describe "get_expiration_reason/1" do
+    test "returns atom when expiration reason is not nil" do
+      request =
+        insert(:transaction_request, %{
+          expiration_reason: TransactionRequest.expired_transaction_request()
+        })
+
+      assert TransactionRequest.get_expiration_reason(request) == :expired_transaction_request
+
+    end
+
+    test "return nil when expiration reason is nil" do
+      request = insert(:transaction_request)
+
+      assert TransactionRequest.get_expiration_reason(request) == nil
+    end
+  end
+
   describe "cancel" do
     test "cancels the request" do
       t = insert(:transaction_request)

--- a/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/transaction_request_test.exs
@@ -370,7 +370,6 @@ defmodule EWalletDB.TransactionRequestTest do
         })
 
       assert TransactionRequest.get_expiration_reason(request) == :expired_transaction_request
-
     end
 
     test "return nil when expiration reason is nil" do


### PR DESCRIPTION
Issue/Task Number: #1053 

Closes #1053 

# Overview

This PR allows the transaction consumption with an expired transaction request with `expiration_reason = "expired_transaction_request"` to be confirmed

> ⚠️  Waiting branch 950-add-endpoint-cancel-transaction-request to be merged
