### PR TITLE
Supporting internal -> external transactions

### DIFF
--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_local_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_local_transaction_gate.ex
@@ -46,7 +46,7 @@ defmodule EWallet.BlockchainLocalTransactionGate do
   end
 
   def process_with_transaction(
-        %Transaction{local_ledger_uuid: local_ledger_uuid, status: "ledger_blockchain_confirmed"} =
+        %Transaction{local_ledger_uuid: local_ledger_uuid, status: "ledger_pending_blockchain_confirmed"} =
           transaction
       )
       when not is_nil(local_ledger_uuid) do
@@ -151,7 +151,7 @@ defmodule EWallet.BlockchainLocalTransactionGate do
 
   defp update_transaction(
          {:ok, _ledger_transaction},
-         %{status: "ledger_blockchain_confirmed"} = transaction,
+         %{status: "ledger_pending_blockchain_confirmed"} = transaction,
          :from_ledger_to_blockchain
        ) do
     {:ok, transaction} =

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_local_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_local_transaction_gate.ex
@@ -31,7 +31,34 @@ defmodule EWallet.BlockchainLocalTransactionGate do
     |> set_blockchain_wallets(:from_wallet, :from, from_blockchain?)
     |> TransactionFormatter.format()
     |> LedgerTransaction.insert(%{genesis: from_blockchain?})
-    |> update_transaction(transaction)
+    |> update_transaction(transaction, :from_blockchain_to_ledger)
+  end
+
+  def process_with_transaction(%Transaction{status: "pending"} = transaction) do
+    to_blockchain? = to_blockchain?(transaction)
+
+    transaction
+    |> Preloader.preload([:from_token, :to_token, :from_wallet, :to_wallet])
+    |> set_blockchain_wallets(:to_wallet, :to, to_blockchain?)
+    |> TransactionFormatter.format()
+    |> LedgerTransaction.insert(%{genesis: false, status: "pending"})
+    |> update_transaction(transaction, :from_ledger_to_blockchain)
+  end
+
+  def process_with_transaction(%Transaction{local_ledger_uuid: local_ledger_uuid, status: "ledger_blockchain_confirmed"} = transaction)
+  when not is_nil(local_ledger_uuid)
+  do
+    local_ledger_uuid
+    |> LedgerTransaction.confirm()
+    |> update_transaction(transaction, :from_ledger_to_blockchain)
+  end
+
+  def process_with_transaction(%Transaction{local_ledger_uuid: local_ledger_uuid, status: "failed_blockchain"} = transaction)
+  when not is_nil(local_ledger_uuid)
+  do
+    local_ledger_uuid
+    |> LedgerTransaction.fail()
+    |> update_transaction(transaction, :from_ledger_to_blockchain)
   end
 
   defp set_blockchain_wallets(transaction, _, _, false), do: transaction
@@ -52,9 +79,15 @@ defmodule EWallet.BlockchainLocalTransactionGate do
       !is_nil(transaction.blockchain_identifier)
   end
 
+  defp to_blockchain?(transaction) do
+    is_nil(transaction.to) && !is_nil(transaction.to_blockchain_address) &&
+      !is_nil(transaction.blockchain_identifier)
+  end
+
   defp update_transaction(
          _,
-         %Transaction{local_ledger_uuid: local_ledger_uuid, error_code: error_code} = transaction
+         %Transaction{local_ledger_uuid: local_ledger_uuid, error_code: error_code} = transaction,
+         _
        )
        when local_ledger_uuid != nil
        when error_code != nil do
@@ -63,7 +96,8 @@ defmodule EWallet.BlockchainLocalTransactionGate do
 
   defp update_transaction(
          {:ok, ledger_transaction},
-         transaction
+         transaction,
+         :from_blockchain_to_ledger
        ) do
     {:ok, transaction} =
       TransactionState.transition_to(
@@ -79,20 +113,61 @@ defmodule EWallet.BlockchainLocalTransactionGate do
     {:ok, transaction}
   end
 
-  defp update_transaction({:error, code, description}, transaction) do
+
+  def update_transaction({:error, code, description}, transaction, flow) do
+    {description, data} =
+      if(is_map(description), do: {nil, description}, else: {description, nil})
+
     {:ok, transaction} =
       TransactionState.transition_to(
-        :from_ledger_to_ledger,
+        flow,
         TransactionState.failed(),
         transaction,
         %{
-          error_code: code,
+          error_code: Atom.to_string(code),
           error_description: description,
-          error_data: nil,
+          error_data: data,
           originator: %System{}
         }
       )
 
     {:error, transaction}
+  end
+
+  def update_transaction(
+        {:ok, ledger_transaction},
+        %{status: "pending"} = transaction,
+        :from_ledger_to_blockchain
+      ) do
+    {:ok, transaction} =
+      TransactionState.transition_to(
+        :from_ledger_to_blockchain,
+        TransactionState.ledger_pending(),
+        transaction,
+        %{
+          local_ledger_uuid: ledger_transaction.uuid,
+          originator: %System{}
+        }
+      )
+
+    {:ok, transaction}
+  end
+
+  def update_transaction(
+        {:ok, _ledger_transaction},
+        %{status: "ledger_blockchain_confirmed"} = transaction,
+        :from_ledger_to_blockchain
+      ) do
+    {:ok, transaction} =
+      TransactionState.transition_to(
+        :from_ledger_to_blockchain,
+        TransactionState.confirmed(),
+        transaction,
+        %{
+          originator: %System{}
+        }
+      )
+
+    {:ok, transaction}
   end
 end

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_local_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_local_transaction_gate.ex
@@ -45,17 +45,21 @@ defmodule EWallet.BlockchainLocalTransactionGate do
     |> update_transaction(transaction, :from_ledger_to_blockchain)
   end
 
-  def process_with_transaction(%Transaction{local_ledger_uuid: local_ledger_uuid, status: "ledger_blockchain_confirmed"} = transaction)
-  when not is_nil(local_ledger_uuid)
-  do
+  def process_with_transaction(
+        %Transaction{local_ledger_uuid: local_ledger_uuid, status: "ledger_blockchain_confirmed"} =
+          transaction
+      )
+      when not is_nil(local_ledger_uuid) do
     local_ledger_uuid
     |> LedgerTransaction.confirm()
     |> update_transaction(transaction, :from_ledger_to_blockchain)
   end
 
-  def process_with_transaction(%Transaction{local_ledger_uuid: local_ledger_uuid, status: "failed_blockchain"} = transaction)
-  when not is_nil(local_ledger_uuid)
-  do
+  def process_with_transaction(
+        %Transaction{local_ledger_uuid: local_ledger_uuid, status: "failed_blockchain"} =
+          transaction
+      )
+      when not is_nil(local_ledger_uuid) do
     local_ledger_uuid
     |> LedgerTransaction.fail()
     |> update_transaction(transaction, :from_ledger_to_blockchain)

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_local_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_local_transaction_gate.ex
@@ -46,8 +46,10 @@ defmodule EWallet.BlockchainLocalTransactionGate do
   end
 
   def process_with_transaction(
-        %Transaction{local_ledger_uuid: local_ledger_uuid, status: "ledger_pending_blockchain_confirmed"} =
-          transaction
+        %Transaction{
+          local_ledger_uuid: local_ledger_uuid,
+          status: "ledger_pending_blockchain_confirmed"
+        } = transaction
       )
       when not is_nil(local_ledger_uuid) do
     local_ledger_uuid

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
@@ -221,8 +221,11 @@ defmodule EWallet.BlockchainTransactionGate do
     end
   end
 
+  # The destination is nil when the transaction is intended to arrive and stay
+  # in the hot wallet, not part of any local ledger wallet, not even the master wallet.
+  # Therefore, we do not proceed to BlockchainLocalTransactionGate in this case and simply
+  # move the transaction to confirmed state.
   def handle_local_insert(%{to: nil} = transaction) do
-    # TODO: Should not this function also insert local ledger (genesis) transactions?
     TransactionState.transition_to(
       :from_blockchain_to_ewallet,
       TransactionState.confirmed(),

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
@@ -99,13 +99,13 @@ defmodule EWallet.BlockchainTransactionGate do
     {:error, :invalid_to_address_for_blockchain_transaction}
   end
 
-  # Here we're handling a regular transaction getting funds out of an
-  # internal wallet to a blockchain address
+  # Sends funds out of an internal wallet to a blockchain address
+  #
+  # Steps:
+  # 1. Insert a local transaction with status: "pending"
+  # 2. Submit a transaction to the blockchain
+  # 3. Start a transaction tracker to confirm the local transaction after enough confirmations
   def create(actor, attrs, {false, true}) do
-    # TODO: Next PR
-    # Insert pending local transaction
-    # submit to blockchain
-    # once enough confirmations, confirm local transaction
     identifier = BlockchainHelper.identifier()
     primary_hot_wallet = BlockchainWallet.get_primary_hot_wallet(identifier)
 
@@ -144,8 +144,8 @@ defmodule EWallet.BlockchainTransactionGate do
     end
   end
 
-  # Handle external -> hot
-  # Handle external -> internal
+  # Handle external -> hot wallet (not registered in local ledger)
+  # Handle external -> internal wallet (registered in local ledger)
   def create_from_tracker(attrs) do
     case Transaction.insert(attrs) do
       {:ok, transaction} ->

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
@@ -222,6 +222,7 @@ defmodule EWallet.BlockchainTransactionGate do
   end
 
   def handle_local_insert(%{to: nil} = transaction) do
+    # TODO: Should not this function also insert local ledger (genesis) transactions?
     TransactionState.transition_to(
       :from_blockchain_to_ewallet,
       TransactionState.confirmed(),

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
@@ -316,8 +316,8 @@ defmodule EWallet.BlockchainTransactionGate do
 
   defp check_amount(%{"amount" => amount}) do
     {:error, :invalid_parameter,
-     "Invalid parameter provided. `amount` must be an integer or integer string."
-     <> " Given: #{inspect(amount)}."}
+     "Invalid parameter provided. `amount` must be an integer or integer string." <>
+       " Given: #{inspect(amount)}."}
   end
 
   defp check_amount(%{"from_amount" => from_amount} = attrs) when is_binary(from_amount) do
@@ -337,8 +337,8 @@ defmodule EWallet.BlockchainTransactionGate do
   defp check_amount(%{"from_amount" => from_amount, "to_amount" => to_amount})
        when is_integer(from_amount) and is_integer(to_amount) and from_amount != to_amount do
     {:error, :invalid_parameter,
-     "Invalid parameter provided. `from_amount` and `to_amount` must be equal."
-     <> " Given: #{inspect(from_amount)} and #{inspect(to_amount)} respectively."}
+     "Invalid parameter provided. `from_amount` and `to_amount` must be equal." <>
+       " Given: #{inspect(from_amount)} and #{inspect(to_amount)} respectively."}
   end
 
   defp check_amount(%{"from_amount" => from_amount, "to_amount" => to_amount} = attrs)
@@ -348,13 +348,13 @@ defmodule EWallet.BlockchainTransactionGate do
 
   defp check_amount(%{"from_amount" => from_amount, "to_amount" => to_amount}) do
     {:error, :invalid_parameter,
-     "Invalid parameter provided. `from_amount` and `to_amount` must be integers or integer strings."
-     <> " Given: #{inspect(from_amount)} and #{inspect(to_amount)} respectively."}
+     "Invalid parameter provided. `from_amount` and `to_amount` must be integers or integer strings." <>
+       " Given: #{inspect(from_amount)} and #{inspect(to_amount)} respectively."}
   end
 
   defp check_amount(_) do
     {:error, :invalid_parameter,
-      "Invalid parameter provided. `amount`, `from_amount` or `to_amount` is required."}
+     "Invalid parameter provided. `amount`, `from_amount` or `to_amount` is required."}
   end
 
   #

