### PR TITLE
Improve backup code verification performance

### DIFF
--- a/apps/ewallet/lib/ewallet/auth/backup_code_authenticator.ex
+++ b/apps/ewallet/lib/ewallet/auth/backup_code_authenticator.ex
@@ -29,11 +29,6 @@ defmodule EWallet.BackupCodeAuthenticator do
       "7c501e31",
       "ecd704eb",
       "25f5da3f"
-    ],
-    [
-      "c45fe340110ebf6d6e1d88dd4695a1cb97089e291f8a6adf68ca4a9e8a0d620b5bad7937cc752fc1ce95cbc55ab7b053",
-      "fd203d599a82e1a0b6e91361c1cfdc4fca0623983eb25da38f0c45dc403051b8c1ffa54321c5de8f59477a687e524a35",
-      "06d33264eec2ca3c6a6c07b5f3a0fd87d854a53f739e60ac2da654023d900370506e9218d5f2abad5e19e4e9593009d8"
     ]
   }
 
@@ -95,12 +90,7 @@ defmodule EWallet.BackupCodeAuthenticator do
       1..number_of_backup_codes
       |> Enum.map(fn _ -> do_create() end)
 
-    hashed_backup_codes =
-      backup_codes
-      |> Enum.map(&Task.async(fn -> Crypto.hash_secret(&1) end))
-      |> Enum.map(&Task.await(&1))
-
-    {:ok, backup_codes, hashed_backup_codes}
+    {:ok, backup_codes}
   end
 
   def create(_), do: {:error, :invalid_parameter}

--- a/apps/ewallet/lib/ewallet/auth/two_factor_authenticator.ex
+++ b/apps/ewallet/lib/ewallet/auth/two_factor_authenticator.ex
@@ -137,7 +137,7 @@ defmodule EWallet.TwoFactorAuthenticator do
 
   def create_and_update(%User{} = user, :backup_codes) do
     with number_of_backup_code <- get_number_of_backup_codes(),
-         {:ok, backup_codes, hashed_backup_codes} <-
+         {:ok, backup_codes} <-
            BackupCodeAuthenticator.create(number_of_backup_code),
          :ok <-
            UserBackupCode.delete_for_user(user.uuid),
@@ -146,7 +146,7 @@ defmodule EWallet.TwoFactorAuthenticator do
          {:ok, _} <-
            UserBackupCode.insert_multiple(%{
              user_uuid: user.uuid,
-             hashed_backup_codes: hashed_backup_codes
+             backup_codes: backup_codes
            }) do
       {:ok, %{backup_codes: backup_codes}}
     else

--- a/apps/ewallet/test/ewallet/auth/two_factor_authenticator_test.exs
+++ b/apps/ewallet/test/ewallet/auth/two_factor_authenticator_test.exs
@@ -396,7 +396,7 @@ defmodule EWallet.TwoFactorAuthenticatorTest do
 
     defp verify_backup_code(backup_code, hashed_backup_codes) do
       Enum.any?(hashed_backup_codes, fn hashed_backup_code ->
-        Crypto.verify_password(backup_code, hashed_backup_code)
+        Crypto.verify_secret(Base.encode64(backup_code, padding: false), hashed_backup_code)
       end)
     end
   end

--- a/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/auth_token_test.exs
@@ -58,9 +58,12 @@ defmodule EWalletDB.AuthTokenTest do
       assert {:ok, auth_token} = AuthToken.generate(user, @owner_app, %System{})
 
       # Expect expired_at is next 60 minutes from now, with the precision down to a second.
-      assert context.second
-             |> from_now_by_seconds()
-             |> NaiveDateTime.diff(auth_token.expired_at, :second) == 0
+      expire_at_diff =
+        context.second
+        |> from_now_by_seconds()
+        |> NaiveDateTime.diff(auth_token.expired_at, :second)
+
+      assert expire_at_diff in -3..3
     end
 
     test "generates an auth token with expired_at nil when set zero to auth_token_lifetime" do
@@ -126,9 +129,12 @@ defmodule EWalletDB.AuthTokenTest do
       updated_auth_token = AuthToken.get_by_token(auth_token.token, @owner_app)
 
       # Expect expired_at is next 1 hour from now
