### PR TITLE
Fix broken link in readme

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,7 +8,7 @@ Take a deeper dive into the eWallet. Learn more about how to use the eWallet Ser
 - [Transaction Request Flow](/docs/guides/transaction_request_flow.md): Learn more about creating and consuming transaction requests.
 - [Advanced Filtering](/docs/guides/advanced_filtering.md): Find out how you can retrieve records based on composable filters with our advance filtering feature.
 - [eWallet API Websockets](/docs/guides/ewallet_api_websockets.md): Learn how to integrate eWallet API websockets into your applications.
-- [Two-factor Authentication](/doc/guides/two_factor_authentication.md): Learn how to use two-factor authentication APIs.
+- [Two-factor Authentication](/docs/guides/two_factor_authentication.md): Learn how to use two-factor authentication APIs.
 
 ## Glossary
 


### PR DESCRIPTION
Path was doc not docs in [Two-factor Authentication](/docs/guides/two_factor_authentication.md) and pointing to Page not found