--- a/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
+++ b/apps/ewallet/lib/ewallet/gates/transactions/blockchain_transaction_gate.ex
@@ -64,9 +64,10 @@ defmodule EWallet.BlockchainTransactionGate do
          %{} = attrs <- set_blockchain_addresses(attrs),
          %{} = attrs <- set_token(attrs),
          %{} = attrs <- check_amount(attrs),
+         # TODO: add this error
          true <-
            enough_funds?(from, attrs["from_token"], attrs["from_amount"]) ||
-             {:error, :insufficient_funds_in_hot_wallet}, # TODO: add this error
+             {:error, :insufficient_funds_in_hot_wallet},
          %{} = attrs <- set_blockchain(attrs),
          {:ok, transaction} <- get_or_insert(attrs),
          {:ok, tx_hash} <- submit(transaction),
@@ -118,7 +119,8 @@ defmodule EWallet.BlockchainTransactionGate do
              {:error, :insufficient_funds_in_hot_wallet},
          %{} = attrs <- set_blockchain(attrs),
          {:ok, transaction} <- get_or_insert(attrs),
-         {:ok, transaction} <- BlockchainLocalTransactionGate.process_with_transaction(transaction),
+         {:ok, transaction} <-
+           BlockchainLocalTransactionGate.process_with_transaction(transaction),
          {:ok, tx_hash} <- submit(transaction),
          {:ok, transaction} <-
            TransactionState.transition_to(
@@ -127,7 +129,6 @@ defmodule EWallet.BlockchainTransactionGate do
              transaction,
              %{blockchain_tx_hash: tx_hash, originator: %System{}}
            ),
-          # Update in ledger after completion
          :ok =
            TransactionRegistry.start_tracker(TransactionTracker, %{
              transaction: transaction,

--- a/apps/ewallet/test/ewallet/gates/blockchain/blockchain_deposit_wallet_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/blockchain/blockchain_deposit_wallet_gate_test.exs
@@ -78,6 +78,7 @@ defmodule EWallet.BlockchainDepositWalletGateTest do
     end
 
     test "returns :hd_wallet_not_found error if the primary HD wallet is missing" do
+      BlockchainHDWallet.get_primary() |> Repo.delete()
       wallet = insert(:wallet)
       _ = Repo.delete_all(BlockchainHDWallet)
 

--- a/apps/ewallet/test/ewallet/gates/transactions/blockchain_transaction_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transactions/blockchain_transaction_gate_test.exs
@@ -30,7 +30,8 @@ defmodule EWallet.BlockchainTransactionGateTest do
   alias Ecto.UUID
 
   describe "create/2" do
-    test "submits a transaction to the blockchain subapp (internal to blockchain address", meta do
+    test "submits a transaction to the blockchain subapp (internal to blockchain address)",
+         meta do
       # TODO: switch to using the seeded Ethereum address
       admin = insert(:admin, global_role: "super_admin")
 
@@ -72,7 +73,8 @@ defmodule EWallet.BlockchainTransactionGateTest do
       receive do
         {:DOWN, ^ref, _, _, _} ->
           transaction = Transaction.get(transaction.id)
-          assert %{confirmations_count: 13, status: "confirmed"} = transaction
+          assert %{confirmations_count: count, status: "confirmed"} = transaction
+          assert count > 10
 
           {:ok, %{balances: [main_balance]}} = BalanceFetcher.all(%{"wallet" => master_wallet})
           assert main_balance[:amount] == 99_999_999
@@ -118,7 +120,6 @@ defmodule EWallet.BlockchainTransactionGateTest do
         {:DOWN, ^ref, _, _, _} ->
           transaction = Transaction.get(transaction.id)
           assert %{confirmations_count: 13, status: "confirmed"} = transaction
-          :ok = GenServer.stop(pid)
       end
     end
 
@@ -192,7 +193,7 @@ defmodule EWallet.BlockchainTransactionGateTest do
         "originator" => %System{}
       }
 
-      assert {:error, :insufficient_funds} ==
+      assert {:error, :insufficient_funds_in_hot_wallet} ==
                BlockchainTransactionGate.create(admin, attrs, {true, true})
     end
 

--- a/apps/ewallet/test/ewallet/gates/transactions/blockchain_transaction_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transactions/blockchain_transaction_gate_test.exs
@@ -167,12 +167,12 @@ defmodule EWallet.BlockchainTransactionGateTest do
       }
 
       assert BlockchainTransactionGate.create(admin, attrs, {true, true}) ==
-        {
-          :error,
-          :invalid_parameter,
-          "Invalid parameter provided. `from_amount` and `to_amount` must be equal." <>
-          " Given: 1 and 2 respectively."
-        }
+               {
+                 :error,
+                 :invalid_parameter,
+                 "Invalid parameter provided. `from_amount` and `to_amount` must be equal." <>
+                   " Given: 1 and 2 respectively."
+               }
     end
 
     test "returns an error when the hot wallet doesn't have enough funds" do

--- a/apps/ewallet/test/ewallet/gates/transactions/blockchain_transaction_gate_test.exs
+++ b/apps/ewallet/test/ewallet/gates/transactions/blockchain_transaction_gate_test.exs
@@ -73,8 +73,8 @@ defmodule EWallet.BlockchainTransactionGateTest do
       receive do
         {:DOWN, ^ref, _, _, _} ->
           transaction = Transaction.get(transaction.id)
-          assert %{confirmations_count: count, status: "confirmed"} = transaction
-          assert count > 10
+          assert transaction.status == TransactionState.confirmed()
+          assert transaction.confirmations_count > 10
 
           {:ok, %{balances: [main_balance]}} = BalanceFetcher.all(%{"wallet" => master_wallet})
           assert main_balance[:amount] == 99_999_999
@@ -119,7 +119,8 @@ defmodule EWallet.BlockchainTransactionGateTest do
       receive do
         {:DOWN, ^ref, _, _, _} ->
           transaction = Transaction.get(transaction.id)
-          assert %{confirmations_count: 13, status: "confirmed"} = transaction
+          assert transaction.confirmations_count == 13
+          assert transaction.status == TransactionState.confirmed()
       end
     end
 
@@ -260,7 +261,7 @@ defmodule EWallet.BlockchainTransactionGateTest do
       receive do
         {:DOWN, ^ref, _, _, _} ->
           transaction = Transaction.get(transaction.id)
