### PR TITLE
Fix match_all & match_any combo failing on nested fields

### DIFF
--- a/apps/ewallet/lib/ewallet/web/filters/match_parser.ex
+++ b/apps/ewallet/lib/ewallet/web/filters/match_parser.ex
@@ -154,6 +154,14 @@ defmodule EWallet.Web.MatchParser do
   defp get_field_definition(_, _), do: nil
 
   defp join_assocs(queryable, rules) do
+    # Offset the existing joins already present on the query
+    # If it's not a query, then it should be safe enough to assume the offet is zero
+    assoc_offset =
+      case queryable do
+        %Ecto.Query{} = queryable -> length(queryable.joins)
+        _ -> 0
+      end
+
     {queryable, joined_assocs} =
       Enum.reduce(rules, {queryable, []}, fn rule, {queryable, joined_assocs} ->
         {field_definition, _comparator, _value} = rule
@@ -173,7 +181,7 @@ defmodule EWallet.Web.MatchParser do
     joined_assocs =
       joined_assocs
       |> Enum.reverse()
-      |> Enum.with_index()
+      |> Enum.with_index(assoc_offset)
 
     {queryable, joined_assocs}
   end


### PR DESCRIPTION
Issue/Task Number: #1079 
Close #1079

# Overview

This PR fixes the internal server error when filtering with both `match_all` and `match_any` with both containing nested fields.

# Changes

- Added an offset to `MatchParser.join_assocs/2` so it offsets the new join position with any joins that happened before entering the function.

# Implementation Details

`MatchParser` relied on join position to correctly place its `where` conditions. Previously this position did not take into account any previous joins that have already happened and so it attempts to `where` on the incorrect join. 

This PR counts the number of existing joins and offset the new join position by that number.

# Usage

Try another request with filtering, example in #1079

# Impact

No changes to DB schema or API specs.