### PR TITLE
Revert nonce if a blockchain transaction returned an error

### DIFF
--- a/apps/eth_blockchain/lib/eth_blockchain/transaction.ex
+++ b/apps/eth_blockchain/lib/eth_blockchain/transaction.ex
@@ -384,7 +384,7 @@ defmodule EthBlockchain.Transaction do
   # We force the refresh of the nonce generator which will reset the nonce to the current
   # transaction count. This way we avoid having failed transaction until we reach the
   # correct nonce
-  defp respond({:error, _, [error_message: "nonce too low"]} = error, from, opts) do
+  defp respond({:error, _, _} = error, from, opts) do
     with {:ok, nonce_handler_pid} <-
            NonceRegistry.lookup(from, opts[:eth_node_adapter], opts[:eth_node_adapter_pid]),
          {:ok, _nonce} <- Nonce.force_refresh(nonce_handler_pid) do

--- a/apps/eth_blockchain/test/eth_blockchain/transaction_test.exs
+++ b/apps/eth_blockchain/test/eth_blockchain/transaction_test.exs
@@ -15,7 +15,7 @@
 defmodule EthBlockchain.TransactionTest do
   use EthBlockchain.EthBlockchainCase, async: true
 
-  alias EthBlockchain.{GasHelper, Transaction, ABIEncoder}
+  alias EthBlockchain.{GasHelper, Transaction, ABIEncoder, NonceRegistry}
   alias ExthCrypto.Math
   alias Keychain.Wallet
   alias Utils.Helpers.Encoding
@@ -222,6 +222,29 @@ defmodule EthBlockchain.TransactionTest do
       assert trx.value == 0
       assert Encoding.to_hex(trx.to) == state[:addr_2]
       assert trx.data == data
+    end
+
+    test "does not increase the nonce if transaction sending failed", state do
+      IO.inspect(state, label: "test context")
+      adapter_opts = Keyword.put(state[:adapter_opts], :eth_node_adapter, :dumb_tx_error)
+
+      {:ok, pid} =
+        NonceRegistry.lookup(
+          state[:valid_sender],
+          adapter_opts[:eth_node_adapter],
+          adapter_opts[:eth_node_adapter_pid]
+        )
+
+      original_nonce = :sys.get_state(pid).nonce
+
+      {:error, _, _} =
+        Transaction.send(
+          %{from: state[:valid_sender], to: state[:addr_1], amount: 100},
+          adapter_opts
+        )
+
+      # Transaction.send/2 was called, but nonce should not have changed since it failed.
+      assert :sys.get_state(pid).nonce == original_nonce
     end
 
     test "supports sending with a child key", state do

--- a/apps/eth_blockchain/test/eth_blockchain/transaction_test.exs
+++ b/apps/eth_blockchain/test/eth_blockchain/transaction_test.exs
@@ -225,7 +225,6 @@ defmodule EthBlockchain.TransactionTest do
     end
 
     test "does not increase the nonce if transaction sending failed", state do
-      IO.inspect(state, label: "test context")
       adapter_opts = Keyword.put(state[:adapter_opts], :eth_node_adapter, :dumb_tx_error)
 
       {:ok, pid} =

--- a/apps/eth_blockchain/test/support/dumb_tx_error_adapter.ex
+++ b/apps/eth_blockchain/test/support/dumb_tx_error_adapter.ex
@@ -1,0 +1,40 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule EthBlockchain.DumbTxErrorAdapter do
+  @moduledoc """
+  This is a dumb adapter that returns a geth error.
+  """
+  use GenServer
+
+  alias EthBlockchain.AdapterServer
+
+  @spec start_link :: :ignore | {:error, any} | {:ok, pid}
+  def start_link, do: GenServer.start_link(__MODULE__, :ok, [])
+
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  def stop(pid), do: GenServer.stop(pid)
+
+  def handle_call({:send_raw, _}, _from, reg) do
+    error = {:error, :geth_error, [error_message: "insufficient funds for gas * price + value"]}
+    {:reply, error, reg}
+  end
+
+  def handle_call(call, _from, reg) do
+    {:reply, AdapterServer.eth_call(call, []), reg}
+  end
+end

--- a/apps/eth_blockchain/test/support/eth_blockchain_case.ex
+++ b/apps/eth_blockchain/test/support/eth_blockchain_case.ex
@@ -43,6 +43,7 @@ defmodule EthBlockchain.EthBlockchainCase do
         adapters: [
           {:dumb, EthBlockchain.DumbAdapter},
           {:dumb_tx, EthBlockchain.DumbTxAdapter},
+          {:dumb_tx_error, EthBlockchain.DumbTxErrorAdapter},
           {:dumb_cc, EthBlockchain.DumbCCAdapter}
         ]
       )


### PR DESCRIPTION
Issue/Task Number: #1166

# Overview

This PR broadens the scope that nonce assignment should get reverted when the blockchain transaction returned an error.

# Changes

- Updated `EthBlockchain.Transaction` to force-refresh the nonce for all blockchain transaction submission error.

# Implementation Details

There's already existing code to handle nonce reversal when a transaction submission errors, but it only covers nonce too low cases:

```elixir
{:error, :geth_error, [error_message: "nonce too low"]}
```

Another common error that should do nonce reversal is insufficient funds:

```elixir
{:error, :geth_error, [error_message: "insufficient funds for gas * price + value"]}
```

By wildcarding to `{:error, _, _}` we will cover both `:geth_error` and `:geth_communication_error` returned by `EthGethAdapter.ErrorHandler.handle_error/1`, which should cover all the cases that the transaction did not get submitted to the blockchain successfully, and hence nonce has not been used.

# Usage

1. Send some funds into the eWallet's hot wallet
2. Send some funds out of the hot wallet (to confirm that the transaction submission is working)
3. Send funds exceeding the available amount
4. Send some funds within the available amount

Previously, step 3 would fail and step 4 would appear to be sent successfully with a transaction hash returned. But the transaction never appears on the blockchain.

With this PR, step 3 would fail as expected and step 4 returns a transaction hash, but the transaction hash would appear on the blockchain.

# Impact

No changes to DB schema or API specs.