### PR TITLE
Fix passing boolean-incompatible value throwing error on `mix omg.config`

### DIFF
--- a/apps/ewallet/lib/ewallet/cli.ex
+++ b/apps/ewallet/lib/ewallet/cli.ex
@@ -45,7 +45,7 @@ defmodule EWallet.CLI do
   @spec assume_yes?([String.t()]) :: boolean()
   def assume_yes?(args), do: Enum.any?(args, fn a -> a in @yes_params end)
 
-  @spec confirm?(String.t()) :: boolean()
+  @spec confirm?(String.t()) :: boolean() | {:error, :normalize_error, String.t()}
   def confirm?(message) do
     (message <> " [Yn] ")
     |> IO.gets()

--- a/apps/ewallet/lib/ewallet/release_tasks/config.ex
+++ b/apps/ewallet/lib/ewallet/release_tasks/config.ex
@@ -87,6 +87,10 @@ defmodule EWallet.ReleaseTasks.Config do
         CLI.error("Error: setting `#{key}` to #{inspect(value)} returned #{error_message}")
         :init.stop(1)
 
+      {:error, :normalize_error, error_message} ->
+        CLI.error("Error: setting `#{key}` to #{inspect(value)}. #{error_message}")
+        :init.stop(1)
+
       _ ->
         give_up()
     end
@@ -99,6 +103,7 @@ defmodule EWallet.ReleaseTasks.Config do
 
       %{value: existing, type: type} ->
         case cast_env(value, type) do
+          {:error, _, _} = error -> error
           ^existing -> {:unchanged, existing}
           casted_value -> do_update(key, casted_value)
         end

--- a/apps/frontend/lib/frontend/application.ex
+++ b/apps/frontend/lib/frontend/application.ex
@@ -39,7 +39,7 @@ defmodule Frontend.Application do
 
     children =
       children ++
-        case Normalize.to_boolean(webpack_watch) do
+        case Normalize.to_boolean!(webpack_watch) do
           true ->
             _ = Logger.info("Enabling webpack watcher.")
 

--- a/apps/status/lib/status.ex
+++ b/apps/status/lib/status.ex
@@ -73,6 +73,6 @@ defmodule Status do
   defp is_enabled?() do
     :status
     |> Application.get_env(:metrics)
-    |> Normalize.to_boolean()
+    |> Normalize.to_boolean!()
   end
 end

--- a/apps/url_dispatcher/lib/url_dispatcher/application.ex
+++ b/apps/url_dispatcher/lib/url_dispatcher/application.ex
@@ -27,7 +27,7 @@ defmodule UrlDispatcher.Application do
     serve_endpoints = Application.get_env(:url_dispatcher, :serve_endpoints)
 
     children =
-      case Normalize.to_boolean(serve_endpoints) do
+      case Normalize.to_boolean!(serve_endpoints) do
         true ->
           dispatchers = []
           port = Application.get_env(:url_dispatcher, :port)

