### PR TITLE
Fix private key generation

### DIFF
--- a/apps/keychain/lib/keychain/wallet.ex
+++ b/apps/keychain/lib/keychain/wallet.ex
@@ -16,7 +16,6 @@ defmodule Keychain.Wallet do
   @moduledoc false
 
   alias Keychain.Key
-  alias ExthCrypto.ECIES.ECDH
   alias ExthCrypto.Hash.Keccak
 
   @typep address :: Keychain.address()
@@ -29,7 +28,8 @@ defmodule Keychain.Wallet do
   """
   @spec generate :: resp({:ok, address()})
   def generate do
-    {public_key, private_key} = ECDH.new_ecdh_keypair()
+    {public_key, private_key} =
+      :crypto.generate_key(:ecdh, :secp256k1, :crypto.strong_rand_bytes(32))
 
     <<4::size(8), key::binary-size(64)>> = public_key
     <<_::binary-size(12), wallet_address::binary-size(20)>> = Keccak.kec(key)


### PR DESCRIPTION
Issue/Task Number: 1125
Closes #1125 

# Overview

This PR fixes the way private keys for the hot wallets are generated.
Previously, the byte size of the private key was randomly 31 instead of 32. 

# Implementation Details

Instead of using the `ExthCrypto.ECIES.ECDH. new_ecdh_keypair ` function, we directly use the erlang function and pass it the randomly generated private key.