### PR TITLE
Pad private keys before encoding and storage

### DIFF
--- a/apps/keychain/lib/keychain/wallet.ex
+++ b/apps/keychain/lib/keychain/wallet.ex
@@ -40,7 +40,12 @@ defmodule Keychain.Wallet do
     wallet_address = "0x#{wallet_address}"
 
     public_key_encoded = Base.encode16(public_key, case: :lower)
-    private_key_encoded = Base.encode16(private_key, case: :lower)
+
+    # Sometimes the generated private key is 31 bytes long, so we need to pad it to 32
+    private_key_encoded =
+      private_key
+      |> Utils.Helpers.Crypto.pad_bytes(32)
+      |> Base.encode16(case: :lower)
 
     {:ok, _} =
       Key.insert(%{

--- a/apps/keychain/test/keychain/wallet_test.exs
+++ b/apps/keychain/test/keychain/wallet_test.exs
@@ -35,6 +35,14 @@ defmodule Keychain.WalletTest do
       assert is_binary(public_key)
       assert byte_size(public_key) == 130
     end
+
+    test "consistently generates a 64-character encoded private key" do
+      for _ <- 1..1000 do
+        {:ok, {_, public_key}} = Wallet.generate()
+        key = Repo.get_by(Key, public_key: public_key)
+        assert String.length(key.private_key) == 64
+      end
+    end
   end
 
   describe "generate_keypair/0" do

--- a/apps/utils/lib/helpers/crypto.ex
+++ b/apps/utils/lib/helpers/crypto.ex
@@ -87,4 +87,18 @@ defmodule Utils.Helpers.Crypto do
     data = 20 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
     "0x" <> data
   end
+
+  @doc """
+  Zero-pads the given `content` to the given `total_bytes`.
+
+  Returns the original `content` if the its byte_size is equal to
+  or greater than the given `total_bytes`.
+  """
+  @spec pad_bytes(binary(), non_neg_integer()) :: binary()
+  def pad_bytes(content, total_bytes) when byte_size(content) >= total_bytes, do: content
+
+  def pad_bytes(content, total_bytes) do
+    bits = (total_bytes - byte_size(content)) * 8
+    <<0::size(bits)>> <> content
+  end
 end

--- a/apps/utils/test/utils/helpers/crypto_test.exs
+++ b/apps/utils/test/utils/helpers/crypto_test.exs
@@ -28,4 +28,18 @@ defmodule Utils.Helpers.CryptoTest do
       assert String.length(key) == 86
     end
   end
+
+  describe "pad_bytes/2" do
+    test "pads up to the given total bytes" do
+      assert Crypto.pad_bytes(<<1>>, 3) == <<0, 0, 1>>
+    end
+
+    test "returns original if the size is equal" do
+      assert Crypto.pad_bytes(<<1, 1, 1>>, 3) == <<1, 1, 1>>
+    end
+
+    test "returns original if the size is larger" do
+      assert Crypto.pad_bytes(<<1, 1, 1, 1, 1>>, 3) == <<1, 1, 1, 1, 1>>
+    end
+  end
 end


### PR DESCRIPTION
Issue/Task Number: -

# Overview

Crypto key generation could produce a private key that is 31 or 32 bytes long. This PR pads the key to 32 bytes so it can be base16-encoded properly.

# Changes

- Added `Utils.Helpers.Crypto.pad_bytes/2`
- Updated `Keychain.Wallet.generate/0` to pad the private key binary before encoding and saving to database.

# Implementation Details

`:crypto.generate_key/3` sometimes generate a 31-byte long private key. A reproduction script is:

```elixir
for i <- 1..1000 do
  {pub, priv} = :crypto.generate_key(:ecdh, :secp256k1, :crypto.strong_rand_bytes(32))

  encoded_priv = Base.encode16(priv, case: :lower)
  encoded_priv_length = String.length(encoded_priv)

  if encoded_priv_length != 64 do
    byte_size(priv) |> IO.inspect(label: "byte size")
    encoded_priv |> byte_size() |> IO.inspect(label: "encoded byte size")
    encoded_priv_length |> IO.inspect(label: "string length")
  end
end
```

which produces:

```
byte size: 31
encoded byte size: 62
string length: 62

byte size: 31
encoded byte size: 62
string length: 62

byte size: 31
...
```

The tricky part was in the debugging, where the Ethereum client simply keeps returning insufficient funds error:

```elixir
{:error, :geth_error, [error_message: "insufficient funds for gas * price + value"]}
```

This is because it can’t tell apart if the private key is invalid. To the client/blockchain, it is valid, but it just derives to a different address.

So this PR simply pads the private key to 32 bytes before encoding.

# Usage

N/A

# Impact

No changes to DB schema or API. Although some existing private keys that has not been working will continue not to work.