-          assert transaction.status == "confirmed"
+          assert transaction.status == TransactionState.confirmed()
       end
     end
 
@@ -358,7 +359,7 @@ defmodule EWallet.BlockchainTransactionGateTest do
       assert TransactionRegistry.lookup(transaction.uuid) == {:error, :not_found}
 
       transaction = Transaction.get(transaction.id)
-      assert transaction.status == "confirmed"
+      assert transaction.status == TransactionState.confirmed()
       # Check balance
       {:ok, %{balances: [balance]}} = BalanceFetcher.all(%{"wallet" => wallet})
       assert balance[:amount] == 1

--- a/apps/ewallet/test/ewallet/trackers/address_tracker_test.exs
+++ b/apps/ewallet/test/ewallet/trackers/address_tracker_test.exs
@@ -31,6 +31,8 @@ defmodule EWallet.AddressTrackerTest do
   alias ActivityLogger.System
   alias Utils.Helpers.Crypto
 
+  @minimum_confirmation_counts 10
+
   describe "start_link/1" do
     test "starts a new server" do
       _hot_wallet = insert(:blockchain_wallet, type: "hot")
@@ -203,8 +205,7 @@ defmodule EWallet.AddressTrackerTest do
             0,
             "01",
             default_token.uuid,
-            1_000,
-            15
+            1_000
           )
 
           # build_eth_transaction(0, "02", hot_wallet_address, other_address, 1_000)
@@ -218,8 +219,7 @@ defmodule EWallet.AddressTrackerTest do
             0,
             "02",
             default_token.uuid,
-            1_000,
-            15
+            1_000
           )
 
           # build_eth_transaction(0, "03", hot_wallet_address, other_address, 1_000)
@@ -233,8 +233,7 @@ defmodule EWallet.AddressTrackerTest do
             0,
             "03",
             default_token.uuid,
-            1_000,
-            15
+            1_000
           )
 
           # build_eth_transaction(0, "04", other_address, deposit_wallet_address, 1_000)
@@ -248,8 +247,7 @@ defmodule EWallet.AddressTrackerTest do
             0,
             "04",
             default_token.uuid,
-            1_000,
-            15
+            1_000
           )
 
           # build_eth_transaction(0, "04", other_address, Crypto.fake_eth_address(), 1_000)
@@ -267,8 +265,7 @@ defmodule EWallet.AddressTrackerTest do
             1,
             "11",
             default_token.uuid,
-            1_337_000,
-            14
+            1_337_000
           )
 
           # build_erc20_transaction(1, "12", erc20_address, hot_wallet_address,
@@ -283,8 +280,7 @@ defmodule EWallet.AddressTrackerTest do
             1,
             "12",
             erc20_token.uuid,
-            1_000,
-            14
+            1_000
           )
 
           # build_erc20_transaction(1, "13", erc20_address, other_address,
@@ -299,8 +295,7 @@ defmodule EWallet.AddressTrackerTest do
             1,
             "13",
             erc20_token.uuid,
-            1_000,
-            14
+            1_000
           )
 
           # build_erc20_transaction(1, "13", erc20_address, other_address, other_address, 1_000)
@@ -321,8 +316,7 @@ defmodule EWallet.AddressTrackerTest do
             2,
             "21",
             default_token.uuid,
-            1_000,
-            13
+            1_000
           )
 
           # build_erc20_transaction(2, "22", erc20_address, other_address,
@@ -337,8 +331,7 @@ defmodule EWallet.AddressTrackerTest do
             2,
             "22",
             erc20_token.uuid,
-            25_000,
-            13
+            25_000
           )
 
           # Check the balance of the deposit wallet to ensure the
@@ -369,12 +362,11 @@ defmodule EWallet.AddressTrackerTest do
          blk_number,
          tx_hash,
          token_uuid,
-         amount,
-         confirmations_count
+         amount
        ) do
     assert transaction.blockchain_tx_hash == tx_hash
     assert transaction.status == TransactionState.confirmed()
-    assert transaction.confirmations_count > 10
+    assert transaction.confirmations_count > @minimum_confirmation_counts
     assert transaction.from_blockchain_address == from_bc
     assert transaction.to_blockchain_address == to_bc
     assert transaction.from == from

--- a/apps/ewallet/test/ewallet/trackers/address_tracker_test.exs
+++ b/apps/ewallet/test/ewallet/trackers/address_tracker_test.exs
@@ -374,7 +374,7 @@ defmodule EWallet.AddressTrackerTest do
        ) do
     assert transaction.blockchain_tx_hash == tx_hash
     assert transaction.status == TransactionState.confirmed()
-    assert transaction.confirmations_count == confirmations_count
+    assert transaction.confirmations_count > 10
     assert transaction.from_blockchain_address == from_bc
     assert transaction.to_blockchain_address == to_bc
     assert transaction.from == from

--- a/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
+++ b/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
@@ -84,7 +84,11 @@ defmodule EWalletDB.TransactionState do
       @pending => [@ledger_pending, @failed],
       @ledger_pending => [@blockchain_submitted, @blockchain_failed],
       @blockchain_submitted => [@pending_confirmations, @blockchain_confirmed, @blockchain_failed],
-      @pending_confirmations => [@pending_confirmations, @ledger_blockchain_confirmed, @blockchain_failed],
+      @pending_confirmations => [
+        @pending_confirmations,
+        @ledger_blockchain_confirmed,
+        @blockchain_failed
+      ],
       @ledger_blockchain_confirmed => [@confirmed],
       @confirmed => []
     }
@@ -109,6 +113,7 @@ defmodule EWalletDB.TransactionState do
   def ledger_pending, do: @ledger_pending
   def pending_confirmations, do: @pending_confirmations
   def blockchain_confirmed, do: @blockchain_confirmed
+  def ledger_blockchain_confirmed, do: @ledger_blockchain_confirmed
   def ledger_confirmed, do: @ledger_confirmed
 
   def states, do: @states

--- a/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
+++ b/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
@@ -107,17 +107,87 @@ defmodule EWalletDB.TransactionState do
     @ledger_pending_blockchain_confirmed
   ]
 
+  @doc """
+  Returns "pending" status's string representation.
+
+  A transaction enters the "pending" status at the very beginning of the transaction flow,
+  when it is not yet recorded by the local ledger, and if also applicable,
+  not yet recorded by the blockchain.
+  """
   def pending, do: @pending
+
+  @doc """
+  Returns the "confirmed" status's string representation.
+
+  A transaction enters the "confirmed" status when it is fully complete. That is,
+  it is successfully recorded by the local ledger, and if also applicable, by the blockchain.
+  """
   def confirmed, do: @confirmed
+
+  @doc """
+  Returns the "failed" status's string representation.
+
+  A transaction enters the "failed" status when it failed at some point. This could be a failure
+  at the local ledger or blockchain level. No further actions can be performed on this transaction.
+  """
   def failed, do: @failed
-  def blockchain_submitted, do: @blockchain_submitted
+
+  @doc """
+  Returns the "ledger_pending" status's string representation.
+
+  A transaction enters the "ledger_pending" status when the transaction has been recorded into
+  the local ledger, but the ledger entries are marked with "pending" status. This means this
+  transaction may be reverted if the blockchain submission or confirmation is unsuccessful.
+  """
   def ledger_pending, do: @ledger_pending
+
+  @doc """
+  Returns the "blockchain_submitted" status's string representation.
+
+  A transaction enters the "blockchain_submitted" status when the transaction has been submitted
+  to the blockchain. A transaction gains this status immediately after a succfessful submission
+  with zero block confirmation.
+  """
+  def blockchain_submitted, do: @blockchain_submitted
+
+  @doc """
+  Returns the "pending_confirmations" status's string representation.
+
+  A transaction enters the "pending_confirmations" status when the transaction has been submitted
+  to the blockchain, and some confirmations have been received. However, the number of confirmations
+  have not reached the threshold to be considered a successful transaction.
+  """
   def pending_confirmations, do: @pending_confirmations
+
+  @doc """
+  Returns the "blockchain_confirmed" status's string representation.
+
+  A transaction enters the "blockchain_confirmed" status when the number of confirmations reach
+  the threshold to be considered successful. This status is used for incoming transactions
+  where the transaction is recorded to the ledger only after the blockchain transaction is
+  confirmed. Outgoing transactions use `ledger_pending_blockchain_confirmed/0` instead.
+  """
   def blockchain_confirmed, do: @blockchain_confirmed
 
-  def states, do: @states
+  @doc """
+  Returns the "ledger_pending_blockchain_confirmed" status's string representation.
+
+  A transaction enters the "ledger_pending_blockchain_confirmed" status when the number of confirmations reach
+  the threshold to be considered successful. This status is used for outgoing transactions
+  where the transaction is recorded to the ledger with "pending" entries before the blockchain
+  transaction is confirmed. Incoming transactions use `blockchain_confirmed/0` instead.
+  """
   def ledger_pending_blockchain_confirmed, do: @ledger_pending_blockchain_confirmed
+
+  @doc """
+  Returns the list of all possible string representations of transaction statuses.
+  """
   def statuses, do: @statuses
