### PR TITLE
Fix can't filter for some fields

### DIFF
--- a/apps/ewallet/lib/ewallet/web/v1/overlays/invite_overlay.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/overlays/invite_overlay.ex
@@ -58,7 +58,7 @@ defmodule EWallet.Web.V1.InviteOverlay do
       verified_at: nil,
       inserted_at: nil,
       updated_at: nil,
-      user: UserOverlay.default_preload_assocs()
+      user: UserOverlay.self_filter_fields()
     ]
 
   def pagination_fields,

--- a/apps/ewallet/lib/ewallet/web/v1/overlays/token_overlay.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/overlays/token_overlay.ex
@@ -82,7 +82,7 @@ defmodule EWallet.Web.V1.TokenOverlay do
       enabled: nil,
       inserted_at: nil,
       created_at: nil,
-      account: AccountOverlay.default_preload_assocs()
+      account: AccountOverlay.self_filter_fields()
     ]
 
   def pagination_fields,

--- a/apps/ewallet/lib/ewallet/web/v1/overlays/transaction_consumption_overlay.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/overlays/transaction_consumption_overlay.ex
@@ -103,6 +103,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionOverlay do
       :correlation_id,
       :idempotency_token,
       :status,
+      :inserted_at,
       :approved_at,
       :rejected_at,
       :confirmed_at,
@@ -111,7 +112,8 @@ defmodule EWallet.Web.V1.TransactionConsumptionOverlay do
       :estimated_at,
       :error_code,
       :error_description,
-      :expiration_date
+      :expiration_date,
+      :wallet_address
     ]
 
   def filter_fields,
@@ -124,6 +126,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionOverlay do
       :correlation_id,
       :idempotency_token,
       :status,
+      :inserted_at,
       :approved_at,
       :rejected_at,
       :confirmed_at,
@@ -133,6 +136,7 @@ defmodule EWallet.Web.V1.TransactionConsumptionOverlay do
       :error_code,
       :error_description,
       :expiration_date,
+      :wallet_address,
       transaction: TransactionOverlay.self_filter_fields(),
       exchange_pair: ExchangePairOverlay.self_filter_fields(),
       user: UserOverlay.self_filter_fields(),

--- a/apps/ewallet/lib/ewallet/web/v1/overlays/user_overlay.ex
+++ b/apps/ewallet/lib/ewallet/web/v1/overlays/user_overlay.ex
@@ -77,12 +77,12 @@ defmodule EWallet.Web.V1.UserOverlay do
       inserted_at: nil,
       created_at: nil,
       global_role: nil,
-      invite: InviteOverlay.default_preload_assocs(),
-      wallets: WalletOverlay.default_preload_assocs(),
-      auth_tokens: AuthTokenOverlay.default_preload_assocs(),
-      memberships: MembershipOverlay.default_preload_assocs(),
-      roles: RoleOverlay.default_preload_assocs(),
-      accounts: AccountOverlay.default_preload_assocs()
+      invite: InviteOverlay.self_filter_fields(),
+      wallets: WalletOverlay.self_filter_fields(),
+      auth_tokens: AuthTokenOverlay.self_filter_fields(),
+      memberships: MembershipOverlay.self_filter_fields(),
+      roles: RoleOverlay.self_filter_fields(),
+      accounts: AccountOverlay.self_filter_fields()
     ]
 
   def pagination_fields,


### PR DESCRIPTION
Issue/Task Number: #1063 

Closes #1063

# Overview

This PR adds more fields supported for advanced filtering as following:

- Added `created_at` and `wallet.address` to **TransactionConsumption**.
- Added `accounts.*`, `invite.*`, `wallet.*`, `auth_tokens.*`, `membership.*`, `roles.*` to **User**
- Added `account.*` to **Token**
- Added `user.*` to **Invite**