### PR TITLE
Bump version in code & as returned by /status.get endpoint

### DIFF
--- a/apps/activity_logger/mix.exs
+++ b/apps/activity_logger/mix.exs
@@ -4,7 +4,7 @@ defmodule ActivityLogger.MixProject do
   def project do
     [
       app: :activity_logger,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/admin_api/mix.exs
+++ b/apps/admin_api/mix.exs
@@ -4,7 +4,7 @@ defmodule AdminAPI.Mixfile do
   def project do
     [
       app: :admin_api,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/admin_panel/mix.exs
+++ b/apps/admin_panel/mix.exs
@@ -4,7 +4,7 @@ defmodule AdminPanel.Mixfile do
   def project do
     [
       app: :admin_panel,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ewallet/config/config.exs
+++ b/apps/ewallet/config/config.exs
@@ -4,7 +4,7 @@ use Mix.Config
 
 config :ewallet,
   ecto_repos: [],
-  version: "1.1.0",
+  version: "1.1.3",
   settings: [
     :base_url,
     :sender_email,

--- a/apps/ewallet/mix.exs
+++ b/apps/ewallet/mix.exs
@@ -4,7 +4,7 @@ defmodule EWallet.Mixfile do
   def project do
     [
       app: :ewallet,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ewallet_api/mix.exs
+++ b/apps/ewallet_api/mix.exs
@@ -4,7 +4,7 @@ defmodule EWalletAPI.Mixfile do
   def project do
     [
       app: :ewallet_api,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ewallet_config/mix.exs
+++ b/apps/ewallet_config/mix.exs
@@ -4,7 +4,7 @@ defmodule EWalletConfig.MixProject do
   def project do
     [
       app: :ewallet_config,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/ewallet_db/mix.exs
+++ b/apps/ewallet_db/mix.exs
@@ -4,7 +4,7 @@ defmodule EWalletDB.Mixfile do
   def project do
     [
       app: :ewallet_db,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/load_tester/mix.exs
+++ b/apps/load_tester/mix.exs
@@ -4,7 +4,7 @@ defmodule LoadTester.MixProject do
   def project do
     [
       app: :load_tester,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/local_ledger/mix.exs
+++ b/apps/local_ledger/mix.exs
@@ -4,7 +4,7 @@ defmodule LocalLedger.Mixfile do
   def project do
     [
       app: :local_ledger,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/local_ledger_db/mix.exs
+++ b/apps/local_ledger_db/mix.exs
@@ -4,7 +4,7 @@ defmodule LocalLedgerDB.Mixfile do
   def project do
     [
       app: :local_ledger_db,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/url_dispatcher/mix.exs
+++ b/apps/url_dispatcher/mix.exs
@@ -4,7 +4,7 @@ defmodule UrlDispatcher.Mixfile do
   def project do
     [
       app: :url_dispatcher,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/utils/mix.exs
+++ b/apps/utils/mix.exs
@@ -4,7 +4,7 @@ defmodule Utils.MixProject do
   def project do
     [
       app: :utils,
-      version: "1.1.0",
+      version: "1.1.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/docker-gen.sh
+++ b/docker-gen.sh
@@ -64,7 +64,7 @@ if [ -z "$IMAGE_NAME" ]; then
    if [ $DEV_MODE = 1 ]; then
        IMAGE_NAME="omisegoimages/ewallet-builder:v1.1"
    else
-       IMAGE_NAME="omisego/ewallet:1.1.0"
+       IMAGE_NAME="omisego/ewallet:1.1.3"
    fi
 fi
 


### PR DESCRIPTION
The v1.1.2 release did not properly bump the version number in code and this is causing confusion on some adopters when they query `/status.get`. This PR bumps them up.