+
+  @doc """
+  Returns a map containing all possible transitions for each transaction flow.
+  """
+  def states, do: @states
 
   def transition_to(flow_name, new_state, %{status: state} = transaction, attrs) do
     with flow when is_map(flow) <- @states[flow_name] || :state_flow_not_found,

--- a/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
+++ b/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
@@ -27,12 +27,11 @@ defmodule EWalletDB.TransactionState do
   @pending_confirmations "pending_confirmations"
   @ledger_blockchain_confirmed "ledger_blockchain_confirmed"
   @blockchain_confirmed "blockchain_confirmed"
-  @ledger_confirmed "ledger_confirmed"
 
   # For each state, we have {[cast_fields], [required_fields]}
   @attrs %{
     @pending => {[], []},
-    @confirmed => {[:local_ledger_uuid], []},
+    @confirmed => {[:local_ledger_uuid], [:ledger_ledger_uuid]},
     @failed => {[:error_code, :error_description, :error_data], [:error_code]},
     @blockchain_failed => {[:error_code, :error_description, :error_data], [:error_code]},
     @blockchain_submitted => {[:blockchain_tx_hash], [:blockchain_tx_hash]},
@@ -40,7 +39,6 @@ defmodule EWalletDB.TransactionState do
     @pending_confirmations => {[:confirmations_count], [:confirmations_count]},
     @ledger_blockchain_confirmed => {[:confirmations_count], [:confirmations_count]},
     @blockchain_confirmed => {[:confirmations_count], [:confirmations_count]},
-    @ledger_confirmed => {[:ledger_ledger_uuid], [:ledger_ledger_uuid]}
   }
 
   @states %{
@@ -103,7 +101,6 @@ defmodule EWalletDB.TransactionState do
     @pending_confirmations,
     @blockchain_confirmed,
     @ledger_blockchain_confirmed,
-    @ledger_confirmed
   ]
 
   def pending, do: @pending
@@ -114,7 +111,6 @@ defmodule EWalletDB.TransactionState do
   def pending_confirmations, do: @pending_confirmations
   def blockchain_confirmed, do: @blockchain_confirmed
   def ledger_blockchain_confirmed, do: @ledger_blockchain_confirmed
-  def ledger_confirmed, do: @ledger_confirmed
 
   def states, do: @states
   def statuses, do: @statuses

--- a/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
+++ b/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
@@ -31,7 +31,7 @@ defmodule EWalletDB.TransactionState do
   # For each state, we have {[cast_fields], [required_fields]}
   @attrs %{
     @pending => {[], []},
-    @confirmed => {[:local_ledger_uuid], [:local_ledger_uuid]},
+    @confirmed => {[:local_ledger_uuid], []},
     @failed => {[:error_code, :error_description, :error_data], [:error_code]},
     @blockchain_failed => {[:error_code, :error_description, :error_data], [:error_code]},
     @blockchain_submitted => {[:blockchain_tx_hash], [:blockchain_tx_hash]},

--- a/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
+++ b/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
@@ -83,7 +83,7 @@ defmodule EWalletDB.TransactionState do
       @ledger_pending => [@blockchain_submitted, @blockchain_failed],
       @blockchain_submitted => [
         @pending_confirmations,
-        @ledger_pending_blockchain_confirmed,
+        @blockchain_confirmed,
         @blockchain_failed
       ],
       @pending_confirmations => [

--- a/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
+++ b/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
@@ -21,9 +21,11 @@ defmodule EWalletDB.TransactionState do
   @pending "pending"
   @confirmed "confirmed"
   @failed "failed"
+  @blockchain_failed "blockchain_failed"
   @blockchain_submitted "blockchain_submitted"
   @ledger_pending "ledger_pending"
   @pending_confirmations "pending_confirmations"
+  @ledger_blockchain_confirmed "ledger_blockchain_confirmed"
   @blockchain_confirmed "blockchain_confirmed"
   @ledger_confirmed "ledger_confirmed"
 
@@ -32,9 +34,11 @@ defmodule EWalletDB.TransactionState do
     @pending => {[], []},
     @confirmed => {[:local_ledger_uuid], []},
     @failed => {[:error_code, :error_description, :error_data], [:error_code]},
+    @blockchain_failed => {[:error_code, :error_description, :error_data], [:error_code]},
     @blockchain_submitted => {[:blockchain_tx_hash], [:blockchain_tx_hash]},
     @ledger_pending => {[], []},
     @pending_confirmations => {[:confirmations_count], [:confirmations_count]},
+    @ledger_blockchain_confirmed => {[:confirmations_count], [:confirmations_count]},
     @blockchain_confirmed => {[:confirmations_count], [:confirmations_count]},
     @ledger_confirmed => {[:ledger_ledger_uuid], [:ledger_ledger_uuid]}
   }
@@ -78,10 +82,10 @@ defmodule EWalletDB.TransactionState do
     # -> blockchain_confirmed -> confirmed
     from_ledger_to_blockchain: %{
       @pending => [@ledger_pending, @failed],
-      @ledger_pending => [@blockchain_submitted],
-      @blockchain_submitted => [@pending_confirmations],
-      @pending_confirmations => [@blockchain_confirmed],
-      @blockchain_confirmed => [@confirmed],
+      @ledger_pending => [@blockchain_submitted, @blockchain_failed],
+      @blockchain_submitted => [@pending_confirmations, @blockchain_confirmed, @blockchain_failed],
+      @pending_confirmations => [@pending_confirmations, @ledger_blockchain_confirmed, @blockchain_failed],
+      @ledger_blockchain_confirmed => [@confirmed],
       @confirmed => []
     }
   }
@@ -94,6 +98,7 @@ defmodule EWalletDB.TransactionState do
     @ledger_pending,
     @pending_confirmations,
     @blockchain_confirmed,
+    @ledger_blockchain_confirmed,
     @ledger_confirmed
   ]
 

--- a/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
+++ b/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
@@ -38,7 +38,7 @@ defmodule EWalletDB.TransactionState do
     @ledger_pending => {[], []},
     @pending_confirmations => {[:confirmations_count], [:confirmations_count]},
     @ledger_pending_blockchain_confirmed => {[:confirmations_count], [:confirmations_count]},