--- a/apps/utils/lib/helpers/normalize.ex
+++ b/apps/utils/lib/helpers/normalize.ex
@@ -18,7 +18,9 @@ defmodule Utils.Helpers.Normalize do
   """
   defmodule ToBooleanError do
     defexception message: "Could not represent the value as a boolean."
-    def error_message(value), do: "Could not represent the value (#{inspect(value)}) as a boolean."
+
+    def error_message(value),
+      do: "Could not represent the value (#{inspect(value)}) as a boolean."
   end
 
   defmodule ToIntegerError do

--- a/apps/utils/lib/helpers/path_resolver.ex
+++ b/apps/utils/lib/helpers/path_resolver.ex
@@ -27,7 +27,7 @@ defmodule Utils.Helpers.PathResolver do
   def static_dir(app) do
     serve_local_static = System.get_env("SERVE_LOCAL_STATIC") || false
 
-    case Normalize.to_boolean(serve_local_static) do
+    case Normalize.to_boolean!(serve_local_static) do
       true ->
         Path.expand("../../../#{app}/priv/static", __DIR__)
 

--- a/apps/utils/test/utils/helpers/normalize_test.exs
+++ b/apps/utils/test/utils/helpers/normalize_test.exs
@@ -30,13 +30,28 @@ defmodule Utils.Helpers.NormalizeTest do
     end
 
     test "returns an error tuple when given an incompatible value" do
-      assert Normalize.string_to_boolean("nope") == {:error, :normalize_error, "Could not represent the value (\"nope\") as a boolean."}
-      assert Normalize.string_to_boolean("yup") == {:error, :normalize_error, "Could not represent the value (\"yup\") as a boolean."}
-      assert Normalize.string_to_boolean("yo") == {:error, :normalize_error, "Could not represent the value (\"yo\") as a boolean."}
-      assert Normalize.string_to_boolean("yawn") == {:error, :normalize_error, "Could not represent the value (\"yawn\") as a boolean."}
-      assert Normalize.string_to_boolean(1) == {:error, :normalize_error, "Could not represent the value (1) as a boolean."}
-      assert Normalize.string_to_boolean(true) == {:error, :normalize_error, "Could not represent the value (true) as a boolean."}
-      assert Normalize.string_to_boolean(false) == {:error, :normalize_error, "Could not represent the value (false) as a boolean."}
+      assert Normalize.string_to_boolean("nope") ==
+               {:error, :normalize_error,
+                "Could not represent the value (\"nope\") as a boolean."}
+
+      assert Normalize.string_to_boolean("yup") ==
+               {:error, :normalize_error, "Could not represent the value (\"yup\") as a boolean."}
+
+      assert Normalize.string_to_boolean("yo") ==
+               {:error, :normalize_error, "Could not represent the value (\"yo\") as a boolean."}
+
+      assert Normalize.string_to_boolean("yawn") ==
+               {:error, :normalize_error,
+                "Could not represent the value (\"yawn\") as a boolean."}
+
+      assert Normalize.string_to_boolean(1) ==
+               {:error, :normalize_error, "Could not represent the value (1) as a boolean."}
+
+      assert Normalize.string_to_boolean(true) ==
+               {:error, :normalize_error, "Could not represent the value (true) as a boolean."}
+
+      assert Normalize.string_to_boolean(false) ==
+               {:error, :normalize_error, "Could not represent the value (false) as a boolean."}
     end
   end
 
@@ -88,15 +103,27 @@ defmodule Utils.Helpers.NormalizeTest do
     end
 
     test "returns an error tuple when given an incompatible value" do
-      assert Normalize.to_boolean("nope") == {:error, :normalize_error, "Could not represent the value (\"nope\") as a boolean."}
-      assert Normalize.to_boolean("yup") == {:error, :normalize_error, "Could not represent the value (\"yup\") as a boolean."}
-      assert Normalize.to_boolean("yo") == {:error, :normalize_error, "Could not represent the value (\"yo\") as a boolean."}
-      assert Normalize.to_boolean("yawn") == {:error, :normalize_error, "Could not represent the value (\"yawn\") as a boolean."}
-      assert Normalize.to_boolean(0) == {:error, :normalize_error, "Could not represent the value (0) as a boolean."}
-      assert Normalize.to_boolean(-1) == {:error, :normalize_error, "Could not represent the value (-1) as a boolean."}
+      assert Normalize.to_boolean("nope") ==
+               {:error, :normalize_error,
+                "Could not represent the value (\"nope\") as a boolean."}
+
+      assert Normalize.to_boolean("yup") ==
+               {:error, :normalize_error, "Could not represent the value (\"yup\") as a boolean."}
+
+      assert Normalize.to_boolean("yo") ==
+               {:error, :normalize_error, "Could not represent the value (\"yo\") as a boolean."}
+
+      assert Normalize.to_boolean("yawn") ==
+               {:error, :normalize_error,
+                "Could not represent the value (\"yawn\") as a boolean."}
+
+      assert Normalize.to_boolean(0) ==
+               {:error, :normalize_error, "Could not represent the value (0) as a boolean."}
+
+      assert Normalize.to_boolean(-1) ==
+               {:error, :normalize_error, "Could not represent the value (-1) as a boolean."}
     end
   end
-
 
   describe "to_boolean!/1" do
     test "converts strings to boolean" do

--- a/apps/utils/test/utils/helpers/normalize_test.exs
+++ b/apps/utils/test/utils/helpers/normalize_test.exs
@@ -27,14 +27,39 @@ defmodule Utils.Helpers.NormalizeTest do
       refute Normalize.string_to_boolean("false")
       refute Normalize.string_to_boolean("0")
       refute Normalize.string_to_boolean("no")
-      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean("nope") end)
+    end
 
-      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean("yup") end)
-      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean("yo") end)
-      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean("yawn") end)
-      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean(1) end)
-      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean(true) end)
-      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean(false) end)
+    test "returns an error tuple when given an incompatible value" do
+      assert Normalize.string_to_boolean("nope") == {:error, :normalize_error, "Could not represent the value (\"nope\") as a boolean."}
+      assert Normalize.string_to_boolean("yup") == {:error, :normalize_error, "Could not represent the value (\"yup\") as a boolean."}
+      assert Normalize.string_to_boolean("yo") == {:error, :normalize_error, "Could not represent the value (\"yo\") as a boolean."}
+      assert Normalize.string_to_boolean("yawn") == {:error, :normalize_error, "Could not represent the value (\"yawn\") as a boolean."}
+      assert Normalize.string_to_boolean(1) == {:error, :normalize_error, "Could not represent the value (1) as a boolean."}
+      assert Normalize.string_to_boolean(true) == {:error, :normalize_error, "Could not represent the value (true) as a boolean."}
+      assert Normalize.string_to_boolean(false) == {:error, :normalize_error, "Could not represent the value (false) as a boolean."}
+    end
+  end
+
+  describe "string_to_boolean!/1" do
+    test "converts strings to boolean" do
+      assert Normalize.string_to_boolean("yes")
+      assert Normalize.string_to_boolean("Yes")
+      assert Normalize.string_to_boolean("true")
+      assert Normalize.string_to_boolean("True")
+      assert Normalize.string_to_boolean("1")
+      refute Normalize.string_to_boolean("false")
+      refute Normalize.string_to_boolean("0")
+      refute Normalize.string_to_boolean("no")
+    end
+
+    test "raises an error when given an incompatible value" do
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean!("nope") end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean!("yup") end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean!("yo") end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean!("yawn") end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean!(1) end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean!(true) end)
+      assert_raise(ToBooleanError, fn -> Normalize.string_to_boolean!(false) end)
     end
   end
 
@@ -48,10 +73,6 @@ defmodule Utils.Helpers.NormalizeTest do
       refute Normalize.to_boolean("false")
       refute Normalize.to_boolean("0")
       refute Normalize.to_boolean("no")
-      assert_raise(ToBooleanError, fn -> Normalize.to_boolean("nope") end)
-      assert_raise(ToBooleanError, fn -> assert Normalize.to_boolean("yup") end)
-      assert_raise(ToBooleanError, fn -> Normalize.to_boolean("yo") end)
-      assert_raise(ToBooleanError, fn -> Normalize.to_boolean("yawn") end)
     end
 
     test "converts boolean to boolean" do
@@ -64,8 +85,50 @@ defmodule Utils.Helpers.NormalizeTest do
       assert Normalize.to_boolean(2)
       assert Normalize.to_boolean(65_535)
       assert Normalize.to_boolean(99_999)
-      assert_raise(ToBooleanError, fn -> Normalize.to_boolean(0) end)
-      assert_raise(ToBooleanError, fn -> Normalize.to_boolean(-1) end)
+    end
+
+    test "returns an error tuple when given an incompatible value" do
+      assert Normalize.to_boolean("nope") == {:error, :normalize_error, "Could not represent the value (\"nope\") as a boolean."}
+      assert Normalize.to_boolean("yup") == {:error, :normalize_error, "Could not represent the value (\"yup\") as a boolean."}
+      assert Normalize.to_boolean("yo") == {:error, :normalize_error, "Could not represent the value (\"yo\") as a boolean."}
+      assert Normalize.to_boolean("yawn") == {:error, :normalize_error, "Could not represent the value (\"yawn\") as a boolean."}
+      assert Normalize.to_boolean(0) == {:error, :normalize_error, "Could not represent the value (0) as a boolean."}
+      assert Normalize.to_boolean(-1) == {:error, :normalize_error, "Could not represent the value (-1) as a boolean."}
+    end
+  end
+
+
+  describe "to_boolean!/1" do
+    test "converts strings to boolean" do
+      assert Normalize.to_boolean!("yes")
+      assert Normalize.to_boolean!("Yes")
+      assert Normalize.to_boolean!("true")
+      assert Normalize.to_boolean!("True")
+      assert Normalize.to_boolean!("1")
+      refute Normalize.to_boolean!("false")
+      refute Normalize.to_boolean!("0")
+      refute Normalize.to_boolean!("no")
+    end
+
+    test "converts boolean to boolean" do
+      assert Normalize.to_boolean!(true)
+      refute Normalize.to_boolean!(false)
+    end
+
+    test "converts integer to boolean" do
+      assert Normalize.to_boolean!(1)
+      assert Normalize.to_boolean!(2)
+      assert Normalize.to_boolean!(65_535)
+      assert Normalize.to_boolean!(99_999)
+    end
+
+    test "returns an error tuple when given an incompatible value" do
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean!("nope") end)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean!("yup") end)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean!("yo") end)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean!("yawn") end)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean!(0) end)
+      assert_raise(ToBooleanError, fn -> Normalize.to_boolean!(-1) end)
     end
   end
 


### PR DESCRIPTION
Issue/Task Number: #894
Closes #894

# Overview

This PR fixes the issue where passing a value that could not be converted to a boolean would throw an exception and stacktrace to the user.

# Changes

- Converted `Utils.Helpers.Normalize.to_boolean/1` to return error tuple and moved the exception raising to `Utils.Helpers.Normalize.to_boolean!/1` instead.
- Converted `Utils.Helpers.Normalize.to_integer/1` to return error tuple and moved the exception raising to `Utils.Helpers.Normalize.to_integer!/1` instead.

# Implementation Details

Since there are both interfaces that are exposed to user and those that are part of application startup that uses this normalize function. The user-exposing parts are changed to use `to_boolean/1` and handle the error by transforming the error tuple to proper message for user.

The rest are used during applications startup and for those ones, the values should already be valid and makes sense to keep raising the error (and crash).

# Usage

The following invalid config should now handle proper error:

```shell
$ mix omg.config enable_standalone 10
Error: setting `enable_standalone` to "10". Could not represent the value ("10") as boolean.
```

The migration task should also handle conversion error properly by informing and skipping them:

```shell
$ mix omg.config --migrate

...

The following settings will be skipped:

  - enable_standalone: "abc" (type conversion error)
```

# Impact

No changes to DB schema or API specs.
