### PR TITLE
Notify failures to slack only for main branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,11 @@ commands:
           name: Notify Slack on failure
           command: |
             # Only notify for main branches. "eth_blockchain" condition may be removed if no longer used on the repo.
-            if [ "$CIRCLE_BRANCH" != "master" ] && [ ! "$CIRCLE_BRANCH" =~ ^v[[:digit:]]+.* ] && [ "$CIRCLE_BRANCH" != "eth_blockchain" ]; then
-              exit 0
-            fi
+            case "$CIRCLE_BRANCH" in
+              master | v[[:digit:]]+.* | eth_blockchain )
+                exit 0
+                ;;
+            esac
 
             if [ -z "$SLACK_WEBHOOK" ]; then
               printf "\\033[0;33mSkipping Slack notification (SLACK_WEBHOOK missing)\\033[0;0m\\n"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ commands:
       - run:
           name: Notify Slack on failure
           command: |
+            # Only notify for main branches. "eth_blockchain" condition may be removed if no longer used on the repo.
+            if [ "$CIRCLE_BRANCH" != "master" ] && [ ! "$CIRCLE_BRANCH" =~ ^v[[:digit:]]+.* ] && [ "$CIRCLE_BRANCH" != "eth_blockchain" ]; then
+              exit 0
+            fi
+
             if [ -z "$SLACK_WEBHOOK" ]; then
               printf "\\033[0;33mSkipping Slack notification (SLACK_WEBHOOK missing)\\033[0;0m\\n"
               exit 0


### PR DESCRIPTION
Issue/Task Number: -

# Overview

Now with many members working on the repo, the slack notifications are getting a bit noisy. This PR limits failure notifications to main branches namely `master`, `v[0-9]+.*` and `eth_blockchain` (`eth_blockchain` can be removed once done).

# Changes

- Update circleci's config for `notify_slack_failure` to notify only for main branches

# Implementation Details

N/A

# Usage

N/A

# Impact

N/A