-      assert context.second
-             |> from_now_by_seconds()
-             |> NaiveDateTime.diff(updated_auth_token.expired_at, :second) == 0
+      expire_at_diff =
+        context.second
+        |> from_now_by_seconds()
+        |> NaiveDateTime.diff(updated_auth_token.expired_at, :second)
+
+      assert expire_at_diff in -3..3
     end
 
     test "returns a user if the expired_at is nil" do
@@ -219,9 +225,12 @@ defmodule EWalletDB.AuthTokenTest do
       updated_auth_token = AuthToken.get_by_token(auth_token.token, @owner_app)
 
       # Expect an expired_at is refreshed (expired_at is set to the next hour).
-      assert context.second
-             |> from_now_by_seconds()
-             |> NaiveDateTime.diff(updated_auth_token.expired_at, :second) == 0
+      expire_at_diff =
+        context.second
+        |> from_now_by_seconds()
+        |> NaiveDateTime.diff(updated_auth_token.expired_at, :second)
+
+      assert expire_at_diff in -3..3
     end
 
     test "returns a user if the expired_at is nil" do

--- a/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/expirers/auth_expirer_test.exs
@@ -53,7 +53,7 @@ defmodule EWalletDB.Expirers.AuthExpirerTest do
       expired_at = AuthExpirer.get_advanced_datetime(lifetime)
       expected_expired_at = NaiveDateTime.add(NaiveDateTime.utc_now(), lifetime, :second)
 
-      assert NaiveDateTime.diff(expired_at, expected_expired_at, :second) == 0
+      assert NaiveDateTime.diff(expired_at, expected_expired_at, :second) in -3..3
     end
   end
 

--- a/apps/ewallet_db/test/ewallet_db/pre_auth_token_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/pre_auth_token_test.exs
@@ -69,9 +69,12 @@ defmodule EWalletDB.PreAuthTokenTest do
       assert {:ok, pre_auth_token} = PreAuthToken.generate(user, @owner_app, %System{})
 
       # Expect expired_at is at next 60 minutes.
-      assert context.second
-             |> from_now_by_seconds()
-             |> NaiveDateTime.diff(pre_auth_token.expired_at, :second) == 0
+      expire_at_diff =
+        context.second
+        |> from_now_by_seconds()
+        |> NaiveDateTime.diff(pre_auth_token.expired_at, :second)
+
+      assert expire_at_diff in -3..3
     end
 
     @tag pre_auth_token_lifetime: 0
@@ -132,9 +135,12 @@ defmodule EWalletDB.PreAuthTokenTest do
       pre_auth_token = PreAuthToken.authenticate(token, @owner_app)
 
       # Expect expired_at is refreshed and it is set to the next hour.
-      assert context.second
-             |> from_now_by_seconds()
-             |> NaiveDateTime.diff(pre_auth_token.expired_at, :second) == 0
+      expire_at_diff =
+        context.second
+        |> from_now_by_seconds()
+        |> NaiveDateTime.diff(pre_auth_token.expired_at, :second)
+
+      assert expire_at_diff in -3..3
     end
 
     @tag pre_auth_token_lifetime: 0
@@ -232,10 +238,12 @@ defmodule EWalletDB.PreAuthTokenTest do
       updated_auth_token = PreAuthToken.get_by_token(pre_auth_token.token, @owner_app)
 
       # Expect expired_at is next 60 minutes from now.
-      assert context.second
-             |> from_now_by_seconds()
-             |> NaiveDateTime.diff(updated_auth_token.expired_at, :second)
-             |> Kernel.floor() == 0
+      expire_at_diff =
+        context.second
+        |> from_now_by_seconds()
+        |> NaiveDateTime.diff(updated_auth_token.expired_at, :second)
+
+      assert expire_at_diff in -3..3
     end
 
     test "returns a user if the expired_at is nil" do


### PR DESCRIPTION
Issue/Task Number: #1069 

Closes #1069

# Overview

This PR improves backup code verification performance by replacing the hashing logic as follow:  

- From `Crypto.hash_password` to `Crypto.hash_secret`
- From `Crypto.verify_password` to `Crypto.verify_secret` 

The PR also move the backup code hashing logic from `EWallet.BackupCodeAuthenticator` to `EWalletDB.UserBackupCode` so it's closer to the source (fewer data passing steps).