-    @blockchain_confirmed => {[:confirmations_count], [:confirmations_count]},
+    @blockchain_confirmed => {[:confirmations_count], [:confirmations_count]}
   }
 
   @states %{

--- a/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
+++ b/apps/ewallet_db/lib/ewallet_db/state_machines/transaction_state.ex
@@ -31,7 +31,7 @@ defmodule EWalletDB.TransactionState do
   # For each state, we have {[cast_fields], [required_fields]}
   @attrs %{
     @pending => {[], []},
-    @confirmed => {[:local_ledger_uuid], [:ledger_ledger_uuid]},
+    @confirmed => {[:local_ledger_uuid], [:local_ledger_uuid]},
     @failed => {[:error_code, :error_description, :error_data], [:error_code]},
     @blockchain_failed => {[:error_code, :error_description, :error_data], [:error_code]},
     @blockchain_submitted => {[:blockchain_tx_hash], [:blockchain_tx_hash]},

--- a/apps/ewallet_db/test/ewallet_db/state_machines/transaction_state_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/state_machines/transaction_state_test.exs
@@ -314,7 +314,7 @@ defmodule EWalletDB.TransactionStateTest do
       test_successful_state_transition(
         :from_ledger_to_blockchain,
         TransactionState.pending_confirmations(),
-        TransactionState.ledger_blockchain_confirmed(),
+        TransactionState.ledger_pending_blockchain_confirmed(),
         %{
           confirmations_count: 1
         }
@@ -324,7 +324,7 @@ defmodule EWalletDB.TransactionStateTest do
     test "transition from blockchain_confirmed to confirmed successfully" do
       test_successful_state_transition(
         :from_ledger_to_blockchain,
-        TransactionState.ledger_blockchain_confirmed(),
+        TransactionState.ledger_pending_blockchain_confirmed(),
         TransactionState.confirmed()
       )
     end
@@ -333,7 +333,7 @@ defmodule EWalletDB.TransactionStateTest do
       test_failed_state_transition(
         :from_ledger_to_blockchain,
         TransactionState.confirmed(),
-        TransactionState.ledger_blockchain_confirmed()
+        TransactionState.ledger_pending_blockchain_confirmed()
       )
     end
   end

--- a/apps/ewallet_db/test/ewallet_db/state_machines/transaction_state_test.exs
+++ b/apps/ewallet_db/test/ewallet_db/state_machines/transaction_state_test.exs
@@ -314,7 +314,7 @@ defmodule EWalletDB.TransactionStateTest do
       test_successful_state_transition(
         :from_ledger_to_blockchain,
         TransactionState.pending_confirmations(),
-        TransactionState.blockchain_confirmed(),
+        TransactionState.ledger_blockchain_confirmed(),
         %{
           confirmations_count: 1
         }
@@ -324,7 +324,7 @@ defmodule EWalletDB.TransactionStateTest do
     test "transition from blockchain_confirmed to confirmed successfully" do
       test_successful_state_transition(
         :from_ledger_to_blockchain,
-        TransactionState.blockchain_confirmed(),
+        TransactionState.ledger_blockchain_confirmed(),
         TransactionState.confirmed()
       )
     end
@@ -333,7 +333,7 @@ defmodule EWalletDB.TransactionStateTest do
       test_failed_state_transition(
         :from_ledger_to_blockchain,
         TransactionState.confirmed(),
-        TransactionState.blockchain_confirmed()
+        TransactionState.ledger_blockchain_confirmed()
       )
     end
   end

--- a/apps/local_ledger/lib/local_ledger/cached_balance.ex
+++ b/apps/local_ledger/lib/local_ledger/cached_balance.ex
@@ -38,7 +38,8 @@ defmodule LocalLedger.CachedBalance do
 
   The given datetime also gets included in the deletion.
   """
-  @spec delete_since(%Wallet{} | [%Wallet{}], NaiveDateTime.t()) :: {:ok, num_deleted :: integer()}
+  @spec delete_since(%Wallet{} | [%Wallet{}], NaiveDateTime.t()) ::
+          {:ok, num_deleted :: integer()}
   def delete_since(wallet_or_wallets, computed_at) do
     wallet_or_wallets
     |> List.wrap()

--- a/apps/local_ledger/lib/local_ledger/entry.ex
+++ b/apps/local_ledger/lib/local_ledger/entry.ex
@@ -23,7 +23,7 @@ defmodule LocalLedger.Entry do
   Get or insert the given token and all the given addresses before
   building a map representation usable by the LocalLedgerDB schemas.
   """
-  def build_all(entries, opts) do
+  def build_all(entries, opts \\ %{}) do
     Enum.map(entries, fn attrs ->
       {:ok, token} = Token.get_or_insert(attrs["token"])
       {:ok, wallet} = Wallet.get_or_insert(attrs)

--- a/apps/local_ledger/lib/local_ledger/entry.ex
+++ b/apps/local_ledger/lib/local_ledger/entry.ex
@@ -23,7 +23,7 @@ defmodule LocalLedger.Entry do
   Get or insert the given token and all the given addresses before
   building a map representation usable by the LocalLedgerDB schemas.
   """
-  def build_all(entries) do
+  def build_all(entries, opts) do
     Enum.map(entries, fn attrs ->
       {:ok, token} = Token.get_or_insert(attrs["token"])
       {:ok, wallet} = Wallet.get_or_insert(attrs)
@@ -32,7 +32,8 @@ defmodule LocalLedger.Entry do
         type: attrs["type"],
         amount: attrs["amount"],
         token_id: token.id,
-        wallet_address: wallet.address
+        wallet_address: wallet.address,
+        status: opts[:status] || Entry.confirmed()
       }
     end)
   end

--- a/apps/local_ledger/lib/local_ledger/transaction.ex
+++ b/apps/local_ledger/lib/local_ledger/transaction.ex
@@ -18,8 +18,10 @@ defmodule LocalLedger.Transaction do
   needed to insert valid transactions and entries.
   """
   alias LocalLedgerDB.{Errors.InsufficientFundsError, Repo, Transaction, Entry}
+  alias LocalLedgerDB.Entry, as: EntrySchema
 
   alias LocalLedger.{
+    CachedBalance,
     Entry,
     Errors.AmountNotPositiveError,
     Errors.InvalidAmountError,
@@ -92,7 +94,6 @@ defmodule LocalLedger.Transaction do
         }],
         idempotency_token: "123"
       })
-
   """
   @spec insert(map(), map(), fun() | nil) :: {:ok, %Transaction{}} | {:error, Ecto.Changeset.t()}
   def insert(
@@ -130,19 +131,18 @@ defmodule LocalLedger.Transaction do
   @spec confirm(String.t()) :: {:ok, %Transaction{}} | {:error, Ecto.Changeset.t()}
   def confirm(transaction_uuid) do
     with %Transaction{} = transaction <-
-           Transaction.get_by(uuid: transaction_uuid, preload: [:entries]) do
-      entries =
+           Transaction.get_by(%{uuid: transaction_uuid}, preload: [:entries]) do
+      flagged_entries =
         Enum.map(transaction.entries, fn entry ->
           %{
             uuid: entry.uuid,
-            status: LocalLedgerDB.Entry.confirmed()
+            status: EntrySchema.confirmed()
           }
         end)
 
-      Transaction.update(%{
-        uuid: transaction.uuid,
+      Transaction.update(transaction, %{
         status: Transaction.confirmed(),
-        entries: entries
+        entries: flagged_entries
       })
     end
   end
@@ -155,20 +155,36 @@ defmodule LocalLedger.Transaction do
   @spec fail(String.t()) :: {:ok, %Transaction{}} | {:error, Ecto.Changeset.t()}
   def fail(transaction_uuid) do
     with %Transaction{} = transaction <-
-           Transaction.get_by(uuid: transaction_uuid, preload: [:entries]) do
-      entries =
+           Transaction.get_by(%{uuid: transaction_uuid}, preload: [entries: [:wallet]]) do
+      flagged_entries =
         Enum.map(transaction.entries, fn entry ->
           %{
             uuid: entry.uuid,
-            status: LocalLedgerDB.Entry.failed()
+            status: EntrySchema.failed()
           }
         end)
 
-      Transaction.update(%{
-        uuid: transaction.uuid,
-        status: Transaction.failed(),
-        entries: entries
-      })
+      result =
+        Transaction.update(transaction, %{
+          status: Transaction.failed(),
+          entries: flagged_entries
+        })
+
+      _ =
+        case result do
+          {:ok, _} ->
+            # A transaction is inserted before entries, so deleting since transaction.insert_at
+            # should cover all its entries just fine.
+            transaction.entries
+            |> Enum.map(fn e -> e.wallet end)
+            |> Enum.uniq()
+            |> CachedBalance.delete_since(transaction.inserted_at)
+
+          _ ->
+            :noop
+        end
+
+      result
     end
   end
 

--- a/apps/local_ledger/lib/local_ledger/transaction.ex
+++ b/apps/local_ledger/lib/local_ledger/transaction.ex
@@ -32,6 +32,7 @@ defmodule LocalLedger.Transaction do
   @doc """
   Retrieve all transactions from the database.
   """
+  @spec all() :: {:ok, [%Transaction{}]}
   def all do
     {:ok, Transaction.all()}
   end
@@ -39,6 +40,7 @@ defmodule LocalLedger.Transaction do
   @doc """
   Retrieve a specific transaction from the database.
   """
+  @spec get(String.t()) :: {:ok, %Transaction{} | nil}
   def get(id) do
     {:ok, Transaction.one(id)}
   end
@@ -46,6 +48,7 @@ defmodule LocalLedger.Transaction do
   @doc """
   Retrieve a specific transaction based on a correlation ID from the database.
   """
+  @spec get_by_idempotency_token(String.t()) :: {:ok, %Transaction{} | nil}
   def get_by_idempotency_token(idempotency_token) do
     {:ok, Transaction.get_by_idempotency_token(idempotency_token)}
   end
@@ -91,6 +94,7 @@ defmodule LocalLedger.Transaction do
       })
 
   """
+  @spec insert(map(), map(), fun() | nil) :: {:ok, %Transaction{}} | {:error, Ecto.Changeset.t()}
   def insert(
         %{
           "metadata" => metadata,
@@ -120,6 +124,10 @@ defmodule LocalLedger.Transaction do
       {:error, :insufficient_funds, e.message}
   end
 
+  @doc """
+  Marks the transaction and its entries as confirmed.
+  """
+  @spec confirm(String.t()) :: {:ok, %Transaction{}} | {:error, Ecto.Changeset.t()}
   def confirm(transaction_uuid) do
     with %Transaction{} = transaction <-
            Transaction.get_by(uuid: transaction_uuid, preload: [:entries]) do
@@ -139,6 +147,12 @@ defmodule LocalLedger.Transaction do
     end
   end
 
+  @doc """
+  Marks the transaction and its entries as failed.
+
+  This operation will also delete the cached balances since the failed transaction.
+  """
+  @spec fail(String.t()) :: {:ok, %Transaction{}} | {:error, Ecto.Changeset.t()}
   def fail(transaction_uuid) do
     with %Transaction{} = transaction <-
            Transaction.get_by(uuid: transaction_uuid, preload: [:entries]) do

--- a/apps/local_ledger/lib/local_ledger/transaction.ex
+++ b/apps/local_ledger/lib/local_ledger/transaction.ex
@@ -120,15 +120,16 @@ defmodule LocalLedger.Transaction do
       {:error, :insufficient_funds, e.message}
   end
 
-
   def confirm(transaction_uuid) do
-    with %Transaction{} = transaction <- Transaction.get_by(uuid: transaction_uuid, preload: [:entries]) do
-      entries = Enum.map(transaction.entries, fn entry ->
-        %{
-          uuid: entry.uuid,
-          status: LocalLedgerDB.Entry.confirmed()
-        }
-      end)
+    with %Transaction{} = transaction <-
+           Transaction.get_by(uuid: transaction_uuid, preload: [:entries]) do
+      entries =
+        Enum.map(transaction.entries, fn entry ->
+          %{
+            uuid: entry.uuid,
+            status: LocalLedgerDB.Entry.confirmed()
+          }
+        end)
 
       Transaction.update(%{
         uuid: transaction.uuid,
@@ -139,13 +140,15 @@ defmodule LocalLedger.Transaction do
   end
 
   def fail(transaction_uuid) do
-    with %Transaction{} = transaction <- Transaction.get_by(uuid: transaction_uuid, preload: [:entries]) do
-      entries = Enum.map(transaction.entries, fn entry ->
-        %{
-          uuid: entry.uuid,
-          status: LocalLedgerDB.Entry.failed()
-        }
-      end)
+    with %Transaction{} = transaction <-
+           Transaction.get_by(uuid: transaction_uuid, preload: [:entries]) do
+      entries =
+        Enum.map(transaction.entries, fn entry ->
+          %{
+            uuid: entry.uuid,
+            status: LocalLedgerDB.Entry.failed()
+          }
+        end)
 
       Transaction.update(%{
         uuid: transaction.uuid,

--- a/apps/local_ledger/test/local_ledger/cached_balance_test.exs
+++ b/apps/local_ledger/test/local_ledger/cached_balance_test.exs
@@ -376,26 +376,35 @@ defmodule LocalLedger.CachedBalanceTest do
   describe "delete_since/2" do
     test "deletes the cached balance since the given datetime", %{wallet: wallet} do
       # Faking a cached balance that will be deleted
-      cached_balance = insert(
-        :cached_balance,
-        wallet_address: wallet.address,
-        amounts: %{"tok_BTC_5678" => 1_000_000, "tok_OMG_1234" => 1_000_000}
-      )
+      cached_balance =
+        insert(
+          :cached_balance,
+          wallet_address: wallet.address,
+          amounts: %{"tok_BTC_5678" => 1_000_000, "tok_OMG_1234" => 1_000_000}
+        )
 
       # Checks that the faked cached balance is working
-      assert CachedBalance.all(wallet) == {:ok, %{wallet.address => %{
-        "tok_BTC_5678" => 1_000_000,
-        "tok_OMG_1234" => 1_000_000,
-      }}}
+      assert CachedBalance.all(wallet) ==
+               {:ok,
+                %{
+                  wallet.address => %{
+                    "tok_BTC_5678" => 1_000_000,
+                    "tok_OMG_1234" => 1_000_000
+                  }
+                }}
 
       # Now perform delete_since/2
       assert CachedBalance.delete_since(wallet, cached_balance.computed_at) == {:ok, 1}
 
       # Checks that the cached balance is back to its normal state
-      assert CachedBalance.all(wallet) == {:ok, %{wallet.address => %{
-        "tok_BTC_5678" => 160_524 - 74_961,
-        "tok_OMG_1234" => 120_000 - 61_047
-      }}}
+      assert CachedBalance.all(wallet) ==
+               {:ok,
+                %{
+                  wallet.address => %{
+                    "tok_BTC_5678" => 160_524 - 74_961,
+                    "tok_OMG_1234" => 120_000 - 61_047
+                  }
+                }}
     end
   end
 

--- a/apps/local_ledger/test/local_ledger/cached_balance_test.exs
+++ b/apps/local_ledger/test/local_ledger/cached_balance_test.exs
@@ -101,7 +101,7 @@ defmodule LocalLedger.CachedBalanceTest do
         amount: 3_892
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 2
 
       assert LocalLedgerDB.CachedBalance.get(wallet_1.address).amounts == %{
@@ -126,7 +126,7 @@ defmodule LocalLedger.CachedBalanceTest do
         config_pid
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 1
 
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
@@ -154,7 +154,7 @@ defmodule LocalLedger.CachedBalanceTest do
         amount: 500
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 3
 
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
@@ -175,9 +175,9 @@ defmodule LocalLedger.CachedBalanceTest do
         config_pid
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 1
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 2
     end
 
@@ -194,16 +194,18 @@ defmodule LocalLedger.CachedBalanceTest do
         config_pid
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 1
-      CachedBalance.cache_all()
+
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 2
     end
 
     test "cached_count is 1 when calculating with strategy = 'since_beginning'", %{wallet: wallet} do
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 1
-      CachedBalance.cache_all()
+
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 1
     end
 
@@ -218,11 +220,13 @@ defmodule LocalLedger.CachedBalanceTest do
         config_pid
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 1
-      CachedBalance.cache_all()
+
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 2
-      CachedBalance.cache_all()
+
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance.get(wallet.address).cached_count == 1
     end
 
@@ -237,7 +241,7 @@ defmodule LocalLedger.CachedBalanceTest do
         config_pid
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
 
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
                "tok_BTC_5678" => 85_563,
@@ -259,7 +263,7 @@ defmodule LocalLedger.CachedBalanceTest do
         amount: 1000
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
 
       # This is wrong because it's based on a wrongly calculated previous cached_balance
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
@@ -269,7 +273,7 @@ defmodule LocalLedger.CachedBalanceTest do
 
       # The reset_frequency is 3 so it will now calculate since the beginning
       # and sync the correct value
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
 
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
                "tok_BTC_5678" => 85_563,
@@ -280,7 +284,7 @@ defmodule LocalLedger.CachedBalanceTest do
     test "reuses the previous cached balance to calculate the new one when
           strategy = 'since_beginning'",
          %{token_1: token_1, wallet: wallet} do
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 1
 
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
@@ -305,7 +309,7 @@ defmodule LocalLedger.CachedBalanceTest do
         amount: 500
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 3
 
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
@@ -327,7 +331,7 @@ defmodule LocalLedger.CachedBalanceTest do
         config_pid
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 1
 
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
@@ -352,7 +356,7 @@ defmodule LocalLedger.CachedBalanceTest do
         amount: 500
       )
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 3
 
       assert LocalLedgerDB.CachedBalance.get(wallet.address).amounts == %{
@@ -364,8 +368,34 @@ defmodule LocalLedger.CachedBalanceTest do
     test "does not store a cached balance if all the amounts are equal to 0" do
       insert(:wallet, address: "1234")
 
-      CachedBalance.cache_all()
+      :ok = CachedBalance.cache_all()
       assert LocalLedgerDB.CachedBalance |> Repo.all() |> length() == 1
+    end
+  end
+
+  describe "delete_since/2" do
+    test "deletes the cached balance since the given datetime", %{wallet: wallet} do
+      # Faking a cached balance that will be deleted
+      cached_balance = insert(
+        :cached_balance,
+        wallet_address: wallet.address,
+        amounts: %{"tok_BTC_5678" => 1_000_000, "tok_OMG_1234" => 1_000_000}
+      )
+
+      # Checks that the faked cached balance is working
+      assert CachedBalance.all(wallet) == {:ok, %{wallet.address => %{
+        "tok_BTC_5678" => 1_000_000,
+        "tok_OMG_1234" => 1_000_000,
+      }}}
+
+      # Now perform delete_since/2
+      assert CachedBalance.delete_since(wallet, cached_balance.computed_at) == {:ok, 1}
+
+      # Checks that the cached balance is back to its normal state
+      assert CachedBalance.all(wallet) == {:ok, %{wallet.address => %{
+        "tok_BTC_5678" => 160_524 - 74_961,
+        "tok_OMG_1234" => 120_000 - 61_047
+      }}}
     end
   end
 

--- a/apps/local_ledger/test/local_ledger/entry_test.exs
+++ b/apps/local_ledger/test/local_ledger/entry_test.exs
@@ -50,13 +50,15 @@ defmodule LocalLedger.EntryTest do
                  type: LocalLedgerDB.Entry.debit_type(),
                  amount: 100,
                  token_id: "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-                 wallet_address: "omisego.test.sender1"
+                 wallet_address: "omisego.test.sender1",
+                 status: "confirmed"
                },
                %{
                  type: LocalLedgerDB.Entry.credit_type(),
                  amount: 100,
                  token_id: "tok_OMG_01cbepz0mhzb042vwgaqv17cjy",
-                 wallet_address: "omisego.test.receiver1"
+                 wallet_address: "omisego.test.receiver1",
+                 status: "confirmed"
                }
              ]
     end

--- a/apps/local_ledger/test/local_ledger/transaction_test.exs
+++ b/apps/local_ledger/test/local_ledger/transaction_test.exs
@@ -82,26 +82,29 @@ defmodule LocalLedger.TransactionTest do
 
     # Continue the balances from genesis() above, now debiting 100 away from Carol and Dan.
     {:ok, transaction} =
-      Transaction.insert(%{
-        "idempotency_token" => UUID.generate(),
-        "entries" => [
-          %{
-            "type" => Entry.debit_type(),
-            "address" => "carol",
-            "metadata" => %{},
-            "amount" => 100,
-            "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
-          },
-          %{
-            "type" => Entry.credit_type(),
-            "address" => "dan",
-            "metadata" => %{},
-            "amount" => 100,
-            "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
-          }
-        ],
-        "metadata" => %{}
-      }, %{status: "pending", genesis: false})
+      Transaction.insert(
+        %{
+          "idempotency_token" => UUID.generate(),
+          "entries" => [
+            %{
+              "type" => Entry.debit_type(),
+              "address" => "carol",
+              "metadata" => %{},
+              "amount" => 100,
+              "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
+            },
+            %{
+              "type" => Entry.credit_type(),
+              "address" => "dan",
+              "metadata" => %{},
+              "amount" => 100,
+              "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
+            }
+          ],
+          "metadata" => %{}
+        },
+        %{status: "pending", genesis: false}
+      )
 
     transaction
   end

--- a/apps/local_ledger/test/local_ledger/transaction_test.exs
+++ b/apps/local_ledger/test/local_ledger/transaction_test.exs
@@ -19,12 +19,98 @@ defmodule LocalLedger.TransactionTest do
   alias Ecto.UUID
   alias LocalLedger.Transaction
   alias LocalLedgerDB.{Entry, Repo}
+  alias LocalLedgerDB.Transaction, as: TransactionSchema
 
   setup do
     :ok = Sandbox.checkout(Repo)
   end
 
-  describe "#all" do
+  defp debits do
+    [
+      %{
+        "type" => Entry.debit_type(),
+        "address" => "alice",
+        "metadata" => %{},
+        "amount" => 100,
+        "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
+      },
+      %{
+        "type" => Entry.debit_type(),
+        "address" => "bob",
+        "metadata" => %{},
+        "amount" => 200,
+        "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
+      }
+    ]
+  end
+
+  defp credits do
+    [
+      %{
+        "type" => Entry.credit_type(),
+        "address" => "carol",
+        "metadata" => %{},
+        "amount" => 150,
+        "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
+      },
+      %{
+        "type" => Entry.credit_type(),
+        "address" => "dan",
+        "metadata" => %{},
+        "amount" => 150,
+        "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
+      }
+    ]
+  end
+
+  defp genesis do
+    {:ok, transaction} =
+      Transaction.insert(
+        %{
+          "metadata" => %{},
+          "entries" => debits() ++ credits(),
+          "idempotency_token" => UUID.generate()
+        },
+        %{genesis: true}
+      )
+
+    transaction
+  end
+
+  defp pending do
+    _ = genesis()
+
+    # Continue the balances from genesis() above, now debiting 100 away from Carol and Dan.
+    {:ok, transaction} =
+      Transaction.insert(%{
+        "idempotency_token" => UUID.generate(),
+        "entries" => [
+          %{
+            "type" => Entry.debit_type(),
+            "address" => "carol",
+            "metadata" => %{},
+            "amount" => 100,
+            "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
+          },
+          %{
+            "type" => Entry.credit_type(),
+            "address" => "dan",
+            "metadata" => %{},
+            "amount" => 100,
+            "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
+          }
+        ],
+        "metadata" => %{}
+      }, %{status: "pending", genesis: false})
+
+    transaction
+  end
+
+  defp get_current_balance(address) do
+    Entry.calculate_current_amount(address, "tok_OMG_01cbepz0mhzb042vwgaqv17cjy")
+  end
+
+  describe "all/0" do
     test "returns all transactions" do
       {:ok, inserted_transaction} = :transaction |> build |> Repo.insert()
 
@@ -40,7 +126,7 @@ defmodule LocalLedger.TransactionTest do
     end
   end
 
-  describe "#get" do
+  describe "get/1" do
     test "returns the specified transaction" do
       {:ok, inserted_transaction} = :transaction |> build |> Repo.insert()
 
@@ -55,63 +141,17 @@ defmodule LocalLedger.TransactionTest do
     end
   end
 
-  describe "#insert" do
-    defp debits do
-      [
-        %{
-          "type" => Entry.debit_type(),
-          "address" => "alice",
-          "metadata" => %{},
-          "amount" => 100,
-          "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
-        },
-        %{
-          "type" => Entry.debit_type(),
-          "address" => "bob",
-          "metadata" => %{},
-          "amount" => 200,
-          "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
-        }
-      ]
+  describe "get_by_idempotency_token/1" do
+    test "returns the specified transaction" do
+      inserted = insert(:transaction)
+      {res, transaction} = Transaction.get_by_idempotency_token(inserted.idempotency_token)
+
+      assert res == :ok
+      assert transaction.uuid == inserted.uuid
     end
+  end
 
-    def credits do
-      [
-        %{
-          "type" => Entry.credit_type(),
-          "address" => "carol",
-          "metadata" => %{},
-          "amount" => 150,
-          "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
-        },
-        %{
-          "type" => Entry.credit_type(),
-          "address" => "dan",
-          "metadata" => %{},
-          "amount" => 150,
-          "token" => %{"id" => "tok_OMG_01cbepz0mhzb042vwgaqv17cjy", "metadata" => %{}}
-        }
-      ]
-    end
-
-    def genesis do
-      {:ok, transaction} =
-        Transaction.insert(
-          %{
-            "metadata" => %{},
-            "entries" => debits() ++ credits(),
-            "idempotency_token" => UUID.generate()
-          },
-          %{genesis: true}
-        )
-
-      transaction
-    end
-
-    def get_current_balance(address) do
-      Entry.calculate_current_amount(address, "tok_OMG_01cbepz0mhzb042vwgaqv17cjy")
-    end
-
+  describe "insert/3" do
     test "inserts a transaction and two entries when genesis" do
       transaction = genesis()
 
@@ -547,6 +587,36 @@ defmodule LocalLedger.TransactionTest do
             %{genesis: true}
           )
       end
+    end
+  end
+
+  describe "confirm/1" do
+    test "returns the confirmed transaction and entries" do
+      transaction = pending()
+      assert transaction.status == TransactionSchema.pending()
+      assert length(transaction.entries) > 1
+      assert Enum.all?(transaction.entries, fn e -> e.status == Entry.pending() end)
+
+      {res, confirmed} = Transaction.confirm(transaction.uuid)
+
+      assert res == :ok
+      assert confirmed.status == TransactionSchema.confirmed()
+      assert Enum.all?(confirmed.entries, fn e -> e.status == Entry.confirmed() end)
+    end
+  end
+
+  describe "fail/1" do
+    test "returns the failed transaction and entries" do
+      transaction = pending()
+      assert transaction.status == TransactionSchema.pending()
+      assert length(transaction.entries) > 1
+      assert Enum.all?(transaction.entries, fn e -> e.status == Entry.pending() end)
+
+      {res, confirmed} = Transaction.fail(transaction.uuid)
+
+      assert res == :ok
+      assert confirmed.status == TransactionSchema.failed()
+      assert Enum.all?(confirmed.entries, fn e -> e.status == Entry.failed() end)
     end
   end
 end

--- a/apps/local_ledger_db/lib/local_ledger_db/cached_balance.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/cached_balance.ex
@@ -83,7 +83,8 @@ defmodule LocalLedgerDB.CachedBalance do
   @doc """
   Delete all cached balances for the given address(es) since the given computed date and time.
   """
-  @spec delete_since(String.t() | [String.t()], NaiveDateTime.t()) :: {:ok, num_deleted :: integer()}
+  @spec delete_since(String.t() | [String.t()], NaiveDateTime.t()) ::
+          {:ok, num_deleted :: integer()}
   def delete_since(addresses, computed_at) do
     addresses = List.wrap(addresses)
 

--- a/apps/local_ledger_db/lib/local_ledger_db/cached_balance.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/cached_balance.ex
@@ -39,10 +39,7 @@ defmodule LocalLedgerDB.CachedBalance do
     timestamps()
   end
 
-  @doc """
-  Validate the cached balance attributes.
-  """
-  def changeset(%CachedBalance{} = balance, attrs) do
+  defp changeset(%CachedBalance{} = balance, attrs) do
     balance
     |> cast(attrs, [:amounts, :wallet_address, :cached_count, :computed_at])
     |> validate_required([:amounts, :wallet_address, :cached_count, :computed_at])
@@ -52,6 +49,7 @@ defmodule LocalLedgerDB.CachedBalance do
   @doc """
   Retrieve a list of cached balances using the specified addresses.
   """
+  @spec all([String.t()]) :: [%CachedBalance{}]
   def all(addresses) do
     CachedBalance
     |> distinct([c], c.wallet_address)
@@ -63,6 +61,7 @@ defmodule LocalLedgerDB.CachedBalance do
   @doc """
   Retrieve a cached balance using the specified address.
   """
+  @spec get(String.t()) :: %CachedBalance{} | nil
   def get(address) do
     CachedBalance
     |> where([c], c.wallet_address == ^address)
@@ -74,9 +73,26 @@ defmodule LocalLedgerDB.CachedBalance do
   @doc """
   Insert a cached balance.
   """
+  @spec insert(map()) :: {:ok, %CachedBalance{}} | {:error, Ecto.Changeset.t()}
   def insert(attrs) do
     %CachedBalance{}
-    |> CachedBalance.changeset(attrs)
+    |> changeset(attrs)
     |> Repo.insert()
+  end
+
+  @doc """
+  Delete all cached balances for the given address(es) since the given computed date and time.
+  """
+  @spec delete_since(String.t() | [String.t()], NaiveDateTime.t()) :: {:ok, num_deleted :: integer()}
+  def delete_since(addresses, computed_at) do
+    addresses = List.wrap(addresses)
+
+    {num_deleted, _} =
+      CachedBalance
+      |> where([c], c.wallet_address in ^addresses)
+      |> where([c], c.computed_at >= ^computed_at)
+      |> Repo.delete_all()
+
+    {:ok, num_deleted}
   end
 end

--- a/apps/local_ledger_db/lib/local_ledger_db/entry.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/entry.ex
@@ -193,7 +193,7 @@ defmodule LocalLedgerDB.Entry do
         e in Entry,
         where:
           e.wallet_address == ^address and e.type == ^type and e.token_id == ^token_id and
-            e.status != "failed",
+            e.status != @failed,
         select: sum(e.amount)
       )
     )

--- a/apps/local_ledger_db/lib/local_ledger_db/entry.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/entry.ex
@@ -31,6 +31,14 @@ defmodule LocalLedgerDB.Entry do
 
   @primary_key {:uuid, Ecto.UUID, autogenerate: true}
   @timestamps_opts [type: :naive_datetime_usec]
+  @pending "pending"
+  @confirmed "confirmed"
+  @failed "failed"
+  @statuses [@pending, @confirmed, @failed]
+
+  def pending, do: @pending
+  def confirmed, do: @confirmed
+  def failed, do: @failed
 
   @credit "credit"
   @debit "debit"
@@ -42,6 +50,7 @@ defmodule LocalLedgerDB.Entry do
   schema "entry" do
     field(:amount, LocalLedger.Types.Integer)
     field(:type, :string)
+    field(:status, :string, default: @confirmed)
 
     belongs_to(
       :token,
@@ -76,8 +85,9 @@ defmodule LocalLedgerDB.Entry do
   """
   def changeset(%Entry{} = entry, attrs) do
     entry
-    |> cast(attrs, [:amount, :type, :token_id, :wallet_address, :transaction_uuid])
-    |> validate_required([:amount, :type, :token_id, :wallet_address])
+    |> cast(attrs, [:amount, :type, :token_id, :wallet_address, :transaction_uuid, :status])
+    |> validate_required([:amount, :type, :token_id, :wallet_address, :status])
+    |> validate_inclusion(:status, @statuses)
     |> validate_inclusion(:type, @types)
     |> foreign_key_constraint(:token_id)
     |> foreign_key_constraint(:wallet_address)
@@ -181,7 +191,7 @@ defmodule LocalLedgerDB.Entry do
     Repo.one(
       from(
         e in Entry,
-        where: e.wallet_address == ^address and e.type == ^type and e.token_id == ^token_id,
+        where: e.wallet_address == ^address and e.type == ^type and e.token_id == ^token_id and e.status != "failed",
         select: sum(e.amount)
       )
     )

--- a/apps/local_ledger_db/lib/local_ledger_db/entry.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/entry.ex
@@ -191,7 +191,9 @@ defmodule LocalLedgerDB.Entry do
     Repo.one(
       from(
         e in Entry,
-        where: e.wallet_address == ^address and e.type == ^type and e.token_id == ^token_id and e.status != "failed",
+        where:
+          e.wallet_address == ^address and e.type == ^type and e.token_id == ^token_id and
+            e.status != "failed",
         select: sum(e.amount)
       )
     )

--- a/apps/local_ledger_db/lib/local_ledger_db/transaction.ex
+++ b/apps/local_ledger_db/lib/local_ledger_db/transaction.ex
@@ -126,7 +126,7 @@ defmodule LocalLedgerDB.Transaction do
   end
 
   @doc """
-  Insert a transction and its entries.
+  Inserts a transction and its entries.
   """
   def insert(attrs) do
     opts = [on_conflict: :nothing, conflict_target: :idempotency_token]
@@ -136,8 +136,11 @@ defmodule LocalLedgerDB.Transaction do
     |> do_insert(opts)
   end
 
-  def update(attrs) do
-    %Transaction{}
+  @doc """
+  Updates a transction and its entries.
+  """
+  def update(%Transaction{} = transaction, attrs) do
+    transaction
     |> changeset(attrs)
     |> Repo.update()
   end

--- a/apps/local_ledger_db/priv/repo/migrations/20190823080516_add_status_to_transaction.exs
+++ b/apps/local_ledger_db/priv/repo/migrations/20190823080516_add_status_to_transaction.exs
@@ -1,0 +1,16 @@
+defmodule LocalLedgerDB.Repo.Migrations.AddStatusToTransaction do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transaction) do
+      add :status, :string, null: false, default: "confirmed"
+    end
+
+    alter table(:entry) do
+      add :status, :string, null: false, default: "confirmed"
+    end
+
+    create index(:transaction, :status)
+    create index(:entry, :status)
+  end
+end

--- a/apps/local_ledger_db/test/local_ledger_db/cached_balance_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/cached_balance_test.exs
@@ -14,6 +14,7 @@
 
 defmodule LocalLedgerDB.CachedBalanceTest do
   use ExUnit.Case
+  import Ecto.Query
   import LocalLedgerDB.Factory
   alias Ecto.Adapters.SQL.Sandbox
   alias LocalLedgerDB.{CachedBalance, Repo}
@@ -68,6 +69,55 @@ defmodule LocalLedgerDB.CachedBalanceTest do
       assert %CachedBalance{} = cached_balance
       assert cached_balance.computed_at != nil
       assert cached_balance.cached_count == 3
+    end
+  end
+
+  describe "delete_since/2" do
+    test "deletes all cached balances for the given address since the given computed time" do
+      wallet = insert(:wallet)
+      wallet_2 = insert(:wallet)
+      cb_1 = insert(:cached_balance, wallet_address: wallet.address)
+      cb_2 = insert(:cached_balance, wallet_address: wallet.address)
+      cb_3 = insert(:cached_balance, wallet_address: wallet_2.address)
+      cb_4 = insert(:cached_balance, wallet_address: wallet.address)
+
+      # Make sure all data exists
+      assert all_uuids_by_address(wallet.address) == [cb_1.uuid, cb_2.uuid, cb_4.uuid]
+      assert all_uuids_by_address(wallet_2.address) == [cb_3.uuid]
+
+      # Perform the deletion
+      assert CachedBalance.delete_since(wallet.address, cb_2.computed_at) == {:ok, 2}
+
+      # Asserts for the remaining cached balances
+      assert all_uuids_by_address(wallet.address) == [cb_1.uuid]
+      assert all_uuids_by_address(wallet_2.address) == [cb_3.uuid]
+    end
+
+    test "supports passing multiple addresses" do
+      wallet = insert(:wallet)
+      wallet_2 = insert(:wallet)
+      cb_1 = insert(:cached_balance, wallet_address: wallet.address)
+      cb_2 = insert(:cached_balance, wallet_address: wallet_2.address)
+      cb_3 = insert(:cached_balance, wallet_address: wallet.address)
+      cb_4 = insert(:cached_balance, wallet_address: wallet_2.address)
+
+      # Make sure all data exists
+      assert all_uuids_by_address(wallet.address) == [cb_1.uuid, cb_3.uuid]
+      assert all_uuids_by_address(wallet_2.address) == [cb_2.uuid, cb_4.uuid]
+
+      # Perform the deletion
+      assert CachedBalance.delete_since([wallet.address, wallet_2.address], cb_3.computed_at) == {:ok, 2}
+
+      # Asserts for the remaining cached balances
+      assert all_uuids_by_address(wallet.address) == [cb_1.uuid]
+      assert all_uuids_by_address(wallet_2.address) == [cb_2.uuid]
+    end
+
+    defp all_uuids_by_address(address) do
+      CachedBalance
+      |> where(wallet_address: ^address)
+      |> select([c], c.uuid)
+      |> Repo.all()
     end
   end
 end

--- a/apps/local_ledger_db/test/local_ledger_db/cached_balance_test.exs
+++ b/apps/local_ledger_db/test/local_ledger_db/cached_balance_test.exs
@@ -116,7 +116,8 @@ defmodule LocalLedgerDB.CachedBalanceTest do
       assert all_uuids_by_address(wallet_2.address) == [cb_2.uuid, cb_4.uuid]
 
       # Perform the deletion
-      assert CachedBalance.delete_since([wallet.address, wallet_2.address], cb_3.computed_at) == {:ok, 2}
+      assert CachedBalance.delete_since([wallet.address, wallet_2.address], cb_3.computed_at) ==
+               {:ok, 2}
 
       # Asserts for the remaining cached balances
       assert all_uuids_by_address(wallet.address) == [cb_1.uuid]


### PR DESCRIPTION
Issue/Task Number: #1086 

# Overview

This PR adds the support for internal to external, in the fastest possible way. The code isn't super clean, let's be honest, but it works. 

# Changes

- Allow the transfer from internal wallets to external addresses.

# Implementation Details

Add a new status to local ledger transactions, that's defaulting to `confirmed`. The eWallet can specify a transaction as being pending, which means it's included into the calculations, but can be turned into a failed transaction, which will not be counted.
