### PR TITLE
Update blockchain seeds

### DIFF
--- a/apps/ewallet_db/priv/repo/seeds_blockchain/02_blockchain_wallet.exs
+++ b/apps/ewallet_db/priv/repo/seeds_blockchain/02_blockchain_wallet.exs
@@ -14,8 +14,12 @@
 
 defmodule EWalletDB.Repo.Seeds.BlockchainWallet do
   alias EWalletDB.{BlockchainWallet, Seeder}
-  alias Keychain.Wallet
+  alias Keychain.Key
   alias EWalletConfig.Config
+
+  @test_private_key "d885a307e35738f773d8c9c63c7a3f3977819274638d04aaf934a1e1158513ce"
+  @test_public_key "04e2a0b5ae9f9b8f0c79751cd99dfddc8caa823d808e23af012a9f3ed41c4fc172de8f518d8e6677b0ea8a8bfb2c6e59b02d03a4efc54c1fd00e0d7ef7fa70d0b6"
+  @test_address "0x6de4b3b9c28e9c3e84c2b2d3a875c947a84de68d"
 
   def seed do
     [
@@ -42,11 +46,16 @@ defmodule EWalletDB.Repo.Seeds.BlockchainWallet do
   end
 
   defp insert_wallet(writer, identifier) do
-    {:ok, {address, public_key}} = Wallet.generate()
+    {:ok, _} =
+      Key.insert(%{
+        wallet_address: @test_address,
+        public_key: @test_public_key,
+        private_key: @test_private_key
+      })
 
     attrs = %{
-      address: address,
-      public_key: public_key,
+      address: @test_address,
+      public_key: @test_public_key,
       name: "Hot Wallet",
       type: BlockchainWallet.type_hot(),
       blockchain_identifier: identifier,
@@ -69,11 +78,11 @@ defmodule EWalletDB.Repo.Seeds.BlockchainWallet do
         """)
 
       {:error, changeset} ->
-        writer.error("  Wallet #{address} could not be inserted.")
+        writer.error("  Wallet #{attrs.address} could not be inserted.")
         writer.print_errors(changeset)
 
       _ ->
-        writer.error("  Wallet #{address} could not be inserted.")
+        writer.error("  Wallet #{attrs.address} could not be inserted.")
         writer.error("  Unknown error.")
     end
   end

--- a/apps/ewallet_db/priv/repo/seeds_blockchain/04_settings.exs
+++ b/apps/ewallet_db/priv/repo/seeds_blockchain/04_settings.exs
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# credo:disable-for-this-file
 defmodule EWalletDB.Repo.Seeds.BlockchainSetting do
   alias EWalletDB.Seeder
   alias EWalletConfig.Config
@@ -38,7 +37,6 @@ defmodule EWalletDB.Repo.Seeds.BlockchainSetting do
         originator: %Seeder{}
       })
     writer.success("Setting `internal_enabled` to false")
-
 
     {:ok, [blockchain_chain_id: {:ok, _}]} =
       Config.update(%{

--- a/apps/ewallet_db/priv/repo/seeds_blockchain/04_settings.exs
+++ b/apps/ewallet_db/priv/repo/seeds_blockchain/04_settings.exs
@@ -38,6 +38,7 @@ defmodule EWalletDB.Repo.Seeds.BlockchainSetting do
       })
     writer.success("Setting `internal_enabled` to false")
 
+    # 1337 is the chain_id value used in the docker-compose file.
     {:ok, [blockchain_chain_id: {:ok, _}]} =
       Config.update(%{
         blockchain_chain_id: 1337,

--- a/apps/ewallet_db/priv/repo/seeds_blockchain/04_settings.exs
+++ b/apps/ewallet_db/priv/repo/seeds_blockchain/04_settings.exs
@@ -1,0 +1,50 @@
+# Copyright 2018-2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# credo:disable-for-this-file
+defmodule EWalletDB.Repo.Seeds.BlockchainSetting do
+  alias EWalletDB.Seeder
+  alias EWalletConfig.Config
+
+  def seed do
+    [
+      run_banner: "Updating blockchain settings",
+      argsline: []
+    ]
+  end
+
+  def run(writer, _args) do
+    {:ok, [blockchain_enabled: {:ok, _}]} =
+      Config.update(%{
+        blockchain_enabled: true,
+        originator: %Seeder{}
+      })
+    writer.success("Setting `blockchain_enabled` to true")
+
+    {:ok, [internal_enabled: {:ok, _}]} =
+      Config.update(%{
+        internal_enabled: false,
+        originator: %Seeder{}
+      })
+    writer.success("Setting `internal_enabled` to false")
+
+
+    {:ok, [blockchain_chain_id: {:ok, _}]} =
+      Config.update(%{
+        blockchain_chain_id: 1337,
+        originator: %Seeder{}
+      })
+    writer.success("Setting `blockchain_chain_id` to 1337")
+  end
+end


### PR DESCRIPTION
Issue/Task Number: #1210 
Closes #1210 

# Overview

Update actions triggered by `mix seed --blockchain`

# Changes

- The hot wallet inserted is now the same as the one running in dockered geth
- `blockchain_enabled` setting is set to `true`
- `internal_enabled` setting is set to `false`
- `blockchain_chain_id` setting is set to `1337` to be the same as the dockered geth

